### PR TITLE
Fix Javadoc errors in Ok, Err, and Try.Failure compact constructors

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -42,7 +42,7 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
-    finalizedBy jacocoTestReport // report is always generated after tests run
+    finalizedBy jacocoTestReport, javadoc // report is always generated after tests run
 }
 
 jacocoTestReport {

--- a/lib/src/main/java/codes/domix/fun/Result.java
+++ b/lib/src/main/java/codes/domix/fun/Result.java
@@ -35,10 +35,15 @@ public sealed interface Result<Value, Error> permits Result.Ok, Result.Err {
      *
      * @param <Value> the type of the value contained in the successful result
      * @param <Error> the type of the error contained in the erroneous result, unused here
-     * @param value   the non-null value that represents the successful result
-     * @throws NullPointerException if {@code value} is {@code null}
+     * @param value   the non-null value that represents the successful result;
+     *                passing {@code null} throws {@link NullPointerException}
      */
     record Ok<Value, Error>(Value value) implements Result<Value, Error> {
+        /**
+         * Compact canonical constructor — validates that {@code value} is non-null.
+         *
+         * @throws NullPointerException if {@code value} is {@code null}
+         */
         public Ok {
             Objects.requireNonNull(value, "Ok value must not be null");
         }
@@ -52,10 +57,15 @@ public sealed interface Result<Value, Error> permits Result.Ok, Result.Err {
      *
      * @param <Value> the type of the value contained in a successful result, unused here
      * @param <Error> the type of the error contained in the erroneous result
-     * @param error   the non-null error value that represents the erroneous result
-     * @throws NullPointerException if {@code error} is {@code null}
+     * @param error   the non-null error value that represents the erroneous result;
+     *                passing {@code null} throws {@link NullPointerException}
      */
     record Err<Value, Error>(Error error) implements Result<Value, Error> {
+        /**
+         * Compact canonical constructor — validates that {@code error} is non-null.
+         *
+         * @throws NullPointerException if {@code error} is {@code null}
+         */
         public Err {
             Objects.requireNonNull(error, "Err error must not be null");
         }

--- a/lib/src/main/java/codes/domix/fun/Try.java
+++ b/lib/src/main/java/codes/domix/fun/Try.java
@@ -37,6 +37,11 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      *                computation had succeeded
      */
     record Failure<Value>(Throwable cause) implements Try<Value> {
+        /**
+         * Compact canonical constructor — validates that {@code cause} is non-null.
+         *
+         * @throws NullPointerException if {@code cause} is {@code null}
+         */
         public Failure {
             Objects.requireNonNull(cause, "Failure cause must not be null");
         }


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null-safety validation to prevent invalid object creation with clear error messages
* **Chores**
  * Build process now generates documentation as part of the testing workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->