### PR TITLE
chore(tests): migrate example files to module import declarations (JEP 476)

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -29,6 +29,24 @@ java {
     }
 }
 
+compileTestJava {
+    def mainClassesDirs = sourceSets.main.output.classesDirs
+    def apiDeps = configurations.compileClasspath   // api-scoped deps (jspecify)
+    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
+
+    // Move main output + api deps off the classpath → module-path to avoid split-package conflict
+    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
+
+    def modulePath = (mainClassesDirs + apiDeps).asPath
+    options.compilerArgs += [
+        '--module-path', modulePath,
+        '--add-modules', 'codes.domix.fun,java.net.http',
+        '--patch-module', "codes.domix.fun=${testSrcPath}",
+        '--add-reads', 'codes.domix.fun=ALL-UNNAMED',
+        '--add-reads', 'codes.domix.fun=java.net.http'
+    ]
+}
+
 test {
     useJUnitPlatform()
     testLogging {

--- a/lib/src/test/java/codes/domix/fun/example/DefaultUserRepository.java
+++ b/lib/src/test/java/codes/domix/fun/example/DefaultUserRepository.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example;
 
-import codes.domix.fun.Result;
+import module codes.domix.fun;
 
 public class DefaultUserRepository implements UserRepository {
     @Override

--- a/lib/src/test/java/codes/domix/fun/example/UserRepository.java
+++ b/lib/src/test/java/codes/domix/fun/example/UserRepository.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example;
 
-import codes.domix.fun.Result;
+import module codes.domix.fun;
 
 public interface UserRepository {
     Result<User, String> createUser(CreateUserCommand command);

--- a/lib/src/test/java/codes/domix/fun/example/UserService.java
+++ b/lib/src/test/java/codes/domix/fun/example/UserService.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example;
 
-import codes.domix.fun.Result;
+import module codes.domix.fun;
 import java.util.regex.Pattern;
 
 

--- a/lib/src/test/java/codes/domix/fun/example/site/QuickExample.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/QuickExample.java
@@ -1,7 +1,6 @@
 package codes.domix.fun.example.site;
 
-import codes.domix.fun.Option;
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 import java.util.function.Function;
 
 public class QuickExample {

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/APIResponseHandling.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/APIResponseHandling.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/Caching.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/Caching.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Option;
+import module codes.domix.fun;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/ConfigLoader.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/ConfigLoader.java
@@ -1,7 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Option;
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 import java.util.Properties;
 
 public class ConfigLoader {

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/DataPipeline.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/DataPipeline.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/OrderProcessor.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/OrderProcessor.java
@@ -1,7 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Option;
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 
 public class OrderProcessor {
     private final ProductRepo productRepo = new ProductRepo();

--- a/lib/src/test/java/codes/domix/fun/example/site/examples/UserValidator.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/examples/UserValidator.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.examples;
 
-import codes.domix.fun.Result;
+import module codes.domix.fun;
 
 public class UserValidator {
     public record User(String email, String password) {

--- a/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/OptionExample.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/OptionExample.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.gettingstarted;
 
-import codes.domix.fun.Option;
+import module codes.domix.fun;
 
  class OptionExample {
     void main() {

--- a/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/ResultExample.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/ResultExample.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.gettingstarted;
 
-import codes.domix.fun.Result;
+import module codes.domix.fun;
 
 class ResultExample {
     void main() {

--- a/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/TryExample.java
+++ b/lib/src/test/java/codes/domix/fun/example/site/gettingstarted/TryExample.java
@@ -1,6 +1,6 @@
 package codes.domix.fun.example.site.gettingstarted;
 
-import codes.domix.fun.Try;
+import module codes.domix.fun;
 
 class TryExample {
     void main() {


### PR DESCRIPTION
  Replace per-type imports with `import module codes.domix.fun;` in all
  16 example files under codes.domix.fun.example.* subpackages.

  Configure compileTestJava to patch test sources into the codes.domix.fun
  module so the module import declaration resolves at compile time. Move
  main output and api deps to the module-path to avoid split-package
  conflicts; keep JUnit/AssertJ on the classpath and grant read access
  via --add-reads. Add java.net.http to the module graph for the
  APIResponseHandling example.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #84

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated test compilation configuration and module import patterns to align with Java module system standards. These changes ensure proper resolution of dependencies during testing while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->