### PR TITLE
feat(Validated): add collector and traverseCollector factories

### DIFF
--- a/lib/src/main/java/dmx/fun/Validated.java
+++ b/lib/src/main/java/dmx/fun/Validated.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.jspecify.annotations.NullMarked;
@@ -437,6 +438,66 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
                 .map(a -> Objects.requireNonNull(mapper.apply(a), "traverse mapper must not return null"))
                 .iterator();
         return accumulate(mapped, errMerge);
+    }
+
+    // ---------- collector / traverseCollector ----------
+
+    /**
+     * Returns a {@link Collector} that accumulates a stream of {@code Validated<E, A>} into a
+     * single {@code Validated<E, List<A>>}, collecting all valid values and merging all errors
+     * left-to-right using {@code errMerge}.
+     *
+     * <p>Compatible with parallel streams: partial results from each split are combined via
+     * {@code errMerge} on errors and list concatenation on values.
+     *
+     * @param <E>      the error type
+     * @param <A>      the value type
+     * @param errMerge a function to merge two errors; must not return {@code null}
+     * @return a {@code Collector} producing {@code Valid(List<A>)} if all elements are valid,
+     *         or {@code Invalid(accumulatedError)} otherwise
+     * @throws NullPointerException if {@code errMerge} is null
+     */
+    static <E, A> Collector<Validated<E, A>, ?, Validated<E, List<A>>> collector(
+        BinaryOperator<E> errMerge
+    ) {
+        Objects.requireNonNull(errMerge, "errMerge");
+        return Collector.of(
+            () -> new ArrayList<Validated<E, A>>(),
+            ArrayList::add,
+            (left, right) -> { left.addAll(right); return left; },
+            list -> accumulate(list, errMerge)
+        );
+    }
+
+    /**
+     * Returns a {@link Collector} that maps each input element through {@code mapper} and
+     * accumulates the results into a single {@code Validated<E, List<B>>}, collecting all valid
+     * values and merging all errors left-to-right using {@code errMerge}.
+     *
+     * <p>The mapper is applied eagerly during accumulation, so parallel streams benefit from
+     * parallel mapping. Compatible with parallel streams.
+     *
+     * @param <E>      the error type
+     * @param <A>      the input element type
+     * @param <B>      the mapped value type
+     * @param mapper   a function mapping each element to a {@code Validated}; must not return {@code null}
+     * @param errMerge a function to merge two errors; must not return {@code null}
+     * @return a {@code Collector} producing {@code Valid(List<B>)} if all mappings succeed,
+     *         or {@code Invalid(accumulatedError)} otherwise
+     * @throws NullPointerException if {@code mapper} or {@code errMerge} is null
+     */
+    static <E, A, B> Collector<A, ?, Validated<E, List<B>>> traverseCollector(
+        Function<? super A, Validated<E, B>> mapper,
+        BinaryOperator<E> errMerge
+    ) {
+        Objects.requireNonNull(mapper, "mapper");
+        Objects.requireNonNull(errMerge, "errMerge");
+        return Collector.of(
+            () -> new ArrayList<Validated<E, B>>(),
+            (list, a) -> list.add(Objects.requireNonNull(mapper.apply(a), "traverseCollector mapper must not return null")),
+            (left, right) -> { left.addAll(right); return left; },
+            list -> accumulate(list, errMerge)
+        );
     }
 
     private static <E, A> Validated<E, List<A>> accumulate(

--- a/lib/src/test/java/dmx/fun/ValidatedTest.java
+++ b/lib/src/test/java/dmx/fun/ValidatedTest.java
@@ -302,4 +302,120 @@ class ValidatedTest {
         assertThat(result.isInvalid()).isTrue();
         assertThat(result.getError()).isEqualTo("bad:2");
     }
+
+    // ---------- collector / traverseCollector ----------
+
+    @Test
+    void collector_allValid_shouldReturnValidList() {
+        Validated<String, List<Integer>> result = Stream.<Validated<String, Integer>>of(
+                Validated.valid(1), Validated.valid(2), Validated.valid(3))
+            .collect(Validated.collector((a, b) -> a + "; " + b));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isEqualTo(List.of(1, 2, 3));
+    }
+
+    @Test
+    void collector_mixedValidAndInvalid_shouldReturnAccumulatedError() {
+        Validated<String, List<Integer>> result = Stream.<Validated<String, Integer>>of(
+                Validated.valid(1), Validated.invalid("e1"), Validated.valid(3), Validated.invalid("e2"))
+            .collect(Validated.collector((a, b) -> a + "; " + b));
+        assertThat(result.isInvalid()).isTrue();
+        assertThat(result.getError()).isEqualTo("e1; e2");
+    }
+
+    @Test
+    void collector_allInvalid_shouldAccumulateAllErrors() {
+        Validated<String, List<Integer>> result = Stream.<Validated<String, Integer>>of(
+                Validated.invalid("e1"), Validated.invalid("e2"), Validated.invalid("e3"))
+            .collect(Validated.collector((a, b) -> a + "; " + b));
+        assertThat(result.isInvalid()).isTrue();
+        assertThat(result.getError()).isEqualTo("e1; e2; e3");
+    }
+
+    @Test
+    void collector_emptyStream_shouldReturnValidEmptyList() {
+        Validated<String, List<Integer>> result = Stream.<Validated<String, Integer>>of()
+            .collect(Validated.collector((a, b) -> a + "; " + b));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isEmpty();
+    }
+
+    @Test
+    void collector_parallelStream_shouldReturnValidList() {
+        Validated<String, List<Integer>> result = Stream.<Validated<String, Integer>>of(
+                Validated.valid(1), Validated.valid(2), Validated.valid(3),
+                Validated.valid(4), Validated.valid(5))
+            .parallel()
+            .collect(Validated.collector((a, b) -> a + "; " + b));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void collector_shouldThrowNPE_ifErrMergeIsNull() {
+        assertThatThrownBy(() -> Validated.collector(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void traverseCollector_allValid_shouldReturnValidList() {
+        Validated<String, List<String>> result = Stream.of(1, 2, 3)
+            .collect(Validated.traverseCollector(
+                n -> Validated.valid("v" + n),
+                (a, b) -> a + "; " + b));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isEqualTo(List.of("v1", "v2", "v3"));
+    }
+
+    @Test
+    void traverseCollector_mixedValidAndInvalid_shouldAccumulateErrors() {
+        Validated<String, List<String>> result = Stream.of(1, 2, 3)
+            .collect(Validated.traverseCollector(
+                n -> n % 2 == 0 ? Validated.invalid("bad:" + n) : Validated.valid("ok:" + n),
+                (a, b) -> a + "; " + b));
+        assertThat(result.isInvalid()).isTrue();
+        assertThat(result.getError()).isEqualTo("bad:2");
+    }
+
+    @Test
+    void traverseCollector_allInvalid_shouldAccumulateAllErrors() {
+        Validated<String, List<String>> result = Stream.of(1, 2, 3)
+            .collect(Validated.traverseCollector(
+                n -> Validated.invalid("e" + n),
+                (a, b) -> a + "; " + b));
+        assertThat(result.isInvalid()).isTrue();
+        assertThat(result.getError()).isEqualTo("e1; e2; e3");
+    }
+
+    @Test
+    void traverseCollector_emptyStream_shouldReturnValidEmptyList() {
+        Validated<String, List<String>> result = Stream.<Integer>of()
+            .collect(Validated.traverseCollector(
+                n -> Validated.valid("v" + n),
+                (a, b) -> a + "; " + b));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isEmpty();
+    }
+
+    @Test
+    void traverseCollector_parallelStream_shouldAccumulateErrors() {
+        Validated<String, List<String>> result = Stream.of(1, 2, 3, 4, 5)
+            .parallel()
+            .collect(Validated.traverseCollector(
+                n -> n % 2 == 0 ? Validated.invalid("bad:" + n) : Validated.valid("ok:" + n),
+                (a, b) -> a + "; " + b));
+        assertThat(result.isInvalid()).isTrue();
+    }
+
+    @Test
+    void traverseCollector_shouldThrowNPE_ifMapperIsNull() {
+        assertThatThrownBy(() -> Validated.traverseCollector(null, (a, b) -> a + "; " + b))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void traverseCollector_shouldThrowNPE_ifErrMergeIsNull() {
+        assertThatThrownBy(() -> Validated.traverseCollector(n -> Validated.valid(n), null))
+            .isInstanceOf(NullPointerException.class);
+    }
 }

--- a/lib/src/test/java/dmx/fun/ValidatedTest.java
+++ b/lib/src/test/java/dmx/fun/ValidatedTest.java
@@ -405,6 +405,7 @@ class ValidatedTest {
                 n -> n % 2 == 0 ? Validated.invalid("bad:" + n) : Validated.valid("ok:" + n),
                 (a, b) -> a + "; " + b));
         assertThat(result.isInvalid()).isTrue();
+        assertThat(result.getError()).contains("bad:2");
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #117

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stream collector support for validation workflows, enabling integration with Java Streams for sequential and parallel processing.
  * Added customizable error-merging behavior and support for mapping elements into validated results within streaming pipelines.

* **Tests**
  * Added unit tests covering all-valid, mixed, all-invalid, empty-stream, parallel scenarios, and null-argument validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->