### PR TITLE
feat(tuples): add Tuple3, Tuple4, TriFunction, and QuadFunction (#50)

### DIFF
--- a/lib/src/main/java/codes/domix/fun/QuadFunction.java
+++ b/lib/src/main/java/codes/domix/fun/QuadFunction.java
@@ -1,0 +1,27 @@
+package codes.domix.fun;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A functional interface for a function that accepts four arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <R> the type of the result
+ */
+@NullMarked
+@FunctionalInterface
+public interface QuadFunction<A, B, C, D, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @return the result of applying this function
+     */
+    R apply(A a, B b, C c, D d);
+}

--- a/lib/src/main/java/codes/domix/fun/TriFunction.java
+++ b/lib/src/main/java/codes/domix/fun/TriFunction.java
@@ -1,0 +1,25 @@
+package codes.domix.fun;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A functional interface for a function that accepts three arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <R> the type of the result
+ */
+@NullMarked
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @return the result of applying this function
+     */
+    R apply(A a, B b, C c);
+}

--- a/lib/src/main/java/codes/domix/fun/Tuple3.java
+++ b/lib/src/main/java/codes/domix/fun/Tuple3.java
@@ -1,0 +1,84 @@
+package codes.domix.fun;
+
+import org.jspecify.annotations.NullMarked;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * An immutable triple holding three values of potentially different types.
+ *
+ * @param <A> the type of the first element
+ * @param <B> the type of the second element
+ * @param <C> the type of the third element
+ * @param _1  the first element
+ * @param _2  the second element
+ * @param _3  the third element
+ */
+@NullMarked
+public record Tuple3<A, B, C>(A _1, B _2, C _3) {
+    /** Validates that none of the elements are null. */
+    public Tuple3 {
+        Objects.requireNonNull(_1, "_1 must not be null");
+        Objects.requireNonNull(_2, "_2 must not be null");
+        Objects.requireNonNull(_3, "_3 must not be null");
+    }
+
+    /**
+     * Creates a new {@code Tuple3} with the given elements.
+     *
+     * @param <A> the type of the first element
+     * @param <B> the type of the second element
+     * @param <C> the type of the third element
+     * @param a   the first element
+     * @param b   the second element
+     * @param c   the third element
+     * @return a new {@code Tuple3} containing the three values
+     */
+    public static <A, B, C> Tuple3<A, B, C> of(A a, B b, C c) {
+        return new Tuple3<>(a, b, c);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the first element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new first element
+     * @param f   the mapping function
+     * @return a new {@code Tuple3} with the transformed first element
+     */
+    public <R> Tuple3<R, B, C> mapFirst(Function<? super A, ? extends R> f) {
+        return new Tuple3<>(Objects.requireNonNull(f.apply(_1)), _2, _3);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the second element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new second element
+     * @param f   the mapping function
+     * @return a new {@code Tuple3} with the transformed second element
+     */
+    public <R> Tuple3<A, R, C> mapSecond(Function<? super B, ? extends R> f) {
+        return new Tuple3<>(_1, Objects.requireNonNull(f.apply(_2)), _3);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the third element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new third element
+     * @param f   the mapping function
+     * @return a new {@code Tuple3} with the transformed third element
+     */
+    public <R> Tuple3<A, B, R> mapThird(Function<? super C, ? extends R> f) {
+        return new Tuple3<>(_1, _2, Objects.requireNonNull(f.apply(_3)));
+    }
+
+    /**
+     * Collapses this triple into a single value by applying {@code f} to all three elements.
+     *
+     * @param <R> the type of the result
+     * @param f   the combining function
+     * @return the non-null result of applying {@code f} to {@code _1}, {@code _2}, and {@code _3}
+     */
+    public <R> R map(TriFunction<? super A, ? super B, ? super C, ? extends R> f) {
+        return Objects.requireNonNull(f.apply(_1, _2, _3));
+    }
+}

--- a/lib/src/main/java/codes/domix/fun/Tuple4.java
+++ b/lib/src/main/java/codes/domix/fun/Tuple4.java
@@ -1,0 +1,100 @@
+package codes.domix.fun;
+
+import org.jspecify.annotations.NullMarked;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * An immutable quadruple holding four values of potentially different types.
+ *
+ * @param <A> the type of the first element
+ * @param <B> the type of the second element
+ * @param <C> the type of the third element
+ * @param <D> the type of the fourth element
+ * @param _1  the first element
+ * @param _2  the second element
+ * @param _3  the third element
+ * @param _4  the fourth element
+ */
+@NullMarked
+public record Tuple4<A, B, C, D>(A _1, B _2, C _3, D _4) {
+    /** Validates that none of the elements are null. */
+    public Tuple4 {
+        Objects.requireNonNull(_1, "_1 must not be null");
+        Objects.requireNonNull(_2, "_2 must not be null");
+        Objects.requireNonNull(_3, "_3 must not be null");
+        Objects.requireNonNull(_4, "_4 must not be null");
+    }
+
+    /**
+     * Creates a new {@code Tuple4} with the given elements.
+     *
+     * @param <A> the type of the first element
+     * @param <B> the type of the second element
+     * @param <C> the type of the third element
+     * @param <D> the type of the fourth element
+     * @param a   the first element
+     * @param b   the second element
+     * @param c   the third element
+     * @param d   the fourth element
+     * @return a new {@code Tuple4} containing the four values
+     */
+    public static <A, B, C, D> Tuple4<A, B, C, D> of(A a, B b, C c, D d) {
+        return new Tuple4<>(a, b, c, d);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the first element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new first element
+     * @param f   the mapping function
+     * @return a new {@code Tuple4} with the transformed first element
+     */
+    public <R> Tuple4<R, B, C, D> mapFirst(Function<? super A, ? extends R> f) {
+        return new Tuple4<>(Objects.requireNonNull(f.apply(_1)), _2, _3, _4);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the second element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new second element
+     * @param f   the mapping function
+     * @return a new {@code Tuple4} with the transformed second element
+     */
+    public <R> Tuple4<A, R, C, D> mapSecond(Function<? super B, ? extends R> f) {
+        return new Tuple4<>(_1, Objects.requireNonNull(f.apply(_2)), _3, _4);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the third element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new third element
+     * @param f   the mapping function
+     * @return a new {@code Tuple4} with the transformed third element
+     */
+    public <R> Tuple4<A, B, R, D> mapThird(Function<? super C, ? extends R> f) {
+        return new Tuple4<>(_1, _2, Objects.requireNonNull(f.apply(_3)), _4);
+    }
+
+    /**
+     * Returns a new tuple with {@code f} applied to the fourth element; the other elements are unchanged.
+     *
+     * @param <R> the type of the new fourth element
+     * @param f   the mapping function
+     * @return a new {@code Tuple4} with the transformed fourth element
+     */
+    public <R> Tuple4<A, B, C, R> mapFourth(Function<? super D, ? extends R> f) {
+        return new Tuple4<>(_1, _2, _3, Objects.requireNonNull(f.apply(_4)));
+    }
+
+    /**
+     * Collapses this quadruple into a single value by applying {@code f} to all four elements.
+     *
+     * @param <R> the type of the result
+     * @param f   the combining function
+     * @return the non-null result of applying {@code f} to {@code _1}, {@code _2}, {@code _3}, and {@code _4}
+     */
+    public <R> R map(QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends R> f) {
+        return Objects.requireNonNull(f.apply(_1, _2, _3, _4));
+    }
+}

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -12,6 +12,10 @@
  *   <li>{@link codes.domix.fun.CheckedRunnable}  — runnable that may throw checked exceptions</li>
  *   <li>{@link codes.domix.fun.CheckedFunction}  — function that may throw checked exceptions</li>
  *   <li>{@link codes.domix.fun.CheckedConsumer}  — consumer that may throw checked exceptions</li>
+ *   <li>{@link codes.domix.fun.Tuple3}       — immutable triple of three values</li>
+ *   <li>{@link codes.domix.fun.Tuple4}       — immutable quadruple of four values</li>
+ *   <li>{@link codes.domix.fun.TriFunction}  — function accepting three arguments</li>
+ *   <li>{@link codes.domix.fun.QuadFunction} — function accepting four arguments</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/codes/domix/fun/TupleTest.java
+++ b/lib/src/test/java/codes/domix/fun/TupleTest.java
@@ -1,0 +1,147 @@
+package codes.domix.fun;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TupleTest {
+
+    // ── Tuple3 ────────────────────────────────────────────────────────────────
+
+    @Test
+    void tuple3_of_exposesFields() {
+        var t = Tuple3.of("a", 2, 3.0);
+        assertEquals("a", t._1());
+        assertEquals(2, t._2());
+        assertEquals(3.0, t._3());
+    }
+
+    @Test
+    void tuple3_null_first_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple3.of(null, 2, 3));
+    }
+
+    @Test
+    void tuple3_null_second_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple3.of(1, null, 3));
+    }
+
+    @Test
+    void tuple3_null_third_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple3.of(1, 2, null));
+    }
+
+    @Test
+    void tuple3_mapFirst_appliesFunction() {
+        var t = Tuple3.of(1, "b", 3.0).mapFirst(n -> n * 10);
+        assertEquals(10, t._1());
+        assertEquals("b", t._2());
+        assertEquals(3.0, t._3());
+    }
+
+    @Test
+    void tuple3_mapSecond_appliesFunction() {
+        var t = Tuple3.of(1, "b", 3.0).mapSecond(String::toUpperCase);
+        assertEquals(1, t._1());
+        assertEquals("B", t._2());
+        assertEquals(3.0, t._3());
+    }
+
+    @Test
+    void tuple3_mapThird_appliesFunction() {
+        var t = Tuple3.of(1, "b", 3.0).mapThird(d -> d * 2);
+        assertEquals(1, t._1());
+        assertEquals("b", t._2());
+        assertEquals(6.0, t._3());
+    }
+
+    @Test
+    void tuple3_map_collapsesToValue() {
+        var result = Tuple3.of(1, 2, 3).map((a, b, c) -> a + b + c);
+        assertEquals(6, result);
+    }
+
+    @Test
+    void tuple3_equality() {
+        assertEquals(Tuple3.of("x", 1, true), Tuple3.of("x", 1, true));
+    }
+
+    // ── Tuple4 ────────────────────────────────────────────────────────────────
+
+    @Test
+    void tuple4_of_exposesFields() {
+        var t = Tuple4.of("a", 2, 3.0, true);
+        assertEquals("a", t._1());
+        assertEquals(2, t._2());
+        assertEquals(3.0, t._3());
+        assertEquals(true, t._4());
+    }
+
+    @Test
+    void tuple4_null_first_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple4.of(null, 2, 3, 4));
+    }
+
+    @Test
+    void tuple4_null_second_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple4.of(1, null, 3, 4));
+    }
+
+    @Test
+    void tuple4_null_third_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple4.of(1, 2, null, 4));
+    }
+
+    @Test
+    void tuple4_null_fourth_throws() {
+        assertThrows(NullPointerException.class, () -> Tuple4.of(1, 2, 3, null));
+    }
+
+    @Test
+    void tuple4_mapFirst_appliesFunction() {
+        var t = Tuple4.of(1, "b", 3.0, true).mapFirst(n -> n * 10);
+        assertEquals(10, t._1());
+        assertEquals("b", t._2());
+        assertEquals(3.0, t._3());
+        assertEquals(true, t._4());
+    }
+
+    @Test
+    void tuple4_mapSecond_appliesFunction() {
+        var t = Tuple4.of(1, "b", 3.0, true).mapSecond(String::toUpperCase);
+        assertEquals(1, t._1());
+        assertEquals("B", t._2());
+        assertEquals(3.0, t._3());
+        assertEquals(true, t._4());
+    }
+
+    @Test
+    void tuple4_mapThird_appliesFunction() {
+        var t = Tuple4.of(1, "b", 3.0, true).mapThird(d -> d * 2);
+        assertEquals(1, t._1());
+        assertEquals("b", t._2());
+        assertEquals(6.0, t._3());
+        assertEquals(true, t._4());
+    }
+
+    @Test
+    void tuple4_mapFourth_appliesFunction() {
+        var t = Tuple4.of(1, "b", 3.0, true).mapFourth(b -> !b);
+        assertEquals(1, t._1());
+        assertEquals("b", t._2());
+        assertEquals(3.0, t._3());
+        assertEquals(false, t._4());
+    }
+
+    @Test
+    void tuple4_map_collapsesToValue() {
+        var result = Tuple4.of(1, 2, 3, 4).map((a, b, c, d) -> a + b + c + d);
+        assertEquals(10, result);
+    }
+
+    @Test
+    void tuple4_equality() {
+        assertEquals(Tuple4.of("x", 1, true, 4.0), Tuple4.of("x", 1, true, 4.0));
+    }
+}


### PR DESCRIPTION
  - Add TriFunction<A,B,C,R> and QuadFunction<A,B,C,D,R> functional interfaces
  - Add Tuple3<A,B,C> record with null-guards, of() factory, mapFirst/mapSecond/mapThird, and map(TriFunction)
  - Add Tuple4<A,B,C,D> record with null-guards, of() factory, mapFirst/mapSecond/mapThird/mapFourth, and
  map(QuadFunction)
  - Add TupleTest covering construction, null-guards, map variants, and equality
  - Update module-info.java Javadoc to reference all four new types

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #50

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional interfaces for functions accepting three and four arguments.
  * Added immutable tuple types with transformation methods for handling three and four values.

* **Tests**
  * Added test coverage for tuple operations and null-safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->