### PR TITLE
chore(build): add JUnit to version catalog and filter non-stable version suggestions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,13 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-groovy = "4.0.29"
-spock-core = "2.4-M6-groovy-4.0"
 assertj = "3.27.7"
 jspecify = "1.0.0"
 junit = "6.0.3"
 
 [libraries]
-groovy = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
-spock-core = { module = "org.spockframework:spock-core", version.ref = "spock-core" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,13 @@ groovy = "4.0.29"
 spock-core = "2.4-M6-groovy-4.0"
 assertj = "3.27.7"
 jspecify = "1.0.0"
+junit = "6.0.3"
 
 [libraries]
 groovy = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock-core" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 
     testImplementation libs.assertj.core
 
-    testImplementation(platform('org.junit:junit-bom:6.0.1'))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -45,6 +45,17 @@ compileTestJava {
         '--add-reads', 'dmx.fun=ALL-UNNAMED',
         '--add-reads', 'dmx.fun=java.net.http'
     ]
+}
+
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+
+tasks.named("dependencyUpdates").configure {
+    rejectVersionIf { isNonStable(it.candidate.version) }
+    gradleReleaseChannel = "current"
 }
 
 test {


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test dependency configuration to use a centralized version catalog and migrate test tooling to JUnit 6.
  * Removed Groovy/Spock testing libraries from the project.
  * Improved the automated dependency-update task to prefer stable releases and filter out non‑stable candidates, and set the release channel to current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->