### PR TITLE
feat(lib): add NonEmptyList<T> type with Validated and Option interop

### DIFF
--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -31,9 +31,14 @@ public final class NonEmptyList<T> implements Iterable<T> {
     private final T head;
     private final List<T> tail;
 
-    private NonEmptyList(T head, List<T> tail) {
+    /**
+     * Trusted internal constructor: stores {@code tail} as-is without copying.
+     * Callers must pass an already-unmodifiable or freshly-built list that will
+     * not be shared with any other code after this call.
+     */
+    private NonEmptyList(T head, List<T> tail, boolean trusted) {
         this.head = head;
-        this.tail = List.copyOf(tail);
+        this.tail = tail;
     }
 
     // -------------------------------------------------------------------------
@@ -53,7 +58,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         Objects.requireNonNull(head, "head must not be null");
         Objects.requireNonNull(tail, "tail must not be null");
         tail.forEach(e -> Objects.requireNonNull(e, "tail elements must not be null"));
-        return new NonEmptyList<>(head, new ArrayList<>(tail));
+        return new NonEmptyList<>(head, List.copyOf(tail), true);
     }
 
     /**
@@ -66,7 +71,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
      */
     public static <T> NonEmptyList<T> singleton(T head) {
         Objects.requireNonNull(head, "head must not be null");
-        return new NonEmptyList<>(head, List.of());
+        return new NonEmptyList<>(head, List.of(), true);
     }
 
     /**
@@ -85,8 +90,8 @@ public final class NonEmptyList<T> implements Iterable<T> {
         }
         list.forEach(e -> Objects.requireNonNull(e, "list elements must not be null"));
         T head = list.get(0);
-        List<T> tail = new ArrayList<>(list.subList(1, list.size()));
-        return Option.some(new NonEmptyList<>(head, tail));
+        List<T> tail = List.copyOf(list.subList(1, list.size()));
+        return Option.some(new NonEmptyList<>(head, tail, true));
     }
 
     // -------------------------------------------------------------------------
@@ -153,7 +158,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         for (T element : tail) {
             newTail.add(Objects.requireNonNull(mapper.apply(element), "mapper must not return null"));
         }
-        return new NonEmptyList<>(newHead, newTail);
+        return new NonEmptyList<>(newHead, Collections.unmodifiableList(newTail), true);
     }
 
     /**
@@ -168,7 +173,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         List<T> newTail = new ArrayList<>(tail.size() + 1);
         newTail.addAll(tail);
         newTail.add(element);
-        return new NonEmptyList<>(head, newTail);
+        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail), true);
     }
 
     /**
@@ -183,7 +188,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         List<T> newTail = new ArrayList<>(1 + tail.size());
         newTail.add(head);
         newTail.addAll(tail);
-        return new NonEmptyList<>(element, newTail);
+        return new NonEmptyList<>(element, Collections.unmodifiableList(newTail), true);
     }
 
     /**
@@ -199,7 +204,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         newTail.addAll(tail);
         newTail.add(other.head);
         newTail.addAll(other.tail);
-        return new NonEmptyList<>(head, newTail);
+        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail), true);
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -32,11 +32,11 @@ public final class NonEmptyList<T> implements Iterable<T> {
     private final List<T> tail;
 
     /**
-     * Trusted internal constructor: stores {@code tail} as-is without copying.
-     * Callers must pass an already-unmodifiable or freshly-built list that will
-     * not be shared with any other code after this call.
+     * Internal constructor: stores {@code tail} as-is without copying.
+     * Callers must pass an already-unmodifiable list that will not be shared
+     * with any other code after this call.
      */
-    private NonEmptyList(T head, List<T> tail, boolean trusted) {
+    private NonEmptyList(T head, List<T> tail) {
         this.head = head;
         this.tail = tail;
     }
@@ -58,7 +58,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         Objects.requireNonNull(head, "head must not be null");
         Objects.requireNonNull(tail, "tail must not be null");
         tail.forEach(e -> Objects.requireNonNull(e, "tail elements must not be null"));
-        return new NonEmptyList<>(head, List.copyOf(tail), true);
+        return new NonEmptyList<>(head, List.copyOf(tail));
     }
 
     /**
@@ -71,7 +71,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
      */
     public static <T> NonEmptyList<T> singleton(T head) {
         Objects.requireNonNull(head, "head must not be null");
-        return new NonEmptyList<>(head, List.of(), true);
+        return new NonEmptyList<>(head, List.of());
     }
 
     /**
@@ -91,7 +91,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         list.forEach(e -> Objects.requireNonNull(e, "list elements must not be null"));
         T head = list.get(0);
         List<T> tail = List.copyOf(list.subList(1, list.size()));
-        return Option.some(new NonEmptyList<>(head, tail, true));
+        return Option.some(new NonEmptyList<>(head, tail));
     }
 
     // -------------------------------------------------------------------------
@@ -158,7 +158,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         for (T element : tail) {
             newTail.add(Objects.requireNonNull(mapper.apply(element), "mapper must not return null"));
         }
-        return new NonEmptyList<>(newHead, Collections.unmodifiableList(newTail), true);
+        return new NonEmptyList<>(newHead, Collections.unmodifiableList(newTail));
     }
 
     /**
@@ -173,7 +173,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         List<T> newTail = new ArrayList<>(tail.size() + 1);
         newTail.addAll(tail);
         newTail.add(element);
-        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail), true);
+        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail));
     }
 
     /**
@@ -188,7 +188,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         List<T> newTail = new ArrayList<>(1 + tail.size());
         newTail.add(head);
         newTail.addAll(tail);
-        return new NonEmptyList<>(element, Collections.unmodifiableList(newTail), true);
+        return new NonEmptyList<>(element, Collections.unmodifiableList(newTail));
     }
 
     /**
@@ -204,7 +204,7 @@ public final class NonEmptyList<T> implements Iterable<T> {
         newTail.addAll(tail);
         newTail.add(other.head);
         newTail.addAll(other.tail);
-        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail), true);
+        return new NonEmptyList<>(head, Collections.unmodifiableList(newTail));
     }
 
     // -------------------------------------------------------------------------
@@ -213,11 +213,12 @@ public final class NonEmptyList<T> implements Iterable<T> {
 
     /**
      * Returns a sequential {@link Stream} of all elements (head first, then tail).
+     * Does not materialize an intermediate list.
      *
      * @return a {@code Stream<T>} over all elements
      */
     public Stream<T> toStream() {
-        return toList().stream();
+        return Stream.concat(Stream.of(head), tail.stream());
     }
 
     /**
@@ -271,12 +272,30 @@ public final class NonEmptyList<T> implements Iterable<T> {
 
     /**
      * Returns an iterator over all elements (head first, then tail).
+     * Does not materialize an intermediate list.
      *
      * @return an iterator
      */
     @Override
     public Iterator<T> iterator() {
-        return toList().iterator();
+        return new Iterator<T>() {
+            private boolean headConsumed = false;
+            private final Iterator<T> tailIt = tail.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return !headConsumed || tailIt.hasNext();
+            }
+
+            @Override
+            public T next() {
+                if (!headConsumed) {
+                    headConsumed = true;
+                    return head;
+                }
+                return tailIt.next();
+            }
+        };
     }
 
     // -------------------------------------------------------------------------
@@ -297,6 +316,6 @@ public final class NonEmptyList<T> implements Iterable<T> {
 
     @Override
     public String toString() {
-        return "NonEmptyList" + toList();
+        return toList().toString();
     }
 }

--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -1,0 +1,297 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An immutable, non-empty list: a list guaranteed at construction time to contain
+ * at least one element.
+ *
+ * <p>This type makes the non-emptiness constraint part of the static type system.
+ * APIs that require at least one item can declare {@code NonEmptyList<T>} instead of
+ * {@code List<T>} and eliminate runtime emptiness checks entirely.
+ *
+ * <p>{@code NonEmptyList<T>} pairs naturally with {@link Validated}'s error accumulation,
+ * which always produces at least one error when invalid.
+ *
+ * <p>This class is {@code @NullMarked}: all elements and parameters are non-null by default.
+ *
+ * @param <T> the type of elements in this list
+ */
+@NullMarked
+public final class NonEmptyList<T> implements Iterable<T> {
+
+    private final T head;
+    private final List<T> tail;
+
+    private NonEmptyList(T head, List<T> tail) {
+        this.head = head;
+        this.tail = List.copyOf(tail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Smart constructors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@code NonEmptyList} with the given head and tail.
+     *
+     * @param head the first (mandatory) element; must not be {@code null}
+     * @param tail the remaining elements; must not be {@code null}; elements must not be {@code null}
+     * @param <T>  the element type
+     * @return a new {@code NonEmptyList}
+     * @throws NullPointerException if {@code head}, {@code tail}, or any tail element is {@code null}
+     */
+    public static <T> NonEmptyList<T> of(T head, List<? extends T> tail) {
+        Objects.requireNonNull(head, "head must not be null");
+        Objects.requireNonNull(tail, "tail must not be null");
+        tail.forEach(e -> Objects.requireNonNull(e, "tail elements must not be null"));
+        return new NonEmptyList<>(head, new ArrayList<>(tail));
+    }
+
+    /**
+     * Creates a {@code NonEmptyList} containing exactly one element.
+     *
+     * @param head the sole element; must not be {@code null}
+     * @param <T>  the element type
+     * @return a singleton {@code NonEmptyList}
+     * @throws NullPointerException if {@code head} is {@code null}
+     */
+    public static <T> NonEmptyList<T> singleton(T head) {
+        Objects.requireNonNull(head, "head must not be null");
+        return new NonEmptyList<>(head, List.of());
+    }
+
+    /**
+     * Attempts to construct a {@code NonEmptyList} from a plain {@link List}.
+     *
+     * @param list the source list; must not be {@code null}; elements must not be {@code null}
+     * @param <T>  the element type
+     * @return {@link Option#some(Object)} wrapping the {@code NonEmptyList} if the list is
+     *         non-empty, or {@link Option#none()} if the list is empty
+     * @throws NullPointerException if {@code list} or any element is {@code null}
+     */
+    public static <T> Option<NonEmptyList<T>> fromList(List<? extends T> list) {
+        Objects.requireNonNull(list, "list must not be null");
+        if (list.isEmpty()) {
+            return Option.none();
+        }
+        list.forEach(e -> Objects.requireNonNull(e, "list elements must not be null"));
+        T head = list.get(0);
+        List<T> tail = new ArrayList<>(list.subList(1, list.size()));
+        return Option.some(new NonEmptyList<>(head, tail));
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the first element of this list.
+     *
+     * @return the head element (never {@code null})
+     */
+    public T head() {
+        return head;
+    }
+
+    /**
+     * Returns an unmodifiable view of all elements after the head.
+     * May be empty if this is a singleton list.
+     *
+     * @return the tail (never {@code null}, may be empty)
+     */
+    public List<T> tail() {
+        return tail;
+    }
+
+    /**
+     * Returns an unmodifiable {@link List} containing all elements (head followed by tail).
+     *
+     * @return a new unmodifiable list with all elements
+     */
+    public List<T> toList() {
+        List<T> result = new ArrayList<>(1 + tail.size());
+        result.add(head);
+        result.addAll(tail);
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * Returns the number of elements in this list. Always &ge; 1.
+     *
+     * @return the size
+     */
+    public int size() {
+        return 1 + tail.size();
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies {@code mapper} to every element and returns a new {@code NonEmptyList}
+     * of the results. The structure (head/tail split) is preserved.
+     *
+     * @param mapper a non-null function to apply to each element; must not return {@code null}
+     * @param <R>    the result element type
+     * @return a new {@code NonEmptyList} of mapped values
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    public <R> NonEmptyList<R> map(Function<? super T, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        R newHead = Objects.requireNonNull(mapper.apply(head), "mapper must not return null");
+        List<R> newTail = new ArrayList<>(tail.size());
+        for (T element : tail) {
+            newTail.add(Objects.requireNonNull(mapper.apply(element), "mapper must not return null"));
+        }
+        return new NonEmptyList<>(newHead, newTail);
+    }
+
+    /**
+     * Returns a new {@code NonEmptyList} with {@code element} appended at the end.
+     *
+     * @param element the element to append; must not be {@code null}
+     * @return a new {@code NonEmptyList} with the element appended
+     * @throws NullPointerException if {@code element} is {@code null}
+     */
+    public NonEmptyList<T> append(T element) {
+        Objects.requireNonNull(element, "element must not be null");
+        List<T> newTail = new ArrayList<>(tail.size() + 1);
+        newTail.addAll(tail);
+        newTail.add(element);
+        return new NonEmptyList<>(head, newTail);
+    }
+
+    /**
+     * Returns a new {@code NonEmptyList} with {@code element} prepended at the front.
+     *
+     * @param element the element to prepend; must not be {@code null}
+     * @return a new {@code NonEmptyList} with the element prepended
+     * @throws NullPointerException if {@code element} is {@code null}
+     */
+    public NonEmptyList<T> prepend(T element) {
+        Objects.requireNonNull(element, "element must not be null");
+        List<T> newTail = new ArrayList<>(1 + tail.size());
+        newTail.add(head);
+        newTail.addAll(tail);
+        return new NonEmptyList<>(element, newTail);
+    }
+
+    /**
+     * Returns a new {@code NonEmptyList} that is the concatenation of this list and {@code other}.
+     *
+     * @param other the list to append; must not be {@code null}
+     * @return a new {@code NonEmptyList} containing all elements of both lists
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    public NonEmptyList<T> concat(NonEmptyList<T> other) {
+        Objects.requireNonNull(other, "other must not be null");
+        List<T> newTail = new ArrayList<>(tail.size() + other.size());
+        newTail.addAll(tail);
+        newTail.add(other.head);
+        newTail.addAll(other.tail);
+        return new NonEmptyList<>(head, newTail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Interop
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a sequential {@link Stream} of all elements (head first, then tail).
+     *
+     * @return a {@code Stream<T>} over all elements
+     */
+    public Stream<T> toStream() {
+        return toList().stream();
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@link Stream}{@code <T>} into an
+     * {@link Option}{@code <NonEmptyList<T>>}.
+     *
+     * <p>Produces {@link Option#some(Object)} if the stream has at least one element,
+     * or {@link Option#none()} if the stream is empty.
+     *
+     * @param <T> the element type
+     * @return a {@code Collector} producing {@code Option<NonEmptyList<T>>}
+     */
+    public static <T> Collector<T, ?, Option<NonEmptyList<T>>> collector() {
+        return Collector.of(
+            ArrayList<T>::new,
+            ArrayList::add,
+            (a, b) -> { a.addAll(b); return a; },
+            list -> NonEmptyList.<T>fromList(list)
+        );
+    }
+
+    /**
+     * Sequences a {@code NonEmptyList} of {@link Option}s into an {@code Option} of a
+     * {@code NonEmptyList}.
+     *
+     * <p>Returns {@link Option#some(Object)} containing all unwrapped values if every element
+     * is {@link Option#some(Object)}; returns {@link Option#none()} as soon as any element is
+     * {@link Option#none()}.
+     *
+     * @param <T> the element type
+     * @param nel a {@code NonEmptyList<Option<T>>}; must not be {@code null}
+     * @return {@code Some(NonEmptyList<T>)} if all options are present, {@code None} otherwise
+     * @throws NullPointerException if {@code nel} is {@code null}
+     */
+    public static <T> Option<NonEmptyList<T>> sequence(NonEmptyList<Option<T>> nel) {
+        Objects.requireNonNull(nel, "nel must not be null");
+        List<T> values = new ArrayList<>(nel.size());
+        for (Option<T> opt : nel) {
+            switch (opt) {
+                case Option.None<T> ignored -> { return Option.none(); }
+                case Option.Some<T>(T v)   -> values.add(v);
+            }
+        }
+        // values.size() == nel.size() >= 1, so fromList always returns Some
+        return NonEmptyList.fromList(values);
+    }
+
+    // -------------------------------------------------------------------------
+    // Iterable
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns an iterator over all elements (head first, then tail).
+     *
+     * @return an iterator
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return toList().iterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Object
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof NonEmptyList<?> other)) return false;
+        return toList().equals(other.toList());
+    }
+
+    @Override
+    public int hashCode() {
+        return toList().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "NonEmptyList" + toList();
+    }
+}

--- a/lib/src/main/java/dmx/fun/Validated.java
+++ b/lib/src/main/java/dmx/fun/Validated.java
@@ -500,6 +500,84 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
         );
     }
 
+    // ---------- NonEmptyList (NEL) convenience ----------
+
+    /**
+     * Creates an {@link Invalid} {@code Validated} whose error is a singleton
+     * {@link NonEmptyList} containing {@code error}.
+     *
+     * <p>This is the canonical way to start error accumulation with {@code NonEmptyList} errors:
+     * multiple {@code invalidNel} results can be combined with
+     * {@link #combine(Validated, BinaryOperator, BiFunction)} using
+     * {@link NonEmptyList#concat} as the merger, and the resulting error list is always non-empty.
+     *
+     * <pre>{@code
+     * Validated<NonEmptyList<String>, String> v1 = Validated.invalidNel("email is required");
+     * Validated<NonEmptyList<String>, String> v2 = Validated.invalidNel("name is required");
+     * Validated<NonEmptyList<String>, Form> combined =
+     *     v1.combine(v2, NonEmptyList::concat, (e, n) -> new Form(e, n));
+     * // combined.getError() → NonEmptyList["email is required", "name is required"]
+     * }</pre>
+     *
+     * @param <E>   the error element type
+     * @param <A>   the value type
+     * @param error the single error to wrap; must not be {@code null}
+     * @return an {@code Invalid<NonEmptyList<E>, A>}
+     * @throws NullPointerException if {@code error} is {@code null}
+     */
+    static <E, A> Validated<NonEmptyList<E>, A> invalidNel(E error) {
+        Objects.requireNonNull(error, "error must not be null");
+        return Validated.invalid(NonEmptyList.singleton(error));
+    }
+
+    /**
+     * Sequences an {@link Iterable} of {@code Validated<NonEmptyList<E>, A>} into a single
+     * {@code Validated<NonEmptyList<E>, List<A>>}, accumulating all errors using
+     * {@link NonEmptyList#concat}.
+     *
+     * <p>Convenience wrapper around {@link #sequence(Iterable, BinaryOperator)} that supplies
+     * the NEL merger automatically.
+     *
+     * @param <E>       the error element type
+     * @param <A>       the value type
+     * @param validated the iterable of validated values; must not be null or contain null elements
+     * @return {@code Valid(List<A>)} if all elements are valid,
+     *         or {@code Invalid(NonEmptyList<E>)} with all accumulated errors
+     * @throws NullPointerException if {@code validated} is null or contains a null element
+     */
+    static <E, A> Validated<NonEmptyList<E>, List<A>> sequenceNel(
+        Iterable<Validated<NonEmptyList<E>, A>> validated
+    ) {
+        Objects.requireNonNull(validated, "validated must not be null");
+        return Validated.sequence(validated, NonEmptyList::concat);
+    }
+
+    /**
+     * Maps each element of {@code values} through {@code mapper} and accumulates the results into
+     * a {@code Validated<NonEmptyList<E>, List<B>>}, accumulating all errors using
+     * {@link NonEmptyList#concat}.
+     *
+     * <p>Convenience wrapper around {@link #traverse(Iterable, Function, BinaryOperator)} that
+     * supplies the NEL merger automatically.
+     *
+     * @param <E>    the error element type
+     * @param <A>    the input element type
+     * @param <B>    the mapped value type
+     * @param values the iterable of input values; must not be null
+     * @param mapper a function mapping each value to a {@code Validated}; must not return null
+     * @return {@code Valid(List<B>)} if all mappings succeed,
+     *         or {@code Invalid(NonEmptyList<E>)} with all accumulated errors
+     * @throws NullPointerException if any argument is null or if the mapper returns null
+     */
+    static <E, A, B> Validated<NonEmptyList<E>, List<B>> traverseNel(
+        Iterable<A> values,
+        Function<? super A, Validated<NonEmptyList<E>, B>> mapper
+    ) {
+        Objects.requireNonNull(values, "values must not be null");
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        return Validated.traverse(values, mapper, NonEmptyList::concat);
+    }
+
     private static <E, A> Validated<E, List<A>> accumulate(
         Iterable<Validated<E, A>> items,
         BinaryOperator<E> errMerge

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -17,6 +17,7 @@
  *   <li>{@link dmx.fun.TriFunction}  — function accepting three arguments</li>
  *   <li>{@link dmx.fun.QuadFunction} — function accepting four arguments</li>
  *   <li>{@link dmx.fun.Lazy}         — lazily evaluated, memoized value</li>
+ *   <li>{@link dmx.fun.NonEmptyList} — list guaranteed to contain at least one element</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/NonEmptyListInteropTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListInteropTest.java
@@ -1,0 +1,279 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NonEmptyListInteropTest {
+
+    // =========================================================================
+    // toStream()
+    // =========================================================================
+
+    @Nested
+    class ToStream {
+
+        @Test
+        void toStream_shouldContainAllElements() {
+            NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+            assertThat(nel.toStream()).containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void toStream_shouldSupportStreamOperations() {
+            NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3, 4));
+            int sum = nel.toStream().mapToInt(Integer::intValue).sum();
+            assertThat(sum).isEqualTo(10);
+        }
+
+        @Test
+        void toStream_onSingleton_shouldContainOneElement() {
+            assertThat(NonEmptyList.singleton("x").toStream()).containsExactly("x");
+        }
+    }
+
+    // =========================================================================
+    // collector()
+    // =========================================================================
+
+    @Nested
+    class CollectorTests {
+
+        @Test
+        void collector_shouldReturnSome_forNonEmptyStream() {
+            Option<NonEmptyList<Integer>> result =
+                Stream.of(1, 2, 3).collect(NonEmptyList.collector());
+
+            assertThat(result.isDefined()).isTrue();
+            assertThat(result.get().toList()).containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void collector_shouldReturnNone_forEmptyStream() {
+            Option<NonEmptyList<String>> result =
+                Stream.<String>empty().collect(NonEmptyList.collector());
+
+            assertThat(result.isEmpty()).isTrue();
+        }
+
+        @Test
+        void collector_shouldPreserveOrder() {
+            Option<NonEmptyList<String>> result =
+                Stream.of("c", "a", "b").collect(NonEmptyList.collector());
+
+            assertThat(result.get().toList()).containsExactly("c", "a", "b");
+        }
+    }
+
+    // =========================================================================
+    // sequence(NonEmptyList<Option<T>>)
+    // =========================================================================
+
+    @Nested
+    class SequenceOption {
+
+        @Test
+        void sequence_shouldReturnSome_whenAllOptionsAreSome() {
+            NonEmptyList<Option<Integer>> nel = NonEmptyList.of(
+                Option.some(1), List.of(Option.some(2), Option.some(3)));
+
+            Option<NonEmptyList<Integer>> result = NonEmptyList.sequence(nel);
+
+            assertThat(result.isDefined()).isTrue();
+            assertThat(result.get().toList()).containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void sequence_shouldReturnNone_whenAnyOptionIsNone() {
+            NonEmptyList<Option<Integer>> nel = NonEmptyList.of(
+                Option.some(1), List.of(Option.none(), Option.some(3)));
+
+            Option<NonEmptyList<Integer>> result = NonEmptyList.sequence(nel);
+
+            assertThat(result.isEmpty()).isTrue();
+        }
+
+        @Test
+        void sequence_shouldReturnNone_whenFirstIsNone() {
+            NonEmptyList<Option<String>> nel = NonEmptyList.singleton(Option.none());
+
+            assertThat(NonEmptyList.sequence(nel).isEmpty()).isTrue();
+        }
+
+        @Test
+        void sequence_singleton_Some_shouldReturnSome() {
+            NonEmptyList<Option<String>> nel = NonEmptyList.singleton(Option.some("ok"));
+
+            Option<NonEmptyList<String>> result = NonEmptyList.sequence(nel);
+
+            assertThat(result.isDefined()).isTrue();
+            assertThat(result.get().size()).isEqualTo(1);
+            assertThat(result.get().head()).isEqualTo("ok");
+        }
+
+        @Test
+        void sequence_shouldThrowNPE_whenNelIsNull() {
+            assertThatThrownBy(() -> NonEmptyList.sequence(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("nel");
+        }
+    }
+
+    // =========================================================================
+    // Validated.invalidNel()
+    // =========================================================================
+
+    @Nested
+    class InvalidNel {
+
+        @Test
+        void invalidNel_shouldProduceInvalidWithSingletonNel() {
+            Validated<NonEmptyList<String>, Integer> v = Validated.invalidNel("email is required");
+
+            assertThat(v.isInvalid()).isTrue();
+            assertThat(v.getError().toList()).containsExactly("email is required");
+        }
+
+        @Test
+        void invalidNel_shouldThrowNPE_whenErrorIsNull() {
+            assertThatThrownBy(() -> Validated.<String, Integer>invalidNel(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("error");
+        }
+
+        @Test
+        void invalidNel_shouldAccumulateErrors_viaCombine() {
+            Validated<NonEmptyList<String>, String> email =
+                Validated.invalidNel("email is required");
+            Validated<NonEmptyList<String>, String> password =
+                Validated.invalidNel("password too short");
+            Validated<NonEmptyList<String>, String> name =
+                Validated.invalidNel("name is required");
+
+            Validated<NonEmptyList<String>, String> combined = email
+                .combine(password, NonEmptyList::concat, (e, p) -> e)
+                .combine(name,     NonEmptyList::concat, (ep, n) -> ep);
+
+            assertThat(combined.isInvalid()).isTrue();
+            assertThat(combined.getError().toList()).containsExactlyInAnyOrder(
+                "email is required",
+                "password too short",
+                "name is required"
+            );
+        }
+
+        @Test
+        void invalidNel_mixedWithValid_shouldCollectOnlyErrors() {
+            Validated<NonEmptyList<String>, String> email = Validated.valid("alice@example.com");
+            Validated<NonEmptyList<String>, String> password =
+                Validated.invalidNel("password too short");
+
+            Validated<NonEmptyList<String>, String> combined =
+                email.combine(password, NonEmptyList::concat, (e, p) -> e);
+
+            assertThat(combined.isInvalid()).isTrue();
+            assertThat(combined.getError().toList()).containsExactly("password too short");
+        }
+    }
+
+    // =========================================================================
+    // Validated.sequenceNel()
+    // =========================================================================
+
+    @Nested
+    class SequenceNel {
+
+        @Test
+        void sequenceNel_shouldReturnValid_whenAllAreValid() {
+            List<Validated<NonEmptyList<String>, Integer>> items = List.of(
+                Validated.valid(1),
+                Validated.valid(2),
+                Validated.valid(3)
+            );
+            Validated<NonEmptyList<String>, List<Integer>> result = Validated.sequenceNel(items);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.get()).containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void sequenceNel_shouldAccumulateAllErrors() {
+            List<Validated<NonEmptyList<String>, Integer>> items = List.of(
+                Validated.invalidNel("err1"),
+                Validated.valid(2),
+                Validated.invalidNel("err2")
+            );
+            Validated<NonEmptyList<String>, List<Integer>> result = Validated.sequenceNel(items);
+
+            assertThat(result.isInvalid()).isTrue();
+            assertThat(result.getError().toList()).containsExactly("err1", "err2");
+        }
+
+        @Test
+        void sequenceNel_empty_shouldReturnValidEmptyList() {
+            Validated<NonEmptyList<String>, List<Integer>> result =
+                Validated.sequenceNel(List.of());
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.get()).isEmpty();
+        }
+    }
+
+    // =========================================================================
+    // Validated.traverseNel()
+    // =========================================================================
+
+    @Nested
+    class TraverseNel {
+
+        @Test
+        void traverseNel_shouldReturnValid_whenAllMappingsSucceed() {
+            List<String> inputs = List.of("1", "2", "3");
+
+            Validated<NonEmptyList<String>, List<Integer>> result =
+                Validated.traverseNel(inputs, s -> {
+                    try {
+                        return Validated.valid(Integer.parseInt(s));
+                    } catch (NumberFormatException e) {
+                        return Validated.invalidNel("not a number: " + s);
+                    }
+                });
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.get()).containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void traverseNel_shouldAccumulateAllErrors() {
+            List<String> inputs = List.of("1", "abc", "3", "xyz");
+
+            Validated<NonEmptyList<String>, List<Integer>> result =
+                Validated.traverseNel(inputs, s -> {
+                    try {
+                        return Validated.valid(Integer.parseInt(s));
+                    } catch (NumberFormatException e) {
+                        return Validated.invalidNel("not a number: " + s);
+                    }
+                });
+
+            assertThat(result.isInvalid()).isTrue();
+            assertThat(result.getError().toList()).containsExactly(
+                "not a number: abc",
+                "not a number: xyz"
+            );
+        }
+
+        @Test
+        void traverseNel_empty_shouldReturnValidEmptyList() {
+            Validated<NonEmptyList<String>, List<Integer>> result =
+                Validated.traverseNel(List.of(), (String s) -> Validated.valid(s.length()));
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.get()).isEmpty();
+        }
+    }
+}

--- a/lib/src/test/java/dmx/fun/NonEmptyListInteropTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListInteropTest.java
@@ -67,6 +67,15 @@ class NonEmptyListInteropTest {
 
             assertThat(result.get().toList()).containsExactly("c", "a", "b");
         }
+
+        @Test
+        void collector_shouldWork_withParallelStream() {
+            Option<NonEmptyList<Integer>> result =
+                Stream.of(1, 2, 3, 4, 5).parallel().collect(NonEmptyList.collector());
+
+            assertThat(result.isDefined()).isTrue();
+            assertThat(result.get().toList()).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
+        }
     }
 
     // =========================================================================
@@ -159,7 +168,7 @@ class NonEmptyListInteropTest {
                 .combine(name,     NonEmptyList::concat, (ep, n) -> ep);
 
             assertThat(combined.isInvalid()).isTrue();
-            assertThat(combined.getError().toList()).containsExactlyInAnyOrder(
+            assertThat(combined.getError().toList()).containsExactly(
                 "email is required",
                 "password too short",
                 "name is required"
@@ -221,6 +230,12 @@ class NonEmptyListInteropTest {
             assertThat(result.isValid()).isTrue();
             assertThat(result.get()).isEmpty();
         }
+
+        @Test
+        void sequenceNel_shouldThrowNPE_whenIterableIsNull() {
+            assertThatThrownBy(() -> Validated.<String, Integer>sequenceNel(null))
+                .isInstanceOf(NullPointerException.class);
+        }
     }
 
     // =========================================================================
@@ -274,6 +289,18 @@ class NonEmptyListInteropTest {
 
             assertThat(result.isValid()).isTrue();
             assertThat(result.get()).isEmpty();
+        }
+
+        @Test
+        void traverseNel_shouldThrowNPE_whenIterableIsNull() {
+            assertThatThrownBy(() -> Validated.<String, String, Integer>traverseNel(null, s -> Validated.valid(1)))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void traverseNel_shouldThrowNPE_whenMapperIsNull() {
+            assertThatThrownBy(() -> Validated.<String, String, Integer>traverseNel(List.of("a"), null))
+                .isInstanceOf(NullPointerException.class);
         }
     }
 }

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -335,9 +335,8 @@ class NonEmptyListTest {
     }
 
     @Test
-    void toString_shouldContainAllElements() {
+    void toString_shouldMatchListFormat() {
         NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
-        assertThat(nel.toString()).contains("1", "2", "3");
-        assertThat(nel.toString()).startsWith("NonEmptyList");
+        assertThat(nel.toString()).isEqualTo("[1, 2, 3]");
     }
 }

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -1,0 +1,343 @@
+package dmx.fun;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NonEmptyListTest {
+
+    // -------------------------------------------------------------------------
+    // of()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_shouldCreateListWithHeadAndTail() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.head()).isEqualTo(1);
+        assertThat(nel.tail()).containsExactly(2, 3);
+        assertThat(nel.size()).isEqualTo(3);
+    }
+
+    @Test
+    void of_shouldCreateListWithEmptyTail() {
+        NonEmptyList<String> nel = NonEmptyList.of("a", List.of());
+        assertThat(nel.head()).isEqualTo("a");
+        assertThat(nel.tail()).isEmpty();
+        assertThat(nel.size()).isEqualTo(1);
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenHeadIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of(null, List.of(1)))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("head");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenTailIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of(1, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("tail");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenTailContainsNull() {
+        List<Integer> tailWithNull = new java.util.ArrayList<>();
+        tailWithNull.add(2);
+        tailWithNull.add(null);
+        assertThatThrownBy(() -> NonEmptyList.of(1, tailWithNull))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // singleton()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void singleton_shouldCreateSingleElementList() {
+        NonEmptyList<String> nel = NonEmptyList.singleton("only");
+        assertThat(nel.head()).isEqualTo("only");
+        assertThat(nel.tail()).isEmpty();
+        assertThat(nel.size()).isEqualTo(1);
+    }
+
+    @Test
+    void singleton_shouldThrowNPE_whenElementIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("head");
+    }
+
+    // -------------------------------------------------------------------------
+    // fromList()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromList_shouldReturnSome_forNonEmptyList() {
+        Option<NonEmptyList<Integer>> result = NonEmptyList.fromList(List.of(1, 2, 3));
+        assertThat(result.isDefined()).isTrue();
+        NonEmptyList<Integer> nel = result.get();
+        assertThat(nel.head()).isEqualTo(1);
+        assertThat(nel.tail()).containsExactly(2, 3);
+    }
+
+    @Test
+    void fromList_shouldReturnSome_forSingletonList() {
+        Option<NonEmptyList<String>> result = NonEmptyList.fromList(List.of("x"));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+    }
+
+    @Test
+    void fromList_shouldReturnNone_forEmptyList() {
+        Option<NonEmptyList<String>> result = NonEmptyList.fromList(List.of());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromList_shouldThrowNPE_whenListIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.fromList(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("list");
+    }
+
+    @Test
+    void fromList_shouldThrowNPE_whenListContainsNull() {
+        List<String> listWithNull = new java.util.ArrayList<>();
+        listWithNull.add("a");
+        listWithNull.add(null);
+        assertThatThrownBy(() -> NonEmptyList.fromList(listWithNull))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // toList()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toList_shouldReturnAllElements_inOrder() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(10, List.of(20, 30));
+        assertThat(nel.toList()).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    void toList_shouldReturnUnmodifiableList() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThatThrownBy(() -> nel.toList().add(99))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void toList_shouldReturnSingleElement_forSingleton() {
+        assertThat(NonEmptyList.singleton("x").toList()).containsExactly("x");
+    }
+
+    // -------------------------------------------------------------------------
+    // map()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void map_shouldTransformAllElements() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        NonEmptyList<String> mapped = nel.map(Object::toString);
+        assertThat(mapped.toList()).containsExactly("1", "2", "3");
+    }
+
+    @Test
+    void map_shouldPreserveHeadTailStructure() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(5, List.of(10, 15));
+        NonEmptyList<Integer> doubled = nel.map(n -> n * 2);
+        assertThat(doubled.head()).isEqualTo(10);
+        assertThat(doubled.tail()).containsExactly(20, 30);
+    }
+
+    @Test
+    void map_shouldWorkOnSingleton() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(7);
+        NonEmptyList<Integer> mapped = nel.map(n -> n + 1);
+        assertThat(mapped.head()).isEqualTo(8);
+        assertThat(mapped.tail()).isEmpty();
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(1);
+        assertThatThrownBy(() -> nel.map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperReturnsNull() {
+        NonEmptyList<String> nel = NonEmptyList.of("a", List.of("b"));
+        assertThatThrownBy(() -> nel.map(s -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // append()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void append_shouldAddElementAtEnd() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2));
+        NonEmptyList<Integer> result = nel.append(3);
+        assertThat(result.toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void append_shouldNotMutateOriginal() {
+        NonEmptyList<Integer> original = NonEmptyList.of(1, List.of(2));
+        original.append(3);
+        assertThat(original.size()).isEqualTo(2);
+    }
+
+    @Test
+    void append_shouldThrowNPE_whenElementIsNull() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(1);
+        assertThatThrownBy(() -> nel.append(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("element");
+    }
+
+    // -------------------------------------------------------------------------
+    // prepend()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void prepend_shouldAddElementAtFront() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(2, List.of(3));
+        NonEmptyList<Integer> result = nel.prepend(1);
+        assertThat(result.toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void prepend_shouldNotMutateOriginal() {
+        NonEmptyList<Integer> original = NonEmptyList.of(2, List.of(3));
+        original.prepend(1);
+        assertThat(original.size()).isEqualTo(2);
+    }
+
+    @Test
+    void prepend_shouldThrowNPE_whenElementIsNull() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(1);
+        assertThatThrownBy(() -> nel.prepend(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("element");
+    }
+
+    @Test
+    void prepend_shouldBecomeNewHead() {
+        NonEmptyList<String> nel = NonEmptyList.of("b", List.of("c"));
+        NonEmptyList<String> result = nel.prepend("a");
+        assertThat(result.head()).isEqualTo("a");
+        assertThat(result.tail()).containsExactly("b", "c");
+    }
+
+    // -------------------------------------------------------------------------
+    // concat()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void concat_shouldCombineBothLists() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2));
+        NonEmptyList<Integer> b = NonEmptyList.of(3, List.of(4, 5));
+        NonEmptyList<Integer> result = a.concat(b);
+        assertThat(result.toList()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void concat_shouldPreserveHeadOfFirst() {
+        NonEmptyList<String> a = NonEmptyList.singleton("x");
+        NonEmptyList<String> b = NonEmptyList.of("y", List.of("z"));
+        assertThat(a.concat(b).head()).isEqualTo("x");
+    }
+
+    @Test
+    void concat_shouldNotMutateEither() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2));
+        NonEmptyList<Integer> b = NonEmptyList.of(3, List.of(4));
+        a.concat(b);
+        assertThat(a.size()).isEqualTo(2);
+        assertThat(b.size()).isEqualTo(2);
+    }
+
+    @Test
+    void concat_shouldThrowNPE_whenOtherIsNull() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(1);
+        assertThatThrownBy(() -> nel.concat(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("other");
+    }
+
+    // -------------------------------------------------------------------------
+    // Iterable
+    // -------------------------------------------------------------------------
+
+    @Test
+    void iterator_shouldYieldAllElementsInOrder() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(10, List.of(20, 30));
+        java.util.List<Integer> collected = new java.util.ArrayList<>();
+        for (Integer i : nel) {
+            collected.add(i);
+        }
+        assertThat(collected).containsExactly(10, 20, 30);
+    }
+
+    // -------------------------------------------------------------------------
+    // equals / hashCode / toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void equals_shouldBeTrue_forSameContent() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2, 3));
+        NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    void equals_shouldBeFalse_forDifferentContent() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2));
+        NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(3));
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void equals_shouldBeFalse_forDifferentSize() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2));
+        NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void equals_shouldBeTrue_forSameInstance() {
+        NonEmptyList<Integer> nel = NonEmptyList.singleton(42);
+        assertThat(nel).isEqualTo(nel);
+    }
+
+    @Test
+    void equals_shouldBeFalse_forNull() {
+        assertThat(NonEmptyList.singleton(1)).isNotEqualTo(null);
+    }
+
+    @Test
+    void equals_shouldBeFalse_forDifferentType() {
+        assertThat(NonEmptyList.singleton(1)).isNotEqualTo(List.of(1));
+    }
+
+    @Test
+    void hashCode_shouldBeConsistent_forEqualLists() {
+        NonEmptyList<Integer> a = NonEmptyList.of(1, List.of(2, 3));
+        NonEmptyList<Integer> b = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void toString_shouldContainAllElements() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.toString()).contains("1", "2", "3");
+        assertThat(nel.toString()).startsWith("NonEmptyList");
+    }
+}


### PR DESCRIPTION
  Introduce NonEmptyList<T>: an immutable, @NullMarked list guaranteed at
  construction time to contain at least one element.

  Public API:
  - of(head, tail), singleton(head), fromList(list) → Option<NonEmptyList<T>>
  - head(), tail(), toList(), size(), iterator()
  - map(mapper), append(element), prepend(element), concat(other)
  - toStream(), collector() → Collector<T, ?, Option<NonEmptyList<T>>>
  - sequence(NonEmptyList<Option<T>>) → Option<NonEmptyList<T>>

  Validated interop (NEL-flavoured convenience):
  - Validated.invalidNel(error) — wraps a single error in a singleton NEL
  - Validated.sequenceNel(iterable) — accumulates errors via NonEmptyList::concat
  - Validated.traverseNel(values, mapper) — traverse with automatic NEL merging

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #122

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NonEmptyList: an immutable list type that always contains at least one non-null element, with construction, mapping, concat/append/prepend, streaming, and collection support.
  * Added Validated helpers for accumulating errors using NonEmptyList (convenience factories and sequence/traverse variants).

* **Tests**
  * Added comprehensive tests for NonEmptyList behavior, collector/stream interop, sequencing of optional elements, and Validated accumulation semantics.

* **Documentation**
  * Module docs updated to describe the new NonEmptyList.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->