### PR TITLE
feat(interop): add `Result.fromOptional` and `Try.fromOptional` (#45)

### DIFF
--- a/lib/src/main/java/codes/domix/fun/Result.java
+++ b/lib/src/main/java/codes/domix/fun/Result.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -561,6 +562,24 @@ public sealed interface Result<Value, Error> permits Result.Ok, Result.Err {
     static <V> Result<V, Throwable> fromTry(Try<V> t) {
         Objects.requireNonNull(t, "t");
         return t.toResult();
+    }
+
+    /**
+     * Converts a {@link Optional} into a {@link Result}.
+     * If the {@code Optional} contains a value, returns {@code Ok} with that value.
+     * If the {@code Optional} is empty, returns {@code Err} with a {@link NoSuchElementException}.
+     *
+     * @param <V>      the value type
+     * @param optional the {@code Optional} to convert; must not be {@code null}
+     * @return {@code Ok(value)} if the {@code Optional} is present,
+     *         or {@code Err(NoSuchElementException)} if empty
+     * @throws NullPointerException if {@code optional} is {@code null}
+     */
+    static <V> Result<V, NoSuchElementException> fromOptional(Optional<? extends V> optional) {
+        Objects.requireNonNull(optional, "optional");
+        return optional.isPresent()
+            ? Result.ok(optional.get())
+            : Result.err(new NoSuchElementException("Optional is empty"));
     }
 
     // ---------- sequence / traverse ----------

--- a/lib/src/main/java/codes/domix/fun/Try.java
+++ b/lib/src/main/java/codes/domix/fun/Try.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -672,6 +673,28 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
                 Objects.requireNonNull(exceptionSupplier.get(), "exceptionSupplier returned null")
             );
         };
+    }
+
+    /**
+     * Converts a {@link Optional} into a {@link Try}.
+     * If the {@code Optional} contains a value, returns {@code Success} with that value.
+     * If the {@code Optional} is empty, returns {@code Failure} with the exception
+     * provided by {@code exceptionSupplier}.
+     *
+     * @param <V>               the value type
+     * @param optional          the {@code Optional} to convert; must not be {@code null}
+     * @param exceptionSupplier a supplier for the throwable to use when the {@code Optional} is empty;
+     *                          must not be {@code null} and must not return {@code null}
+     * @return {@code Success(value)} if the {@code Optional} is present,
+     *         or {@code Failure(exception)} if empty
+     * @throws NullPointerException if {@code optional} or {@code exceptionSupplier} is {@code null}
+     */
+    static <V> Try<V> fromOptional(Optional<? extends V> optional, Supplier<? extends Throwable> exceptionSupplier) {
+        Objects.requireNonNull(optional, "optional");
+        Objects.requireNonNull(exceptionSupplier, "exceptionSupplier");
+        return optional.isPresent()
+            ? Try.success(optional.get())
+            : Try.failure(Objects.requireNonNull(exceptionSupplier.get(), "exceptionSupplier returned null"));
     }
 
     // ---------- sequence / traverse ----------

--- a/lib/src/test/java/codes/domix/fun/InteropTest.java
+++ b/lib/src/test/java/codes/domix/fun/InteropTest.java
@@ -1,10 +1,14 @@
 package codes.domix.fun;
 
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InteropTest {
@@ -112,5 +116,64 @@ class InteropTest {
         assertEquals(10, success.get());
         var failure = Option.<Integer>none().toTry(() -> new RuntimeException("boom"));
         assertTrue(failure.isFailure());
+    }
+
+    // ---------- Optional interop ----------
+
+    @Test
+    void result_fromOptional_present_returnsOk() {
+        Result<Integer, NoSuchElementException> r = Result.fromOptional(Optional.of(42));
+        assertTrue(r.isOk());
+        assertEquals(42, r.get());
+    }
+
+    @Test
+    void result_fromOptional_empty_returnsErrWithNoSuchElementException() {
+        Result<Integer, NoSuchElementException> r = Result.fromOptional(Optional.empty());
+        assertTrue(r.isError());
+        assertInstanceOf(NoSuchElementException.class, r.getError());
+    }
+
+    @Test
+    void result_fromOptional_null_throwsNPE() {
+        assertThrows(NullPointerException.class, () -> Result.fromOptional(null));
+    }
+
+    @Test
+    void try_fromOptional_present_returnsSuccess() {
+        Try<Integer> t = Try.fromOptional(Optional.of(99), () -> new RuntimeException("missing"));
+        assertTrue(t.isSuccess());
+        assertEquals(99, t.get());
+    }
+
+    @Test
+    void try_fromOptional_empty_returnsFailureFromSupplier() {
+        RuntimeException ex = new RuntimeException("missing");
+        Try<Integer> t = Try.fromOptional(Optional.empty(), () -> ex);
+        assertTrue(t.isFailure());
+        assertEquals(ex, t.getCause());
+    }
+
+    @Test
+    void try_fromOptional_supplierNotCalledWhenPresent() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        Try<Integer> t = Try.fromOptional(Optional.of(1), () -> {
+            called.set(true);
+            return new RuntimeException("should not be called");
+        });
+        assertTrue(t.isSuccess());
+        assertFalse(called.get(), "supplier must not be called when Optional is present");
+    }
+
+    @Test
+    void try_fromOptional_null_throwsNPE() {
+        assertThrows(NullPointerException.class,
+            () -> Try.fromOptional(null, () -> new RuntimeException("x")));
+    }
+
+    @Test
+    void try_fromOptional_nullSupplier_throwsNPE() {
+        assertThrows(NullPointerException.class,
+            () -> Try.fromOptional(Optional.empty(), null));
     }
 }


### PR DESCRIPTION
  Bridge `java.util.Optional` to both `Result` and `Try`:
  - `Result.fromOptional(Optional<V>)` → `Result<V, NoSuchElementException>`
  - `Try.fromOptional(Optional<V>, Supplier<Throwable>)` → `Try<V>`

  Includes null-guard validation and 7 new tests in `InteropTest`.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [x] I have tested my changes locally
- [x] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [x] My code follows the project's coding conventions
- [x] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #45
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversion utilities to transform Java Optional instances into Result and Try types, enabling seamless interoperability with automatic error handling for empty Optionals.

* **Tests**
  * Added comprehensive test coverage for Optional interoperability with Result and Try, including edge cases such as null handling and lazy evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->