### PR TITLE
refactor(sequence): replace iterator loops with Stream Gatherers in sequence/traverse

### DIFF
--- a/lib/src/main/java/codes/domix/fun/Option.java
+++ b/lib/src/main/java/codes/domix/fun/Option.java
@@ -1,7 +1,6 @@
 package codes.domix.fun;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -13,7 +12,9 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Gatherer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A sealed interface representing an optional value with two possible states:
@@ -374,17 +375,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      */
     static <V> Option<List<V>> sequence(Iterable<Option<V>> options) {
         Objects.requireNonNull(options, "options");
-        ArrayList<V> out = new ArrayList<>();
-        for (Option<V> opt : options) {
-            if (opt == null) {
-                throw new NullPointerException("options contains null element (use Option.none() instead)");
-            }
-            if (opt instanceof None<V>) {
-                return Option.none();
-            }
-            out.add(((Some<V>) opt).value());
-        }
-        return Option.some(List.copyOf(out));
+        return sequence(StreamSupport.stream(options.spliterator(), false));
     }
 
     /**
@@ -400,21 +391,21 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      */
     static <V> Option<List<V>> sequence(Stream<Option<V>> options) {
         Objects.requireNonNull(options, "options");
-        ArrayList<V> out = new ArrayList<>();
-        try (options) {
-            Iterator<Option<V>> it = options.iterator();
-            while (it.hasNext()) {
-                Option<V> opt = it.next();
-                if (opt == null) {
-                    throw new NullPointerException("options contains null element (use Option.none() instead)");
-                }
-                if (opt instanceof None<V>) {
-                    return Option.none();
-                }
-                out.add(((Some<V>) opt).value());
-            }
+        try (var gathered = options.gather(Gatherer.<Option<V>, ArrayList<V>, Option<List<V>>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Objects.requireNonNull(element, "options contains null element (use Option.none() instead)");
+                    if (element instanceof None<V>) {
+                        downstream.push(Option.none());
+                        return false;
+                    }
+                    state.add(((Some<V>) element).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Option.some(List.copyOf(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
-        return Option.some(List.copyOf(out));
     }
 
     /**
@@ -434,15 +425,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     static <A, B> Option<List<B>> traverse(Iterable<A> values, Function<? super A, Option<B>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        ArrayList<B> out = new ArrayList<>();
-        for (A a : values) {
-            Option<B> ob = Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null");
-            if (ob instanceof None<B>) {
-                return Option.none();
-            }
-            out.add(((Some<B>) ob).value());
-        }
-        return Option.some(List.copyOf(out));
+        return traverse(StreamSupport.stream(values.spliterator(), false), mapper);
     }
 
     /**
@@ -461,19 +444,21 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     static <A, B> Option<List<B>> traverse(Stream<A> values, Function<? super A, Option<B>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        ArrayList<B> out = new ArrayList<>();
-        try (values) {
-            Iterator<A> it = values.iterator();
-            while (it.hasNext()) {
-                A a = it.next();
-                Option<B> ob = Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null");
-                if (ob instanceof None<B>) {
-                    return Option.none();
-                }
-                out.add(((Some<B>) ob).value());
-            }
+        try (var gathered = values.gather(Gatherer.<A, ArrayList<B>, Option<List<B>>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Option<B> ob = Objects.requireNonNull(mapper.apply(element), "traverse mapper must not return null");
+                    if (ob instanceof None<B>) {
+                        downstream.push(Option.none());
+                        return false;
+                    }
+                    state.add(((Some<B>) ob).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Option.some(List.copyOf(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
-        return Option.some(List.copyOf(out));
     }
 
     // ---------- Interoperability: Option <-> Result / Try ----------

--- a/lib/src/main/java/codes/domix/fun/Result.java
+++ b/lib/src/main/java/codes/domix/fun/Result.java
@@ -2,7 +2,6 @@ package codes.domix.fun;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -13,7 +12,9 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collector;
+import java.util.stream.Gatherer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.jspecify.annotations.NullMarked;
 
 
@@ -584,17 +585,7 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      */
     static <V, E> Result<List<V>, E> sequence(Iterable<Result<V, E>> results) {
         Objects.requireNonNull(results, "results");
-        ArrayList<V> out = new ArrayList<>();
-        for (Result<V, E> r : results) {
-            if (r == null) {
-                throw new NullPointerException("results contains null element");
-            }
-            if (r instanceof Err<V, E> err) {
-                return Result.err(err.error());
-            }
-            out.add(((Ok<V, E>) r).value());
-        }
-        return Result.ok(List.copyOf(out));
+        return sequence(StreamSupport.stream(results.spliterator(), false));
     }
 
     /**
@@ -611,21 +602,21 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      */
     static <V, E> Result<List<V>, E> sequence(Stream<Result<V, E>> results) {
         Objects.requireNonNull(results, "results");
-        ArrayList<V> out = new ArrayList<>();
-        try (results) {
-            Iterator<Result<V, E>> it = results.iterator();
-            while (it.hasNext()) {
-                Result<V, E> r = it.next();
-                if (r == null) {
-                    throw new NullPointerException("results contains null element");
-                }
-                if (r instanceof Err<V, E> err) {
-                    return Result.err(err.error());
-                }
-                out.add(((Ok<V, E>) r).value());
-            }
+        try (var gathered = results.gather(Gatherer.<Result<V, E>, ArrayList<V>, Result<List<V>, E>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Objects.requireNonNull(element, "results contains null element");
+                    if (element instanceof Err<V, E> err) {
+                        downstream.push(Result.err(err.error()));
+                        return false;
+                    }
+                    state.add(((Ok<V, E>) element).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Result.ok(List.copyOf(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
-        return Result.ok(List.copyOf(out));
     }
 
     /**
@@ -645,15 +636,7 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     static <A, B, E> Result<List<B>, E> traverse(Iterable<A> values, Function<? super A, Result<B, E>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        ArrayList<B> out = new ArrayList<>();
-        for (A a : values) {
-            Result<B, E> r = Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null");
-            if (r instanceof Err<B, E> err) {
-                return Result.err(err.error());
-            }
-            out.add(((Ok<B, E>) r).value());
-        }
-        return Result.ok(List.copyOf(out));
+        return traverse(StreamSupport.stream(values.spliterator(), false), mapper);
     }
 
     /**
@@ -674,19 +657,21 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     static <A, B, E> Result<List<B>, E> traverse(Stream<A> values, Function<? super A, Result<B, E>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        ArrayList<B> out = new ArrayList<>();
-        try (values) {
-            Iterator<A> it = values.iterator();
-            while (it.hasNext()) {
-                A a = it.next();
-                Result<B, E> r = Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null");
-                if (r instanceof Err<B, E> err) {
-                    return Result.err(err.error());
-                }
-                out.add(((Ok<B, E>) r).value());
-            }
+        try (var gathered = values.gather(Gatherer.<A, ArrayList<B>, Result<List<B>, E>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Result<B, E> r = Objects.requireNonNull(mapper.apply(element), "traverse mapper must not return null");
+                    if (r instanceof Err<B, E> err) {
+                        downstream.push(Result.err(err.error()));
+                        return false;
+                    }
+                    state.add(((Ok<B, E>) r).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Result.ok(List.copyOf(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
-        return Result.ok(List.copyOf(out));
     }
 
     // ---------- Collectors ----------

--- a/lib/src/main/java/codes/domix/fun/Try.java
+++ b/lib/src/main/java/codes/domix/fun/Try.java
@@ -2,7 +2,6 @@ package codes.domix.fun;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -14,7 +13,9 @@ import java.util.function.Supplier;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Gatherer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -724,7 +725,7 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      */
     static <V> Try<List<V>> sequence(Iterable<Try<V>> tries) {
         Objects.requireNonNull(tries, "tries");
-        return collectFromIterator(tries.iterator());
+        return sequence(StreamSupport.stream(tries.spliterator(), false));
     }
 
     /**
@@ -740,8 +741,20 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      */
     static <V> Try<List<V>> sequence(Stream<Try<V>> tries) {
         Objects.requireNonNull(tries, "tries");
-        try (tries) {
-            return collectFromIterator(tries.iterator());
+        try (var gathered = tries.gather(Gatherer.<Try<V>, ArrayList<V>, Try<List<V>>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Objects.requireNonNull(element, "tries contains a null element");
+                    if (element instanceof Failure<V> f) {
+                        downstream.push(Try.failure(f.cause()));
+                        return false;
+                    }
+                    state.add(((Success<V>) element).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Try.success(Collections.unmodifiableList(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
     }
 
@@ -761,14 +774,7 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     static <A, B> Try<List<B>> traverse(Iterable<A> values, Function<? super A, Try<B>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        Iterator<A> raw = values.iterator();
-        Iterator<Try<B>> it = new Iterator<>() {
-            public boolean hasNext() { return raw.hasNext(); }
-            public Try<B> next() {
-                return Objects.requireNonNull(mapper.apply(raw.next()), "traverse mapper must not return null");
-            }
-        };
-        return collectFromIterator(it);
+        return traverse(StreamSupport.stream(values.spliterator(), false), mapper);
     }
 
     /**
@@ -788,24 +794,21 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     static <A, B> Try<List<B>> traverse(Stream<A> values, Function<? super A, Try<B>> mapper) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mapper, "mapper");
-        try (values) {
-            Iterator<Try<B>> it = values
-                .map(a -> Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null"))
-                .iterator();
-            return collectFromIterator(it);
+        try (var gathered = values.gather(Gatherer.<A, ArrayList<B>, Try<List<B>>>ofSequential(
+                ArrayList::new,
+                (state, element, downstream) -> {
+                    Try<B> t = Objects.requireNonNull(mapper.apply(element), "traverse mapper must not return null");
+                    if (t instanceof Failure<B> f) {
+                        downstream.push(Try.failure(f.cause()));
+                        return false;
+                    }
+                    state.add(((Success<B>) t).value());
+                    return true;
+                },
+                (state, downstream) -> downstream.push(Try.success(Collections.unmodifiableList(state)))
+        ))) {
+            return gathered.findFirst().orElseThrow();
         }
-    }
-
-    private static <V> Try<List<V>> collectFromIterator(Iterator<? extends Try<V>> it) {
-        ArrayList<V> out = new ArrayList<>();
-        while (it.hasNext()) {
-            Try<V> t = Objects.requireNonNull(it.next(), "tries contains a null element");
-            if (t instanceof Failure<V> f) {
-                return Try.failure(f.cause());
-            }
-            out.add(((Success<V>) t).value());
-        }
-        return Try.success(Collections.unmodifiableList(out));
     }
 
     // ---------- zip / zip3 ----------

--- a/lib/src/test/java/codes/domix/fun/SequenceTraverseTest.java
+++ b/lib/src/test/java/codes/domix/fun/SequenceTraverseTest.java
@@ -184,6 +184,37 @@ class SequenceTraverseTest {
             assertThat(result.isError()).isTrue();
             assertThat(result.getError()).isEqualTo("invalid: bad");
         }
+
+        @Test
+        void sequence_stream_shortCircuitsAfterFirstErr() {
+            AtomicInteger seen = new AtomicInteger(0);
+            Stream<Result<Integer, String>> base = Stream.of(
+                Result.ok(1), Result.<Integer, String>err("stop"), Result.ok(3)
+            );
+            Result<List<Integer>, String> result = Result.sequence(base.peek(r -> seen.incrementAndGet()));
+            assertThat(result.isError()).isTrue();
+            assertThat(result.getError()).isEqualTo("stop");
+            assertThat(seen.get()).isLessThan(3);
+        }
+
+        @Test
+        void traverse_stream_shortCircuitsAfterFirstErr() {
+            AtomicInteger calls = new AtomicInteger(0);
+            Result<List<Integer>, String> result = Result.traverse(
+                Stream.of("1", "bad", "3"),
+                s -> {
+                    calls.incrementAndGet();
+                    try {
+                        return Result.ok(Integer.parseInt(s));
+                    } catch (NumberFormatException e) {
+                        return Result.err("invalid: " + s);
+                    }
+                }
+            );
+            assertThat(result.isError()).isTrue();
+            assertThat(result.getError()).isEqualTo("invalid: bad");
+            assertThat(calls.get()).isEqualTo(2);
+        }
     }
 
     // =========================================================================
@@ -356,6 +387,34 @@ class SequenceTraverseTest {
             );
             assertThat(result.isFailure()).isTrue();
             assertThat(result.getCause()).isInstanceOf(NumberFormatException.class);
+        }
+
+        @Test
+        void sequence_stream_shortCircuitsAfterFirstFailure() {
+            RuntimeException boom = new RuntimeException("boom");
+            AtomicInteger seen = new AtomicInteger(0);
+            Try<List<Integer>> result = Try.sequence(
+                Stream.of(Try.success(1), Try.<Integer>failure(boom), Try.success(3))
+                      .peek(t -> seen.incrementAndGet())
+            );
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause()).isSameAs(boom);
+            assertThat(seen.get()).isLessThan(3);
+        }
+
+        @Test
+        void traverse_stream_shortCircuitsAfterFirstFailure() {
+            AtomicInteger calls = new AtomicInteger(0);
+            Try<List<Integer>> result = Try.traverse(
+                Stream.of("1", "bad", "3"),
+                s -> {
+                    calls.incrementAndGet();
+                    return Try.of(() -> Integer.parseInt(s));
+                }
+            );
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause()).isInstanceOf(NumberFormatException.class);
+            assertThat(calls.get()).isEqualTo(2);
         }
     }
 }


### PR DESCRIPTION
  Replace manual iterator-based while-loops in Option, Result, and Try with
  Gatherer.ofSequential(), giving the stream pipeline native short-circuit
  semantics: the integrator returns false on the first None/Err/Failure and
  the source stops being pulled immediately.

  Iterable overloads now delegate to their Stream counterpart via
  StreamSupport.stream(iterable.spliterator(), false), eliminating duplicated
  accumulation logic. The private Try.collectFromIterator helper is deleted.

  New tests in SequenceTraverseTest verify that no elements past the first
  failure are evaluated in the stream variants of sequence and traverse for
  both Result and Try.

  Closes #81

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #81

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sequence() and traverse() implementations to use modern stream processing APIs with early termination upon errors.
  * Improved resource utilization through fail-fast behavior in Option, Result, and Try types.

* **Tests**
  * Added comprehensive test coverage for short-circuit behavior during sequence and traverse operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->