### PR TITLE
feat(Option,Result): add eager and lazy orElse overloads for fallback chaining (closes #123)

### DIFF
--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A sealed interface representing an optional value with two possible states:
@@ -24,8 +25,11 @@ import java.util.stream.StreamSupport;
  * integrating functional-style operations for working with optional values in a more
  * expressive and composable manner.
  *
+ * <p>This interface is {@link NullMarked}: all types are non-null by default.
+ *
  * @param <Value> The type of the optional value.
  */
+@NullMarked
 public sealed interface Option<Value> permits Option.Some, Option.None {
 
     /**

--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -178,6 +178,35 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     }
 
     /**
+     * Returns this {@code Option} if it is {@code Some}, otherwise returns {@code alternative}.
+     *
+     * @param alternative the fallback {@code Option} to return when this is {@code None};
+     *                    must not be {@code null}
+     * @return this instance if {@code Some}, otherwise {@code alternative}
+     * @throws NullPointerException if {@code alternative} is null
+     */
+    @SuppressWarnings("unchecked")
+    default Option<Value> orElse(Option<? extends Value> alternative) {
+        Objects.requireNonNull(alternative, "alternative");
+        return isDefined() ? this : (Option<Value>) alternative;
+    }
+
+    /**
+     * Returns this {@code Option} if it is {@code Some}, otherwise evaluates and returns
+     * the supplier's result. The supplier is <em>not</em> called when this is {@code Some}.
+     *
+     * @param alternative a lazy supplier of a fallback {@code Option}; must not return {@code null}
+     * @return this instance if {@code Some}, or the result of {@code alternative.get()} if {@code None}
+     * @throws NullPointerException if {@code alternative} is null or returns {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    default Option<Value> orElse(Supplier<? extends Option<? extends Value>> alternative) {
+        Objects.requireNonNull(alternative, "alternative");
+        if (isDefined()) return this;
+        return (Option<Value>) Objects.requireNonNull(alternative.get(), "alternative returned null");
+    }
+
+    /**
      * Retrieves the encapsulated value if this {@code Option} instance is of type {@code Some},
      * or returns {@code null} if this instance is of type {@code None}.
      *

--- a/lib/src/main/java/dmx/fun/Result.java
+++ b/lib/src/main/java/dmx/fun/Result.java
@@ -366,6 +366,35 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     }
 
     /**
+     * Returns this {@code Result} if it is {@code Ok}, otherwise returns {@code alternative}.
+     *
+     * @param alternative the fallback {@code Result} to return when this is {@code Err};
+     *                    must not be {@code null}
+     * @return this instance if {@code Ok}, otherwise {@code alternative}
+     * @throws NullPointerException if {@code alternative} is null
+     */
+    @SuppressWarnings("unchecked")
+    default Result<Value, Error> orElse(Result<? extends Value, ? extends Error> alternative) {
+        Objects.requireNonNull(alternative, "alternative");
+        return isOk() ? this : (Result<Value, Error>) alternative;
+    }
+
+    /**
+     * Returns this {@code Result} if it is {@code Ok}, otherwise evaluates and returns
+     * the supplier's result. The supplier is <em>not</em> called when this instance is {@code Ok}.
+     *
+     * @param alternative a lazy supplier of a fallback {@code Result}; must not return {@code null}
+     * @return this instance if {@code Ok}, or the result of {@code alternative.get()} if {@code Err}
+     * @throws NullPointerException if {@code alternative} is null or returns {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    default Result<Value, Error> orElse(Supplier<? extends Result<? extends Value, ? extends Error>> alternative) {
+        Objects.requireNonNull(alternative, "alternative");
+        if (isOk()) return this;
+        return (Result<Value, Error>) Objects.requireNonNull(alternative.get(), "alternative returned null");
+    }
+
+    /**
      * Returns this {@code Result} if it is {@code Ok}; otherwise evaluates the given supplier
      * and returns its result. The supplier is <em>not</em> called when this instance is {@code Ok}.
      *

--- a/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/lib/src/test/java/dmx/fun/OptionTest.java
@@ -78,6 +78,68 @@ class OptionTest {
         assertThat(called.get()).as("fallback supplier must be called for None").isTrue();
     }
 
+    // ---------- orElse ----------
+
+    @Test
+    void orElse_eager_shouldReturnSelf_forSome() {
+        Option<Integer> some = Option.some(10);
+        Option<Integer> result = some.orElse(Option.some(99));
+        assertThat(result).isSameAs(some);
+    }
+
+    @Test
+    void orElse_eager_shouldReturnAlternative_forNone() {
+        Option<Integer> result = Option.<Integer>none().orElse(Option.some(99));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get()).isEqualTo(99);
+    }
+
+    @Test
+    void orElse_eager_shouldChainMultipleAlternatives() {
+        Option<Integer> result = Option.<Integer>none()
+            .orElse(Option.none())
+            .orElse(Option.some(42));
+        assertThat(result.get()).isEqualTo(42);
+    }
+
+    @Test
+    void orElse_eager_shouldThrowNPE_ifAlternativeIsNull() {
+        assertThatThrownBy(() -> Option.<Integer>none().orElse((Option<Integer>) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void orElse_lazy_shouldReturnSelf_forSome_andNotCallSupplier() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        Option<Integer> some = Option.some(10);
+        Option<Integer> result = some.orElse(() -> {
+            called.set(true);
+            return Option.some(99);
+        });
+        assertThat(result).isSameAs(some);
+        assertThat(called.get()).as("supplier must not be called for Some").isFalse();
+    }
+
+    @Test
+    void orElse_lazy_shouldReturnAlternative_forNone() {
+        Option<Integer> result = Option.<Integer>none().orElse(() -> Option.some(99));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get()).isEqualTo(99);
+    }
+
+    @Test
+    void orElse_lazy_shouldThrowNPE_ifSupplierIsNull() {
+        assertThatThrownBy(() -> Option.<Integer>none().orElse((java.util.function.Supplier<Option<Integer>>) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void orElse_lazy_shouldThrowNPE_ifSupplierReturnsNull() {
+        assertThatThrownBy(() -> Option.<Integer>none().orElse(() -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("alternative returned null");
+    }
+
     @Test
     void getOrNull_shouldReturnValueOrNull() {
         assertThat(Option.some(10).getOrNull()).isEqualTo(10);

--- a/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/lib/src/test/java/dmx/fun/ResultTest.java
@@ -366,6 +366,71 @@ class ResultTest {
             .hasMessageContaining("rescue returned null");
     }
 
+    // ---------- orElse ----------
+
+    @Test
+    void orElse_eager_shouldReturnSelf_whenOk() {
+        Result<String, String> ok = Result.ok("primary");
+        Result<String, String> result = ok.orElse(Result.ok("fallback"));
+        assertThat(result).isSameAs(ok);
+    }
+
+    @Test
+    void orElse_eager_shouldReturnAlternative_whenErr() {
+        Result<String, String> result = Result.<String, String>err("e")
+            .orElse(Result.ok("fallback"));
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get()).isEqualTo("fallback");
+    }
+
+    @Test
+    void orElse_eager_shouldChainMultipleAlternatives() {
+        Result<String, String> result = Result.<String, String>err("e1")
+            .orElse(Result.err("e2"))
+            .orElse(Result.ok("found"));
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get()).isEqualTo("found");
+    }
+
+    @Test
+    void orElse_eager_shouldThrowNPE_ifAlternativeIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>err("e").orElse((Result<String, String>) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void orElse_lazy_shouldReturnSelf_whenOk_andNotCallSupplier() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        Result<String, String> ok = Result.ok("primary");
+        Result<String, String> result = ok.orElse(() -> {
+            called.set(true);
+            return Result.ok("fallback");
+        });
+        assertThat(result).isSameAs(ok);
+        assertThat(called.get()).as("supplier must not be called for Ok").isFalse();
+    }
+
+    @Test
+    void orElse_lazy_shouldReturnAlternative_whenErr() {
+        Result<String, String> result = Result.<String, String>err("e")
+            .orElse(() -> Result.ok("fallback"));
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get()).isEqualTo("fallback");
+    }
+
+    @Test
+    void orElse_lazy_shouldThrowNPE_ifSupplierIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>err("e").orElse((Supplier<Result<String, String>>) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void orElse_lazy_shouldThrowNPE_ifSupplierReturnsNull() {
+        assertThatThrownBy(() -> Result.<String, String>err("e").orElse(() -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("alternative returned null");
+    }
+
     // ---------- or ----------
 
     @Test


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #123

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `orElse()` fallback methods with eager and lazy evaluation variants for providing alternative values, supporting chainable operations with automatic null-safety validation.

* **Tests**
  * Added comprehensive test coverage for new fallback functionality, including method chaining, null-safety validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->