### PR TITLE
feat(assertj): add dmx-fun-assertj module with fluent AssertJ custom assertions (#116)

### DIFF
--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -7,14 +7,6 @@ dependencies {
     api libs.assertj.core
 }
 
-compileJava {
-    options.compilerArgs += ['--add-exports', 'org.assertj.core/org.assertj.core.internal=dmx.fun.assertj']
-}
-
-javadoc {
-    options.addStringOption('-add-exports', 'org.assertj.core/org.assertj.core.internal=dmx.fun.assertj')
-}
-
 compileTestJava {
     def mainClassesDirs = sourceSets.main.output.classesDirs
     def apiDeps = configurations.compileClasspath

--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'dmx-fun.java-module'
+}
+
+dependencies {
+    api project(':lib')
+    api libs.assertj.core
+}
+
+compileTestJava {
+    def mainClassesDirs = sourceSets.main.output.classesDirs
+    def apiDeps = configurations.compileClasspath
+    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
+
+    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
+
+    def modulePath = (mainClassesDirs + apiDeps).asPath
+    options.compilerArgs += [
+        '--module-path', modulePath,
+        '--add-modules', 'dmx.fun.assertj',
+        '--patch-module', "dmx.fun.assertj=${testSrcPath}",
+        '--add-reads', 'dmx.fun.assertj=ALL-UNNAMED',
+    ]
+}
+
+mavenPublishing {
+    coordinates("codes.domix", "fun-assertj", "${project.version}")
+
+    pom {
+        name = 'AssertJ custom assertions for dmx-fun types.'
+        description = 'Fluent AssertJ custom assertions for Option, Result, Try, Validated, Tuple2, Tuple3, and Tuple4.'
+    }
+}

--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -7,6 +7,14 @@ dependencies {
     api libs.assertj.core
 }
 
+compileJava {
+    options.compilerArgs += ['--add-exports', 'org.assertj.core/org.assertj.core.internal=dmx.fun.assertj']
+}
+
+javadoc {
+    options.addStringOption('-add-exports', 'org.assertj.core/org.assertj.core.internal=dmx.fun.assertj')
+}
+
 compileTestJava {
     def mainClassesDirs = sourceSets.main.output.classesDirs
     def apiDeps = configurations.compileClasspath

--- a/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
+++ b/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
@@ -1,0 +1,114 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Option;
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Tuple2;
+import dmx.fun.Tuple3;
+import dmx.fun.Tuple4;
+import dmx.fun.Validated;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Entry point for AssertJ custom assertions for all dmx-fun types.
+ *
+ * <p>Use static imports for fluent syntax:
+ * <pre>{@code
+ * import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+ *
+ * assertThat(Option.some(42)).isSome().containsValue(42);
+ * assertThat(Result.ok("hello")).isOk().containsValue("hello");
+ * assertThat(Try.success(1)).isSuccess().containsValue(1);
+ * assertThat(Validated.valid("ok")).isValid().containsValue("ok");
+ * }</pre>
+ */
+@NullMarked
+public final class DmxFunAssertions {
+
+    private DmxFunAssertions() {}
+
+    /**
+     * Creates an assertion for an {@link Option}.
+     *
+     * @param <V>    the value type
+     * @param actual the Option to assert on
+     * @return a new {@link OptionAssert}
+     */
+    public static <V> OptionAssert<V> assertThat(Option<V> actual) {
+        return new OptionAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Result}.
+     *
+     * @param <V>    the success value type
+     * @param <E>    the error type
+     * @param actual the Result to assert on
+     * @return a new {@link ResultAssert}
+     */
+    public static <V, E> ResultAssert<V, E> assertThat(Result<V, E> actual) {
+        return new ResultAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Try}.
+     *
+     * @param <V>    the success value type
+     * @param actual the Try to assert on
+     * @return a new {@link TryAssert}
+     */
+    public static <V> TryAssert<V> assertThat(Try<V> actual) {
+        return new TryAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Validated}.
+     *
+     * @param <E>    the error type
+     * @param <A>    the value type
+     * @param actual the Validated to assert on
+     * @return a new {@link ValidatedAssert}
+     */
+    public static <E, A> ValidatedAssert<E, A> assertThat(Validated<E, A> actual) {
+        return new ValidatedAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Tuple2}.
+     *
+     * @param <A>    the first element type
+     * @param <B>    the second element type
+     * @param actual the Tuple2 to assert on
+     * @return a new {@link Tuple2Assert}
+     */
+    public static <A, B> Tuple2Assert<A, B> assertThat(Tuple2<A, B> actual) {
+        return new Tuple2Assert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Tuple3}.
+     *
+     * @param <A>    the first element type
+     * @param <B>    the second element type
+     * @param <C>    the third element type
+     * @param actual the Tuple3 to assert on
+     * @return a new {@link Tuple3Assert}
+     */
+    public static <A, B, C> Tuple3Assert<A, B, C> assertThat(Tuple3<A, B, C> actual) {
+        return new Tuple3Assert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Tuple4}.
+     *
+     * @param <A>    the first element type
+     * @param <B>    the second element type
+     * @param <C>    the third element type
+     * @param <D>    the fourth element type
+     * @param actual the Tuple4 to assert on
+     * @return a new {@link Tuple4Assert}
+     */
+    public static <A, B, C, D> Tuple4Assert<A, B, C, D> assertThat(Tuple4<A, B, C, D> actual) {
+        return new Tuple4Assert<>(actual);
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
@@ -4,6 +4,8 @@ import dmx.fun.Option;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -28,7 +30,8 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> isSome() {
         isNotNull();
         if (!actual.isDefined()) {
-            failWithMessage("Expected Option to be Some but was None");
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Option to be Some but was None"));
         }
         return this;
     }
@@ -41,7 +44,8 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> isNone() {
         isNotNull();
         if (!actual.isEmpty()) {
-            failWithMessage("Expected Option to be None but was Some<%s>", actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Option to be None but was Some<%s>", actual.get()));
         }
         return this;
     }
@@ -55,7 +59,8 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> containsValue(V expected) {
         isSome();
         if (!Objects.equals(actual.get(), expected)) {
-            failWithMessage("Expected Option to contain <%s> but contained <%s>", expected, actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Option to contain <%s> but contained <%s>", expected, actual.get()));
         }
         return this;
     }
@@ -67,6 +72,7 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
      * @return this assertion for chaining
      */
     public OptionAssert<V> hasValueSatisfying(Consumer<V> requirement) {
+        Objects.requireNonNull(requirement, "requirement must not be null");
         isSome();
         requirement.accept(actual.get());
         return this;

--- a/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
@@ -4,8 +4,6 @@ import dmx.fun.Option;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.error.BasicErrorMessageFactory;
-import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -30,8 +28,7 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> isSome() {
         isNotNull();
         if (!actual.isDefined()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Option to be Some but was None"));
+            throw buildError("Expected Option to be Some but was None");
         }
         return this;
     }
@@ -44,8 +41,7 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> isNone() {
         isNotNull();
         if (!actual.isEmpty()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Option to be None but was Some<%s>", actual.get()));
+            throw buildError("Expected Option to be None but was Some<%s>", actual.get());
         }
         return this;
     }
@@ -59,8 +55,7 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
     public OptionAssert<V> containsValue(V expected) {
         isSome();
         if (!Objects.equals(actual.get(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Option to contain <%s> but contained <%s>", expected, actual.get()));
+            throw buildError("Expected Option to contain <%s> but contained <%s>", expected, actual.get());
         }
         return this;
     }
@@ -76,5 +71,11 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
         isSome();
         requirement.accept(actual.get());
         return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
@@ -1,11 +1,10 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Option;
+import java.util.Objects;
 import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ assertions for {@link Option}.
@@ -28,9 +27,9 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
      */
     public OptionAssert<V> isSome() {
         isNotNull();
-        assertThat(actual.isDefined())
-            .withFailMessage("Expected Option to be Some but was None")
-            .isTrue();
+        if (!actual.isDefined()) {
+            failWithMessage("Expected Option to be Some but was None");
+        }
         return this;
     }
 
@@ -41,9 +40,9 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
      */
     public OptionAssert<V> isNone() {
         isNotNull();
-        assertThat(actual.isEmpty())
-            .withFailMessage(() -> String.format("Expected Option to be None but was Some<%s>", actual.get()))
-            .isTrue();
+        if (!actual.isEmpty()) {
+            failWithMessage("Expected Option to be None but was Some<%s>", actual.get());
+        }
         return this;
     }
 
@@ -55,9 +54,9 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
      */
     public OptionAssert<V> containsValue(V expected) {
         isSome();
-        assertThat(actual.get())
-            .withFailMessage(() -> String.format("Expected Option to contain <%s> but contained <%s>", expected, actual.get()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.get(), expected)) {
+            failWithMessage("Expected Option to contain <%s> but contained <%s>", expected, actual.get());
+        }
         return this;
     }
 

--- a/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
@@ -1,0 +1,75 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Option;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Option}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Option)}.
+ *
+ * @param <V> the type of the optional value
+ */
+@NullMarked
+public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Option<V>> {
+
+    OptionAssert(Option<V> actual) {
+        super(actual, OptionAssert.class);
+    }
+
+    /**
+     * Verifies that the {@code Option} is {@code Some}.
+     *
+     * @return this assertion for chaining
+     */
+    public OptionAssert<V> isSome() {
+        isNotNull();
+        assertThat(actual.isDefined())
+            .withFailMessage("Expected Option to be Some but was None")
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Option} is {@code None}.
+     *
+     * @return this assertion for chaining
+     */
+    public OptionAssert<V> isNone() {
+        isNotNull();
+        assertThat(actual.isEmpty())
+            .withFailMessage(() -> String.format("Expected Option to be None but was Some<%s>", actual.get()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Option} is {@code Some} and contains the given value.
+     *
+     * @param expected the expected value
+     * @return this assertion for chaining
+     */
+    public OptionAssert<V> containsValue(V expected) {
+        isSome();
+        assertThat(actual.get())
+            .withFailMessage(() -> String.format("Expected Option to contain <%s> but contained <%s>", expected, actual.get()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Option} is {@code Some} and that its value satisfies the given requirement.
+     *
+     * @param requirement a consumer that performs assertions on the value
+     * @return this assertion for chaining
+     */
+    public OptionAssert<V> hasValueSatisfying(Consumer<V> requirement) {
+        isSome();
+        requirement.accept(actual.get());
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
@@ -3,8 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Result;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.error.BasicErrorMessageFactory;
-import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -30,8 +28,7 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> isOk() {
         isNotNull();
         if (!actual.isOk()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Result to be Ok but was Err<%s>", actual.getError()));
+            throw buildError("Expected Result to be Ok but was Err<%s>", actual.getError());
         }
         return this;
     }
@@ -44,8 +41,7 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> isErr() {
         isNotNull();
         if (!actual.isError()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Result to be Err but was Ok<%s>", actual.get()));
+            throw buildError("Expected Result to be Err but was Ok<%s>", actual.get());
         }
         return this;
     }
@@ -59,8 +55,7 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> containsValue(V expected) {
         isOk();
         if (!Objects.equals(actual.get(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Result to contain value <%s> but contained <%s>", expected, actual.get()));
+            throw buildError("Expected Result to contain value <%s> but contained <%s>", expected, actual.get());
         }
         return this;
     }
@@ -74,9 +69,14 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> containsError(E expected) {
         isErr();
         if (!Objects.equals(actual.getError(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError()));
+            throw buildError("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError());
         }
         return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
@@ -3,6 +3,8 @@ package dmx.fun.assertj;
 import dmx.fun.Result;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -28,7 +30,8 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> isOk() {
         isNotNull();
         if (!actual.isOk()) {
-            failWithMessage("Expected Result to be Ok but was Err<%s>", actual.getError());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Result to be Ok but was Err<%s>", actual.getError()));
         }
         return this;
     }
@@ -41,7 +44,8 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> isErr() {
         isNotNull();
         if (!actual.isError()) {
-            failWithMessage("Expected Result to be Err but was Ok<%s>", actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Result to be Err but was Ok<%s>", actual.get()));
         }
         return this;
     }
@@ -55,7 +59,8 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> containsValue(V expected) {
         isOk();
         if (!Objects.equals(actual.get(), expected)) {
-            failWithMessage("Expected Result to contain value <%s> but contained <%s>", expected, actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Result to contain value <%s> but contained <%s>", expected, actual.get()));
         }
         return this;
     }
@@ -69,7 +74,8 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
     public ResultAssert<V, E> containsError(E expected) {
         isErr();
         if (!Objects.equals(actual.getError(), expected)) {
-            failWithMessage("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError()));
         }
         return this;
     }

--- a/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
@@ -1,10 +1,9 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Result;
+import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ assertions for {@link Result}.
@@ -28,9 +27,9 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
      */
     public ResultAssert<V, E> isOk() {
         isNotNull();
-        assertThat(actual.isOk())
-            .withFailMessage(() -> String.format("Expected Result to be Ok but was Err<%s>", actual.getError()))
-            .isTrue();
+        if (!actual.isOk()) {
+            failWithMessage("Expected Result to be Ok but was Err<%s>", actual.getError());
+        }
         return this;
     }
 
@@ -41,9 +40,9 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
      */
     public ResultAssert<V, E> isErr() {
         isNotNull();
-        assertThat(actual.isError())
-            .withFailMessage(() -> String.format("Expected Result to be Err but was Ok<%s>", actual.get()))
-            .isTrue();
+        if (!actual.isError()) {
+            failWithMessage("Expected Result to be Err but was Ok<%s>", actual.get());
+        }
         return this;
     }
 
@@ -55,9 +54,9 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
      */
     public ResultAssert<V, E> containsValue(V expected) {
         isOk();
-        assertThat(actual.get())
-            .withFailMessage(() -> String.format("Expected Result to contain value <%s> but contained <%s>", expected, actual.get()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.get(), expected)) {
+            failWithMessage("Expected Result to contain value <%s> but contained <%s>", expected, actual.get());
+        }
         return this;
     }
 
@@ -69,9 +68,9 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
      */
     public ResultAssert<V, E> containsError(E expected) {
         isErr();
-        assertThat(actual.getError())
-            .withFailMessage(() -> String.format("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.getError(), expected)) {
+            failWithMessage("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError());
+        }
         return this;
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
@@ -1,0 +1,77 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Result;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Result}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Result)}.
+ *
+ * @param <V> the success value type
+ * @param <E> the error type
+ */
+@NullMarked
+public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>, Result<V, E>> {
+
+    ResultAssert(Result<V, E> actual) {
+        super(actual, ResultAssert.class);
+    }
+
+    /**
+     * Verifies that the {@code Result} is {@code Ok}.
+     *
+     * @return this assertion for chaining
+     */
+    public ResultAssert<V, E> isOk() {
+        isNotNull();
+        assertThat(actual.isOk())
+            .withFailMessage(() -> String.format("Expected Result to be Ok but was Err<%s>", actual.getError()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Result} is {@code Err}.
+     *
+     * @return this assertion for chaining
+     */
+    public ResultAssert<V, E> isErr() {
+        isNotNull();
+        assertThat(actual.isError())
+            .withFailMessage(() -> String.format("Expected Result to be Err but was Ok<%s>", actual.get()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Result} is {@code Ok} and contains the given value.
+     *
+     * @param expected the expected success value
+     * @return this assertion for chaining
+     */
+    public ResultAssert<V, E> containsValue(V expected) {
+        isOk();
+        assertThat(actual.get())
+            .withFailMessage(() -> String.format("Expected Result to contain value <%s> but contained <%s>", expected, actual.get()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Result} is {@code Err} and contains the given error.
+     *
+     * @param expected the expected error value
+     * @return this assertion for chaining
+     */
+    public ResultAssert<V, E> containsError(E expected) {
+        isErr();
+        assertThat(actual.getError())
+            .withFailMessage(() -> String.format("Expected Result to contain error <%s> but contained <%s>", expected, actual.getError()))
+            .isEqualTo(expected);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
@@ -3,8 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Try;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.error.BasicErrorMessageFactory;
-import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -29,8 +27,7 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> isSuccess() {
         isNotNull();
         if (!actual.isSuccess()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Try to be Success but was Failure<%s>", actual.getCause()));
+            throw buildError("Expected Try to be Success but was Failure<%s>", actual.getCause());
         }
         return this;
     }
@@ -43,8 +40,7 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> isFailure() {
         isNotNull();
         if (!actual.isFailure()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Try to be Failure but was Success<%s>", actual.get()));
+            throw buildError("Expected Try to be Failure but was Success<%s>", actual.get());
         }
         return this;
     }
@@ -58,8 +54,7 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> containsValue(V expected) {
         isSuccess();
         if (!Objects.equals(actual.get(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Try to contain <%s> but contained <%s>", expected, actual.get()));
+            throw buildError("Expected Try to contain <%s> but contained <%s>", expected, actual.get());
         }
         return this;
     }
@@ -73,10 +68,15 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> failsWith(Class<? extends Throwable> exceptionType) {
         isFailure();
         if (!exceptionType.isInstance(actual.getCause())) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Try to fail with <%s> but failed with <%s>",
-                    exceptionType.getName(), actual.getCause().getClass().getName()));
+            throw buildError("Expected Try to fail with <%s> but failed with <%s>",
+                exceptionType.getName(), actual.getCause().getClass().getName());
         }
         return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
@@ -1,0 +1,77 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Try;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Try}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Try)}.
+ *
+ * @param <V> the success value type
+ */
+@NullMarked
+public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
+
+    TryAssert(Try<V> actual) {
+        super(actual, TryAssert.class);
+    }
+
+    /**
+     * Verifies that the {@code Try} is a {@code Success}.
+     *
+     * @return this assertion for chaining
+     */
+    public TryAssert<V> isSuccess() {
+        isNotNull();
+        assertThat(actual.isSuccess())
+            .withFailMessage(() -> String.format("Expected Try to be Success but was Failure<%s>", actual.getCause()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Try} is a {@code Failure}.
+     *
+     * @return this assertion for chaining
+     */
+    public TryAssert<V> isFailure() {
+        isNotNull();
+        assertThat(actual.isFailure())
+            .withFailMessage(() -> String.format("Expected Try to be Failure but was Success<%s>", actual.get()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Try} is a {@code Success} and contains the given value.
+     *
+     * @param expected the expected value
+     * @return this assertion for chaining
+     */
+    public TryAssert<V> containsValue(V expected) {
+        isSuccess();
+        assertThat(actual.get())
+            .withFailMessage(() -> String.format("Expected Try to contain <%s> but contained <%s>", expected, actual.get()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Try} is a {@code Failure} caused by an exception of the given type.
+     *
+     * @param exceptionType the expected exception type
+     * @return this assertion for chaining
+     */
+    public TryAssert<V> failsWith(Class<? extends Throwable> exceptionType) {
+        isFailure();
+        assertThat(actual.getCause())
+            .withFailMessage(() -> String.format("Expected Try to fail with <%s> but failed with <%s>",
+                exceptionType.getName(), actual.getCause().getClass().getName()))
+            .isInstanceOf(exceptionType);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
@@ -1,10 +1,9 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Try;
+import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ assertions for {@link Try}.
@@ -27,9 +26,9 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
      */
     public TryAssert<V> isSuccess() {
         isNotNull();
-        assertThat(actual.isSuccess())
-            .withFailMessage(() -> String.format("Expected Try to be Success but was Failure<%s>", actual.getCause()))
-            .isTrue();
+        if (!actual.isSuccess()) {
+            failWithMessage("Expected Try to be Success but was Failure<%s>", actual.getCause());
+        }
         return this;
     }
 
@@ -40,9 +39,9 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
      */
     public TryAssert<V> isFailure() {
         isNotNull();
-        assertThat(actual.isFailure())
-            .withFailMessage(() -> String.format("Expected Try to be Failure but was Success<%s>", actual.get()))
-            .isTrue();
+        if (!actual.isFailure()) {
+            failWithMessage("Expected Try to be Failure but was Success<%s>", actual.get());
+        }
         return this;
     }
 
@@ -54,9 +53,9 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
      */
     public TryAssert<V> containsValue(V expected) {
         isSuccess();
-        assertThat(actual.get())
-            .withFailMessage(() -> String.format("Expected Try to contain <%s> but contained <%s>", expected, actual.get()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.get(), expected)) {
+            failWithMessage("Expected Try to contain <%s> but contained <%s>", expected, actual.get());
+        }
         return this;
     }
 
@@ -68,10 +67,10 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
      */
     public TryAssert<V> failsWith(Class<? extends Throwable> exceptionType) {
         isFailure();
-        assertThat(actual.getCause())
-            .withFailMessage(() -> String.format("Expected Try to fail with <%s> but failed with <%s>",
-                exceptionType.getName(), actual.getCause().getClass().getName()))
-            .isInstanceOf(exceptionType);
+        if (!exceptionType.isInstance(actual.getCause())) {
+            failWithMessage("Expected Try to fail with <%s> but failed with <%s>",
+                exceptionType.getName(), actual.getCause().getClass().getName());
+        }
         return this;
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
@@ -3,6 +3,8 @@ package dmx.fun.assertj;
 import dmx.fun.Try;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -27,7 +29,8 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> isSuccess() {
         isNotNull();
         if (!actual.isSuccess()) {
-            failWithMessage("Expected Try to be Success but was Failure<%s>", actual.getCause());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Try to be Success but was Failure<%s>", actual.getCause()));
         }
         return this;
     }
@@ -40,7 +43,8 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> isFailure() {
         isNotNull();
         if (!actual.isFailure()) {
-            failWithMessage("Expected Try to be Failure but was Success<%s>", actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Try to be Failure but was Success<%s>", actual.get()));
         }
         return this;
     }
@@ -54,7 +58,8 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> containsValue(V expected) {
         isSuccess();
         if (!Objects.equals(actual.get(), expected)) {
-            failWithMessage("Expected Try to contain <%s> but contained <%s>", expected, actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Try to contain <%s> but contained <%s>", expected, actual.get()));
         }
         return this;
     }
@@ -68,8 +73,9 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
     public TryAssert<V> failsWith(Class<? extends Throwable> exceptionType) {
         isFailure();
         if (!exceptionType.isInstance(actual.getCause())) {
-            failWithMessage("Expected Try to fail with <%s> but failed with <%s>",
-                exceptionType.getName(), actual.getCause().getClass().getName());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Try to fail with <%s> but failed with <%s>",
+                    exceptionType.getName(), actual.getCause().getClass().getName()));
         }
         return this;
     }

--- a/assertj/src/main/java/dmx/fun/assertj/Tuple2Assert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/Tuple2Assert.java
@@ -1,0 +1,51 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Tuple2;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Tuple2}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Tuple2)}.
+ *
+ * @param <A> the first element type
+ * @param <B> the second element type
+ */
+@NullMarked
+public final class Tuple2Assert<A, B> extends AbstractAssert<Tuple2Assert<A, B>, Tuple2<A, B>> {
+
+    Tuple2Assert(Tuple2<A, B> actual) {
+        super(actual, Tuple2Assert.class);
+    }
+
+    /**
+     * Verifies that the first element equals the given value.
+     *
+     * @param expected the expected first element
+     * @return this assertion for chaining
+     */
+    public Tuple2Assert<A, B> hasFirst(A expected) {
+        isNotNull();
+        assertThat(actual._1())
+            .withFailMessage(() -> String.format("Expected Tuple2 first element to be <%s> but was <%s>", expected, actual._1()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the second element equals the given value.
+     *
+     * @param expected the expected second element
+     * @return this assertion for chaining
+     */
+    public Tuple2Assert<A, B> hasSecond(B expected) {
+        isNotNull();
+        assertThat(actual._2())
+            .withFailMessage(() -> String.format("Expected Tuple2 second element to be <%s> but was <%s>", expected, actual._2()))
+            .isEqualTo(expected);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/Tuple3Assert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/Tuple3Assert.java
@@ -1,0 +1,66 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Tuple3;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Tuple3}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Tuple3)}.
+ *
+ * @param <A> the first element type
+ * @param <B> the second element type
+ * @param <C> the third element type
+ */
+@NullMarked
+public final class Tuple3Assert<A, B, C> extends AbstractAssert<Tuple3Assert<A, B, C>, Tuple3<A, B, C>> {
+
+    Tuple3Assert(Tuple3<A, B, C> actual) {
+        super(actual, Tuple3Assert.class);
+    }
+
+    /**
+     * Verifies that the first element equals the given value.
+     *
+     * @param expected the expected first element
+     * @return this assertion for chaining
+     */
+    public Tuple3Assert<A, B, C> hasFirst(A expected) {
+        isNotNull();
+        assertThat(actual._1())
+            .withFailMessage(() -> String.format("Expected Tuple3 first element to be <%s> but was <%s>", expected, actual._1()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the second element equals the given value.
+     *
+     * @param expected the expected second element
+     * @return this assertion for chaining
+     */
+    public Tuple3Assert<A, B, C> hasSecond(B expected) {
+        isNotNull();
+        assertThat(actual._2())
+            .withFailMessage(() -> String.format("Expected Tuple3 second element to be <%s> but was <%s>", expected, actual._2()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the third element equals the given value.
+     *
+     * @param expected the expected third element
+     * @return this assertion for chaining
+     */
+    public Tuple3Assert<A, B, C> hasThird(C expected) {
+        isNotNull();
+        assertThat(actual._3())
+            .withFailMessage(() -> String.format("Expected Tuple3 third element to be <%s> but was <%s>", expected, actual._3()))
+            .isEqualTo(expected);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/Tuple4Assert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/Tuple4Assert.java
@@ -1,0 +1,81 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Tuple4;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Tuple4}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Tuple4)}.
+ *
+ * @param <A> the first element type
+ * @param <B> the second element type
+ * @param <C> the third element type
+ * @param <D> the fourth element type
+ */
+@NullMarked
+public final class Tuple4Assert<A, B, C, D> extends AbstractAssert<Tuple4Assert<A, B, C, D>, Tuple4<A, B, C, D>> {
+
+    Tuple4Assert(Tuple4<A, B, C, D> actual) {
+        super(actual, Tuple4Assert.class);
+    }
+
+    /**
+     * Verifies that the first element equals the given value.
+     *
+     * @param expected the expected first element
+     * @return this assertion for chaining
+     */
+    public Tuple4Assert<A, B, C, D> hasFirst(A expected) {
+        isNotNull();
+        assertThat(actual._1())
+            .withFailMessage(() -> String.format("Expected Tuple4 first element to be <%s> but was <%s>", expected, actual._1()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the second element equals the given value.
+     *
+     * @param expected the expected second element
+     * @return this assertion for chaining
+     */
+    public Tuple4Assert<A, B, C, D> hasSecond(B expected) {
+        isNotNull();
+        assertThat(actual._2())
+            .withFailMessage(() -> String.format("Expected Tuple4 second element to be <%s> but was <%s>", expected, actual._2()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the third element equals the given value.
+     *
+     * @param expected the expected third element
+     * @return this assertion for chaining
+     */
+    public Tuple4Assert<A, B, C, D> hasThird(C expected) {
+        isNotNull();
+        assertThat(actual._3())
+            .withFailMessage(() -> String.format("Expected Tuple4 third element to be <%s> but was <%s>", expected, actual._3()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the fourth element equals the given value.
+     *
+     * @param expected the expected fourth element
+     * @return this assertion for chaining
+     */
+    public Tuple4Assert<A, B, C, D> hasFourth(D expected) {
+        isNotNull();
+        assertThat(actual._4())
+            .withFailMessage(() -> String.format("Expected Tuple4 fourth element to be <%s> but was <%s>", expected, actual._4()))
+            .isEqualTo(expected);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
@@ -1,0 +1,77 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Validated;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ assertions for {@link Validated}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Validated)}.
+ *
+ * @param <E> the error type
+ * @param <A> the value type
+ */
+@NullMarked
+public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>, Validated<E, A>> {
+
+    ValidatedAssert(Validated<E, A> actual) {
+        super(actual, ValidatedAssert.class);
+    }
+
+    /**
+     * Verifies that the {@code Validated} is {@code Valid}.
+     *
+     * @return this assertion for chaining
+     */
+    public ValidatedAssert<E, A> isValid() {
+        isNotNull();
+        assertThat(actual.isValid())
+            .withFailMessage(() -> String.format("Expected Validated to be Valid but was Invalid<%s>", actual.getError()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Validated} is {@code Invalid}.
+     *
+     * @return this assertion for chaining
+     */
+    public ValidatedAssert<E, A> isInvalid() {
+        isNotNull();
+        assertThat(actual.isInvalid())
+            .withFailMessage(() -> String.format("Expected Validated to be Invalid but was Valid<%s>", actual.get()))
+            .isTrue();
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Validated} is {@code Valid} and contains the given value.
+     *
+     * @param expected the expected value
+     * @return this assertion for chaining
+     */
+    public ValidatedAssert<E, A> containsValue(A expected) {
+        isValid();
+        assertThat(actual.get())
+            .withFailMessage(() -> String.format("Expected Validated to contain <%s> but contained <%s>", expected, actual.get()))
+            .isEqualTo(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Validated} is {@code Invalid} and contains the given error.
+     *
+     * @param expected the expected error
+     * @return this assertion for chaining
+     */
+    public ValidatedAssert<E, A> hasError(E expected) {
+        isInvalid();
+        assertThat(actual.getError())
+            .withFailMessage(() -> String.format("Expected Validated to have error <%s> but had <%s>", expected, actual.getError()))
+            .isEqualTo(expected);
+        return this;
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
@@ -3,6 +3,8 @@ package dmx.fun.assertj;
 import dmx.fun.Validated;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -28,7 +30,8 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> isValid() {
         isNotNull();
         if (!actual.isValid()) {
-            failWithMessage("Expected Validated to be Valid but was Invalid<%s>", actual.getError());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Validated to be Valid but was Invalid<%s>", actual.getError()));
         }
         return this;
     }
@@ -41,7 +44,8 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> isInvalid() {
         isNotNull();
         if (!actual.isInvalid()) {
-            failWithMessage("Expected Validated to be Invalid but was Valid<%s>", actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Validated to be Invalid but was Valid<%s>", actual.get()));
         }
         return this;
     }
@@ -55,7 +59,8 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> containsValue(A expected) {
         isValid();
         if (!Objects.equals(actual.get(), expected)) {
-            failWithMessage("Expected Validated to contain <%s> but contained <%s>", expected, actual.get());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Validated to contain <%s> but contained <%s>", expected, actual.get()));
         }
         return this;
     }
@@ -69,7 +74,8 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> hasError(E expected) {
         isInvalid();
         if (!Objects.equals(actual.getError(), expected)) {
-            failWithMessage("Expected Validated to have error <%s> but had <%s>", expected, actual.getError());
+            throw Failures.instance().failure(info,
+                new BasicErrorMessageFactory("Expected Validated to have error <%s> but had <%s>", expected, actual.getError()));
         }
         return this;
     }

--- a/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
@@ -1,10 +1,9 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Validated;
+import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ assertions for {@link Validated}.
@@ -28,9 +27,9 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
      */
     public ValidatedAssert<E, A> isValid() {
         isNotNull();
-        assertThat(actual.isValid())
-            .withFailMessage(() -> String.format("Expected Validated to be Valid but was Invalid<%s>", actual.getError()))
-            .isTrue();
+        if (!actual.isValid()) {
+            failWithMessage("Expected Validated to be Valid but was Invalid<%s>", actual.getError());
+        }
         return this;
     }
 
@@ -41,9 +40,9 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
      */
     public ValidatedAssert<E, A> isInvalid() {
         isNotNull();
-        assertThat(actual.isInvalid())
-            .withFailMessage(() -> String.format("Expected Validated to be Invalid but was Valid<%s>", actual.get()))
-            .isTrue();
+        if (!actual.isInvalid()) {
+            failWithMessage("Expected Validated to be Invalid but was Valid<%s>", actual.get());
+        }
         return this;
     }
 
@@ -55,9 +54,9 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
      */
     public ValidatedAssert<E, A> containsValue(A expected) {
         isValid();
-        assertThat(actual.get())
-            .withFailMessage(() -> String.format("Expected Validated to contain <%s> but contained <%s>", expected, actual.get()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.get(), expected)) {
+            failWithMessage("Expected Validated to contain <%s> but contained <%s>", expected, actual.get());
+        }
         return this;
     }
 
@@ -69,9 +68,9 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
      */
     public ValidatedAssert<E, A> hasError(E expected) {
         isInvalid();
-        assertThat(actual.getError())
-            .withFailMessage(() -> String.format("Expected Validated to have error <%s> but had <%s>", expected, actual.getError()))
-            .isEqualTo(expected);
+        if (!Objects.equals(actual.getError(), expected)) {
+            failWithMessage("Expected Validated to have error <%s> but had <%s>", expected, actual.getError());
+        }
         return this;
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
@@ -3,8 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Validated;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.error.BasicErrorMessageFactory;
-import org.assertj.core.internal.Failures;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -30,8 +28,7 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> isValid() {
         isNotNull();
         if (!actual.isValid()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Validated to be Valid but was Invalid<%s>", actual.getError()));
+            throw buildError("Expected Validated to be Valid but was Invalid<%s>", actual.getError());
         }
         return this;
     }
@@ -44,8 +41,7 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> isInvalid() {
         isNotNull();
         if (!actual.isInvalid()) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Validated to be Invalid but was Valid<%s>", actual.get()));
+            throw buildError("Expected Validated to be Invalid but was Valid<%s>", actual.get());
         }
         return this;
     }
@@ -59,8 +55,7 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> containsValue(A expected) {
         isValid();
         if (!Objects.equals(actual.get(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Validated to contain <%s> but contained <%s>", expected, actual.get()));
+            throw buildError("Expected Validated to contain <%s> but contained <%s>", expected, actual.get());
         }
         return this;
     }
@@ -74,9 +69,14 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
     public ValidatedAssert<E, A> hasError(E expected) {
         isInvalid();
         if (!Objects.equals(actual.getError(), expected)) {
-            throw Failures.instance().failure(info,
-                new BasicErrorMessageFactory("Expected Validated to have error <%s> but had <%s>", expected, actual.getError()));
+            throw buildError("Expected Validated to have error <%s> but had <%s>", expected, actual.getError());
         }
         return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }
 }

--- a/assertj/src/main/java/module-info.java
+++ b/assertj/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+/**
+ * AssertJ custom assertions for dmx-fun types.
+ *
+ * <p>Provides fluent, self-documenting assertions for {@code Option}, {@code Result},
+ * {@code Try}, {@code Validated}, {@code Tuple2}, {@code Tuple3}, and {@code Tuple4}.
+ *
+ * <p>Entry point: {@link dmx.fun.assertj.DmxFunAssertions#assertThat}.
+ */
+module dmx.fun.assertj {
+    requires dmx.fun;
+    requires org.assertj.core;
+    requires org.jspecify;
+
+    exports dmx.fun.assertj;
+}

--- a/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
@@ -1,6 +1,7 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Option;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 import static dmx.fun.assertj.DmxFunAssertions.assertThat;
@@ -51,8 +52,14 @@ class OptionAssertTest {
 
     @Test
     void hasValueSatisfying_shouldPass_whenRequirementHolds() {
-        assertThat(Option.some(42)).hasValueSatisfying(v ->
-            assertThat(Option.some(v)).containsValue(42));
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        assertThat(Option.some(42)).hasValueSatisfying(v -> {
+            invoked.set(true);
+            org.assertj.core.api.Assertions.assertThat(v).isEqualTo(42);
+        });
+        org.assertj.core.api.Assertions.assertThat(invoked.get())
+            .as("consumer must be invoked")
+            .isTrue();
     }
 
     @Test

--- a/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
@@ -72,4 +72,11 @@ class OptionAssertTest {
     void isFluent_shouldChain() {
         assertThat(Option.some("hello")).isSome().containsValue("hello");
     }
+
+    @Test
+    void isSome_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(Option.<Integer>none()).as("my option").isSome())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my option]");
+    }
 }

--- a/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
@@ -1,0 +1,68 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Option;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OptionAssertTest {
+
+    @Test
+    void isSome_shouldPass_forSome() {
+        assertThat(Option.some(42)).isSome();
+    }
+
+    @Test
+    void isSome_shouldFail_forNone() {
+        assertThatThrownBy(() -> assertThat(Option.none()).isSome())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Some");
+    }
+
+    @Test
+    void isNone_shouldPass_forNone() {
+        assertThat(Option.<Integer>none()).isNone();
+    }
+
+    @Test
+    void isNone_shouldFail_forSome() {
+        assertThatThrownBy(() -> assertThat(Option.some(1)).isNone())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("None");
+    }
+
+    @Test
+    void containsValue_shouldPass_whenValueMatches() {
+        assertThat(Option.some(42)).containsValue(42);
+    }
+
+    @Test
+    void containsValue_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Option.some(1)).containsValue(99))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsValue_shouldFail_forNone() {
+        assertThatThrownBy(() -> assertThat(Option.<Integer>none()).containsValue(1))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasValueSatisfying_shouldPass_whenRequirementHolds() {
+        assertThat(Option.some(42)).hasValueSatisfying(v ->
+            assertThat(Option.some(v)).containsValue(42));
+    }
+
+    @Test
+    void hasValueSatisfying_shouldFail_forNone() {
+        assertThatThrownBy(() -> assertThat(Option.<Integer>none()).hasValueSatisfying(v -> {}))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(Option.some("hello")).isSome().containsValue("hello");
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
@@ -70,4 +70,11 @@ class ResultAssertTest {
     void isFluent_shouldChain() {
         assertThat(Result.ok(42)).isOk().containsValue(42);
     }
+
+    @Test
+    void isOk_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(Result.<Integer, String>err("e")).as("my result").isOk())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my result]");
+    }
 }

--- a/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
@@ -1,0 +1,73 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Result;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResultAssertTest {
+
+    @Test
+    void isOk_shouldPass_forOk() {
+        assertThat(Result.ok("hello")).isOk();
+    }
+
+    @Test
+    void isOk_shouldFail_forErr() {
+        assertThatThrownBy(() -> assertThat(Result.err("oops")).isOk())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Ok");
+    }
+
+    @Test
+    void isErr_shouldPass_forErr() {
+        assertThat(Result.<String, String>err("oops")).isErr();
+    }
+
+    @Test
+    void isErr_shouldFail_forOk() {
+        assertThatThrownBy(() -> assertThat(Result.ok("v")).isErr())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Err");
+    }
+
+    @Test
+    void containsValue_shouldPass_whenValueMatches() {
+        assertThat(Result.ok("hello")).containsValue("hello");
+    }
+
+    @Test
+    void containsValue_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Result.ok("hello")).containsValue("world"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsValue_shouldFail_forErr() {
+        assertThatThrownBy(() -> assertThat(Result.<String, String>err("e")).containsValue("v"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsError_shouldPass_whenErrorMatches() {
+        assertThat(Result.<String, String>err("oops")).containsError("oops");
+    }
+
+    @Test
+    void containsError_shouldFail_whenErrorDiffers() {
+        assertThatThrownBy(() -> assertThat(Result.<String, String>err("oops")).containsError("other"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsError_shouldFail_forOk() {
+        assertThatThrownBy(() -> assertThat(Result.<String, String>ok("v")).containsError("e"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(Result.ok(42)).isOk().containsValue(42);
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
@@ -1,0 +1,73 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Try;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TryAssertTest {
+
+    @Test
+    void isSuccess_shouldPass_forSuccess() {
+        assertThat(Try.success(1)).isSuccess();
+    }
+
+    @Test
+    void isSuccess_shouldFail_forFailure() {
+        assertThatThrownBy(() -> assertThat(Try.failure(new RuntimeException("boom"))).isSuccess())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Success");
+    }
+
+    @Test
+    void isFailure_shouldPass_forFailure() {
+        assertThat(Try.failure(new RuntimeException("boom"))).isFailure();
+    }
+
+    @Test
+    void isFailure_shouldFail_forSuccess() {
+        assertThatThrownBy(() -> assertThat(Try.success(1)).isFailure())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Failure");
+    }
+
+    @Test
+    void containsValue_shouldPass_whenValueMatches() {
+        assertThat(Try.success(42)).containsValue(42);
+    }
+
+    @Test
+    void containsValue_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Try.success(1)).containsValue(99))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsValue_shouldFail_forFailure() {
+        assertThatThrownBy(() -> assertThat(Try.<Integer>failure(new RuntimeException())).containsValue(1))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void failsWith_shouldPass_whenExceptionTypeMatches() {
+        assertThat(Try.failure(new IllegalArgumentException("bad"))).failsWith(IllegalArgumentException.class);
+    }
+
+    @Test
+    void failsWith_shouldPass_forSupertype() {
+        assertThat(Try.failure(new IllegalArgumentException("bad"))).failsWith(RuntimeException.class);
+    }
+
+    @Test
+    void failsWith_shouldFail_whenExceptionTypeDiffers() {
+        assertThatThrownBy(() ->
+            assertThat(Try.failure(new RuntimeException())).failsWith(IllegalArgumentException.class))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(Try.success("ok")).isSuccess().containsValue("ok");
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
@@ -67,6 +67,13 @@ class TryAssertTest {
     }
 
     @Test
+    void failsWith_shouldFail_whenTryIsSuccess() {
+        assertThatThrownBy(() ->
+            assertThat(Try.success(1)).failsWith(RuntimeException.class))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
     void isFluent_shouldChain() {
         assertThat(Try.success("ok")).isSuccess().containsValue("ok");
     }

--- a/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
@@ -77,4 +77,11 @@ class TryAssertTest {
     void isFluent_shouldChain() {
         assertThat(Try.success("ok")).isSuccess().containsValue("ok");
     }
+
+    @Test
+    void isSuccess_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(Try.failure(new RuntimeException())).as("my try").isSuccess())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my try]");
+    }
 }

--- a/assertj/src/test/java/dmx/fun/assertj/Tuple2AssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/Tuple2AssertTest.java
@@ -1,0 +1,141 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Tuple2;
+import dmx.fun.Tuple3;
+import dmx.fun.Tuple4;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Tuple2AssertTest {
+
+    // ---------- Tuple2 ----------
+
+    @Test
+    void hasFirst_shouldPass_whenFirstMatches() {
+        assertThat(new Tuple2<>("a", 1)).hasFirst("a");
+    }
+
+    @Test
+    void hasFirst_shouldFail_whenFirstDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple2<>("a", 1)).hasFirst("b"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("first");
+    }
+
+    @Test
+    void hasSecond_shouldPass_whenSecondMatches() {
+        assertThat(new Tuple2<>("a", 1)).hasSecond(1);
+    }
+
+    @Test
+    void hasSecond_shouldFail_whenSecondDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple2<>("a", 1)).hasSecond(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("second");
+    }
+
+    @Test
+    void tuple2_isFluent_shouldChain() {
+        assertThat(new Tuple2<>("x", 42)).hasFirst("x").hasSecond(42);
+    }
+
+    // ---------- Tuple3 ----------
+
+    @Test
+    void tuple3_hasFirst_shouldPass() {
+        assertThat(new Tuple3<>("a", 2, true)).hasFirst("a");
+    }
+
+    @Test
+    void tuple3_hasFirst_shouldFail_whenFirstDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple3<>("a", 2, true)).hasFirst("z"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("first");
+    }
+
+    @Test
+    void tuple3_hasSecond_shouldPass() {
+        assertThat(new Tuple3<>("a", 2, true)).hasSecond(2);
+    }
+
+    @Test
+    void tuple3_hasSecond_shouldFail_whenSecondDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple3<>("a", 2, true)).hasSecond(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("second");
+    }
+
+    @Test
+    void tuple3_hasThird_shouldPass() {
+        assertThat(new Tuple3<>("a", 2, true)).hasThird(true);
+    }
+
+    @Test
+    void tuple3_hasThird_shouldFail_whenThirdDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple3<>("a", 2, true)).hasThird(false))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("third");
+    }
+
+    @Test
+    void tuple3_isFluent_shouldChain() {
+        assertThat(new Tuple3<>("x", 1, true)).hasFirst("x").hasSecond(1).hasThird(true);
+    }
+
+    // ---------- Tuple4 ----------
+
+    @Test
+    void tuple4_hasFirst_shouldPass() {
+        assertThat(new Tuple4<>("a", 2, true, 3.14)).hasFirst("a");
+    }
+
+    @Test
+    void tuple4_hasFirst_shouldFail_whenFirstDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple4<>("a", 2, true, 3.14)).hasFirst("z"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("first");
+    }
+
+    @Test
+    void tuple4_hasSecond_shouldPass() {
+        assertThat(new Tuple4<>("a", 2, true, 3.14)).hasSecond(2);
+    }
+
+    @Test
+    void tuple4_hasSecond_shouldFail_whenSecondDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple4<>("a", 2, true, 3.14)).hasSecond(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("second");
+    }
+
+    @Test
+    void tuple4_hasThird_shouldPass() {
+        assertThat(new Tuple4<>("a", 2, true, 3.14)).hasThird(true);
+    }
+
+    @Test
+    void tuple4_hasThird_shouldFail_whenThirdDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple4<>("a", 2, true, 3.14)).hasThird(false))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("third");
+    }
+
+    @Test
+    void tuple4_hasFourth_shouldPass() {
+        assertThat(new Tuple4<>("a", 2, true, 3.14)).hasFourth(3.14);
+    }
+
+    @Test
+    void tuple4_hasFourth_shouldFail_whenFourthDiffers() {
+        assertThatThrownBy(() -> assertThat(new Tuple4<>("a", 2, true, 3.14)).hasFourth(0.0))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("fourth");
+    }
+
+    @Test
+    void tuple4_isFluent_shouldChain() {
+        assertThat(new Tuple4<>(1, 2, 3, 4)).hasFirst(1).hasSecond(2).hasThird(3).hasFourth(4);
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
@@ -1,0 +1,73 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Validated;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ValidatedAssertTest {
+
+    @Test
+    void isValid_shouldPass_forValid() {
+        assertThat(Validated.valid("ok")).isValid();
+    }
+
+    @Test
+    void isValid_shouldFail_forInvalid() {
+        assertThatThrownBy(() -> assertThat(Validated.invalid("err")).isValid())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Valid");
+    }
+
+    @Test
+    void isInvalid_shouldPass_forInvalid() {
+        assertThat(Validated.<String, String>invalid("err")).isInvalid();
+    }
+
+    @Test
+    void isInvalid_shouldFail_forValid() {
+        assertThatThrownBy(() -> assertThat(Validated.valid("v")).isInvalid())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Invalid");
+    }
+
+    @Test
+    void containsValue_shouldPass_whenValueMatches() {
+        assertThat(Validated.valid(42)).containsValue(42);
+    }
+
+    @Test
+    void containsValue_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Validated.valid(1)).containsValue(99))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void containsValue_shouldFail_forInvalid() {
+        assertThatThrownBy(() -> assertThat(Validated.<String, Integer>invalid("e")).containsValue(1))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasError_shouldPass_whenErrorMatches() {
+        assertThat(Validated.<String, Integer>invalid("name must not be blank")).hasError("name must not be blank");
+    }
+
+    @Test
+    void hasError_shouldFail_whenErrorDiffers() {
+        assertThatThrownBy(() -> assertThat(Validated.<String, Integer>invalid("err")).hasError("other"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void hasError_shouldFail_forValid() {
+        assertThatThrownBy(() -> assertThat(Validated.<String, Integer>valid(1)).hasError("e"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(Validated.<String, String>invalid("bad")).isInvalid().hasError("bad");
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
@@ -70,4 +70,11 @@ class ValidatedAssertTest {
     void isFluent_shouldChain() {
         assertThat(Validated.<String, String>invalid("bad")).isInvalid().hasError("bad");
     }
+
+    @Test
+    void isValid_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(Validated.invalid("err")).as("my validated").isValid())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my validated]");
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,3 +6,4 @@ plugins {
 rootProject.name = 'dmx-fun'
 includeBuild('build-logic')
 include('lib')
+include('assertj')

--- a/site/src/data/blog/testing-in-functional-programming.md
+++ b/site/src/data/blog/testing-in-functional-programming.md
@@ -1,0 +1,405 @@
+---
+title: "Testing in Functional Programming: Why It Is Often Simpler"
+description: "Pure functions, immutable data, and typed errors remove most of the friction in unit testing. This post explains why FP code is inherently easier to test, and shows concrete examples using Java and dmx-fun types."
+pubDate: 2026-04-09
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Best Practices"
+tags: ["Testing", "Functional Programming", "Java", "Pure Functions", "TDD", "dmx-fun"]
+image: "https://images.unsplash.com/photo-1751661527913-480074245211?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+imageCredit:
+    author: "Pavel Keyzik"
+    authorUrl: "https://unsplash.com/@pavelkeyzik"
+    source: "Unsplash"
+    sourceUrl: "https://unsplash.com/es/fotos/una-persona-se-arrodilla-cerca-de-un-coche-al-atardecer-RHGXLFT1D6Q"
+---
+
+Testing object-oriented Java code is often an infrastructure problem. Before you write the first assertion you need to wire up a Spring context, stub a repository, mock a clock, inject a fake event publisher, and make sure the test database is in the right state. You are not testing your logic. You are testing your ability to reconstruct the environment your logic lives in.
+
+Functional code eliminates most of that scaffolding — not by convention, not by discipline, but structurally. This post explains why, and shows what that looks like in practice with Java and the `dmx-fun` types.
+
+---
+
+## The Root Cause of Test Complexity
+
+Before looking at solutions, it is worth naming the problem precisely.
+
+Imperative, object-oriented code is typically hard to test because functions have **hidden inputs and outputs** beyond their parameters and return value:
+
+- They read from fields set by a constructor (hidden input).
+- They call collaborators that call other collaborators (hidden side effects).
+- They throw exceptions that bypass the return type (hidden output path).
+- They depend on the current time, a random seed, or a system property (non-determinism).
+
+A test for such a method must simulate all of those hidden channels. That is where mocks, spies, fakes, `PowerMock`, `@MockBean`, test containers, and three-page `@BeforeEach` blocks come from.
+
+Functional programming solves this at the design level: **make the inputs and outputs explicit, and make the function deterministic**. When you do that, the test complexity disappears alongside the hidden channels.
+
+---
+
+## Property 1: Pure Functions Need No Setup
+
+A pure function takes its inputs, computes a result, and returns it. Nothing else. No database, no clock, no static field, no service locator.
+
+```java
+// Pure function — every input is explicit, no hidden state
+public static Result<Email, String> validateEmail(String raw) {
+    if (raw == null || raw.isBlank())
+        return Result.err("email must not be blank");
+    if (!raw.contains("@"))
+        return Result.err("email is not valid");
+    return Result.ok(new Email(raw.trim().toLowerCase()));
+}
+```
+
+The test for this function is as simple as calling it:
+
+```java
+@Test
+void shouldRejectBlankEmail() {
+    assertThat(validateEmail("")).isErr();
+    assertThat(validateEmail("  ")).isErr();
+    assertThat(validateEmail(null)).isErr();
+}
+
+@Test
+void shouldRejectEmailWithoutAtSign() {
+    Result<Email, String> result = validateEmail("notanemail");
+    assertThat(result).isErr();
+    assertThat(result.getError()).contains("not valid");
+}
+
+@Test
+void shouldNormaliseAndAcceptValidEmail() {
+    Result<Email, String> result = validateEmail("  Alice@Example.COM  ");
+    assertThat(result).isOk();
+    assertThat(result.get().value()).isEqualTo("alice@example.com");
+}
+```
+
+No mocks. No `@SpringBootTest`. No `@MockBean`. No `@BeforeEach`. The function is a black box with explicit inputs and explicit outputs — exactly the shape a test needs.
+
+---
+
+## Property 2: Typed Errors Make Test Cases Obvious
+
+In traditional Java code, a method communicates failure through exceptions. The test must catch the exception, check the type, check the message — and hope it is the right exception out of a stack of wrapped ones.
+
+```java
+// What could go wrong here? Hard to tell from the signature alone.
+public Order createOrder(String customerId, List<String> productIds)
+    throws CustomerNotFoundException, ProductOutOfStockException, PaymentDeclinedException { ... }
+```
+
+With typed errors, the test cases write themselves. Every variant of the error type is a test:
+
+```java
+// The return type documents every failure mode
+public sealed interface OrderError permits
+    OrderError.CustomerNotFound,
+    OrderError.ProductOutOfStock,
+    OrderError.PaymentDeclined { ... }
+
+public Result<Order, OrderError> createOrder(
+    String customerId, List<String> productIds
+) { ... }
+```
+
+```java
+@Test
+void shouldFailWhenCustomerDoesNotExist() {
+    Result<Order, OrderError> result =
+        service.createOrder("unknown-id", List.of("prod-1"));
+
+    assertThat(result).isErr();
+    assertThat(result.getError()).isInstanceOf(OrderError.CustomerNotFound.class);
+}
+
+@Test
+void shouldFailWhenProductIsOutOfStock() {
+    Result<Order, OrderError> result =
+        service.createOrder("cust-1", List.of("out-of-stock-prod"));
+
+    assertThat(result).isErr();
+    assertThat(result.getError()).isInstanceOf(OrderError.ProductOutOfStock.class);
+}
+```
+
+The sealed hierarchy acts as a *test checklist*. If you have not covered every `permits` variant, your coverage is incomplete — and the compiler tells you so in any `switch` expression that tries to exhaust it.
+
+---
+
+## Property 3: Immutability Removes Shared-State Bugs
+
+A common source of test fragility is **test order dependency**: test B passes only if test A has left some shared object in a certain state. This happens when production objects mutate their internal state, and tests drive them through sequences of calls.
+
+Immutable data structures cannot have this problem. There is no state to pollute. Each function produces a new value; the input is unchanged.
+
+```java
+// Immutable pipeline step — input unchanged, new value returned
+public static Option<UserProfile> applyDiscount(UserProfile profile, Discount discount) {
+    if (!discount.isApplicable(profile)) {
+        return Option.none();
+    }
+    return Option.some(profile.withDiscount(discount));
+}
+```
+
+```java
+UserProfile base = new UserProfile("alice", Tier.STANDARD);
+Discount vip    = new Discount("VIP50", Tier.PREMIUM);
+
+// Each call is independent — base is never modified
+assertThat(applyDiscount(base, vip)).isNone();
+
+Discount regular = new Discount("WELCOME10", Tier.STANDARD);
+assertThat(applyDiscount(base, regular)).isSome();
+```
+
+Two tests, no `@BeforeEach`, no shared object to reset. The `base` profile is never touched. Every test starts from scratch by construction.
+
+---
+
+## Property 4: Composition Tests Replace Integration Tests
+
+A well-designed functional pipeline is a composition of pure steps. When each step is individually tested, the pipeline's correctness follows from the tests of its parts plus a single composition test that verifies the wiring.
+
+Consider an order enrichment pipeline:
+
+```java
+// Each step tested independently
+public static Result<Order, OrderError> parseOrder(String json)       { ... }
+public static Result<Order, OrderError> validateOrder(Order order)    { ... }
+public static Result<Order, OrderError> enrichOrder(Order order)      { ... }
+public static Result<Order, OrderError> persistOrder(Order order)     { ... }
+
+// Composition is just wiring
+public Result<Order, OrderError> process(String rawJson) {
+    return parseOrder(rawJson)
+        .flatMap(OrderSteps::validateOrder)
+        .flatMap(OrderSteps::enrichOrder)
+        .flatMap(OrderSteps::persistOrder);
+}
+```
+
+Testing `process` only needs to verify two things:
+
+1. **Short-circuit behaviour** — an error in any step propagates to the end without calling subsequent steps.
+2. **Happy path** — all steps succeed and produce the final order.
+
+```java
+@Test
+void shouldShortCircuitOnParseFailure() {
+    // Steps after parse are never called — no need to set them up
+    Result<Order, OrderError> result = service.process("{ bad json }");
+    assertThat(result).isErr();
+    assertThat(result.getError()).isInstanceOf(OrderError.ParseFailure.class);
+}
+
+@Test
+void happyPath_shouldProducePersistedOrder() {
+    String validJson = """
+        {"customerId":"c1","productIds":["p1","p2"]}
+        """;
+    Result<Order, OrderError> result = service.process(validJson);
+    assertThat(result).isOk();
+    assertThat(result.get().customerId()).isEqualTo("c1");
+}
+```
+
+There are no mocks injected into `process`. The individual step tests cover all the edge cases. The composition test only verifies that the steps are connected correctly.
+
+---
+
+## Property 5: `Try` Makes Exception-Throwing Code Trivially Testable
+
+Not all code is written in a pure style from the start. When you must call a legacy API that throws checked exceptions, `Try` captures the exception as a value — and the test treats it like any other value.
+
+```java
+// Wrapping a throwing legacy API
+public Try<Report> generateReport(ReportRequest request) {
+    return Try.of(() -> legacyReportEngine.generate(request));
+}
+```
+
+```java
+@Test
+void shouldCaptureEngineException_asFailure() {
+    ReportRequest badRequest = new ReportRequest(null); // triggers NPE in legacy code
+
+    Try<Report> result = service.generateReport(badRequest);
+
+    assertThat(result.isFailure()).isTrue();
+    assertThat(result.getCause()).isInstanceOf(NullPointerException.class);
+}
+
+@Test
+void shouldReturnSuccess_forValidRequest() {
+    ReportRequest request = new ReportRequest("2026-Q1");
+
+    Try<Report> result = service.generateReport(request);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.get().period()).isEqualTo("2026-Q1");
+}
+```
+
+No `assertThrows`. No `try/catch` in the test. The exception is a value, and the test reads like every other value-based assertion.
+
+---
+
+## Property 6: `Validated` Lets You Assert All Errors at Once
+
+Form-validation logic written with `Validated` produces all errors in a single pass. The test can assert the complete set of errors without invoking the validator multiple times:
+
+```java
+public Validated<List<String>, RegistrationForm> validate(RegistrationForm form) {
+    Validated<List<String>, String> email = form.email().isBlank()
+        ? Validated.invalid(List.of("email is required"))
+        : Validated.valid(form.email());
+
+    Validated<List<String>, String> password = form.password().length() < 8
+        ? Validated.invalid(List.of("password must be at least 8 characters"))
+        : Validated.valid(form.password());
+
+    Validated<List<String>, String> name = form.name().isBlank()
+        ? Validated.invalid(List.of("name is required"))
+        : Validated.valid(form.name());
+
+    BinaryOperator<List<String>> merge =
+        (a, b) -> Stream.concat(a.stream(), b.stream()).toList();
+
+    return email
+        .combine(password, merge, (e, p) -> e)
+        .combine(name, merge, (ep, n) -> form);
+}
+```
+
+```java
+@Test
+void shouldCollectAllErrors_whenAllFieldsAreInvalid() {
+    RegistrationForm empty = new RegistrationForm("", "ab", "");
+
+    Validated<List<String>, RegistrationForm> result = validator.validate(empty);
+
+    assertThat(result.isInvalid()).isTrue();
+    assertThat(result.getError()).containsExactlyInAnyOrder(
+        "email is required",
+        "password must be at least 8 characters",
+        "name is required"
+    );
+}
+
+@Test
+void shouldSucceed_whenAllFieldsAreValid() {
+    RegistrationForm form = new RegistrationForm("alice@example.com", "secret123", "Alice");
+
+    assertThat(validator.validate(form).isValid()).isTrue();
+}
+```
+
+A single call, a single assertion on the full error list. No loop, no incremental calls, no partial-state manipulation.
+
+---
+
+## What About Side Effects?
+
+Pure functions are easy to test precisely because they have no side effects. Real programs must eventually communicate with databases, message queues, and HTTP APIs. Does this mean FP helps only in the "pure core" and falls apart at the edges?
+
+No — but it does shift the problem. The key is the **functional core / imperative shell** pattern:
+
+- **Core** — domain logic is pure. All business rules, transformations, and validations live here as pure functions returning typed values. Zero mocks needed.
+- **Shell** — infrastructure adapters (repositories, HTTP clients, event publishers) live here. They are thin, explicit, and tested with integration tests or test doubles applied *at the interface boundary*, not injected three layers deep.
+
+```
+┌─────────────────────────────────────┐
+│  Shell (side-effecting adapters)    │
+│                                     │
+│   OrderRepository (DB)              │
+│   PaymentGateway (HTTP)             │
+│   EventBus (Kafka)                  │
+│                                     │
+│  ┌───────────────────────────────┐  │
+│  │  Core (pure domain logic)     │  │
+│  │                               │  │
+│  │  validateOrder()   → Result   │  │
+│  │  applyPricing()    → Order    │  │
+│  │  computeDiscount() → Discount │  │
+│  └───────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
+The core is tested with plain JUnit — no framework, no container. The shell is tested with integration tests that hit the real infrastructure. The two test suites remain small and focused because the boundary between them is explicit.
+
+---
+
+## The Mock Count Heuristic
+
+Here is a practical signal: **count your mocks**.
+
+A test with three or more mocks is a sign that the code under test has three or more hidden dependencies. The mocks are not the problem — they are a symptom. The problem is that the function does not declare its dependencies in its signature.
+
+With functional code, the trend runs in the opposite direction:
+
+| Style              | Typical mock count | What the mocks replace             |
+|--------------------|--------------------|------------------------------------|
+| Service + repo     | 2–5                | DB, clock, event bus, config       |
+| Pure function      | 0                  | Nothing — all inputs are explicit  |
+| Functional + shell | 0–1                | One real adapter at the boundary   |
+
+The goal is not "zero mocks forever" — it is "mocks only at the true boundaries." Pure functions at the core and thin adapters at the shell get you there.
+
+---
+
+## Using `dmx-fun` Assertions in Tests
+
+If you are using `dmx-fun` types in your production code, the companion `fun-assertj` module provides fluent assertions that eliminate the boilerplate of unwrapping:
+
+```java
+// Without fun-assertj
+Result<User, String> result = service.register(form);
+assertThat(result.isOk()).isTrue();
+assertThat(result.get().email()).isEqualTo("alice@example.com");
+
+// With fun-assertj
+assertThat(result).isOk().containsValue(expectedUser);
+
+// For Try
+assertThat(Try.of(() -> parser.parse(input)))
+    .isSuccess()
+    .containsValue(expectedAst);
+
+// For Option
+assertThat(Option.some(42))
+    .isSome()
+    .hasValueSatisfying(v -> assertThat(v).isGreaterThan(0));
+
+// For Validated — full error list
+assertThat(validator.validate(invalidForm))
+    .isInvalid();
+```
+
+The assertions follow the same fluent, chainable style as the rest of AssertJ, so they fit naturally into existing test suites.
+
+---
+
+## Practical Checklist
+
+When writing a new function in functional style, ask these questions before writing a single test:
+
+1. **Are all inputs in the parameter list?** If the function reads from a field, clock, or static, it is not pure — extract those dependencies to a parameter.
+2. **Is every output in the return type?** Exceptions, log entries, and mutations are hidden outputs. Replace them with typed return values.
+3. **Is the function deterministic?** Same arguments → same result, always. If not, isolate the non-determinism to the shell.
+4. **Can failure happen?** If yes, is it represented as `Result`, `Try`, or `Validated`? Exceptions as control flow make tests fragile.
+
+Answer "yes" to all four, and the test writes itself.
+
+---
+
+## Conclusion
+
+The reason testing functional code is often simpler is not a matter of style or testing philosophy — it is structural. Pure functions have explicit contracts. Immutable data has no state to corrupt. Typed errors document every outcome. Composition tests replace sprawling integration setups.
+
+None of this prevents you from writing complex, hard-to-test functional code. But the functional style has a clear gravitational pull: if you follow it, the tests become easier; if the tests are hard, you have usually drifted back toward hidden state or hidden side effects.
+
+The simplest test a function can have is `assert f(input) == expected`. Functional programming is, at its core, the discipline of making more of your functions look exactly like that.


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #116

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AssertJ-compatible assertions module with assertThat(...) helpers for Option, Result, Try, Validated and Tuple2/3/4 supporting state, content checks and fluent chaining.

* **Tests**
  * Added comprehensive JUnit 5 test suites covering all new assertion behaviors, failure messages and chaining.

* **Chores**
  * Included the new assertions module in the build and configured publication coordinates and POM metadata.

* **Documentation**
  * Added a new blog post: "Testing in Functional Programming: Why It Is Often Simpler".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->