### PR TITLE
feat(lib): add Either<L,R> type with full interop across existing types

### DIFF
--- a/lib/src/main/java/dmx/fun/Either.java
+++ b/lib/src/main/java/dmx/fun/Either.java
@@ -208,7 +208,7 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
             case Right<L, R> right -> {
                 @SuppressWarnings("unchecked")
                 Either<L, R2> result = (Either<L, R2>) mapper.apply(right.value());
-                yield result;
+                yield Objects.requireNonNull(result, "mapper returned null");
             }
         };
     }

--- a/lib/src/main/java/dmx/fun/Either.java
+++ b/lib/src/main/java/dmx/fun/Either.java
@@ -1,0 +1,307 @@
+package dmx.fun;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A disjoint union that is either a {@link Left} or a {@link Right}.
+ *
+ * <p>{@code Either<L,R>} is a neutral two-track type: neither side carries error
+ * semantics. Use it when a computation legitimately returns one of two value types
+ * without implying that one side is a failure. For error-handling use cases prefer
+ * {@link Result}, which is semantically opinionated ({@code Ok} = success,
+ * {@code Err} = failure) and offers richer recovery operations.
+ *
+ * <p>By convention, {@code map}, {@code flatMap}, and related operations act on
+ * the <em>right</em> side. Use {@link #swap()} to flip the sides when you need
+ * to operate on the left.
+ *
+ * <p>This interface is {@code @NullMarked}: all values — left and right — are
+ * non-null by default.
+ *
+ * @param <L> the type of the left value
+ * @param <R> the type of the right value
+ */
+@NullMarked
+public sealed interface Either<L, R> permits Either.Left, Either.Right {
+
+    /**
+     * The left variant of {@link Either}.
+     *
+     * @param <L>   the type of the left value
+     * @param <R>   the type of the right value
+     * @param value the non-null left value
+     */
+    record Left<L, R>(L value) implements Either<L, R> {
+        /** Validates that {@code value} is non-null. */
+        public Left {
+            Objects.requireNonNull(value, "Left value must not be null");
+        }
+    }
+
+    /**
+     * The right variant of {@link Either}.
+     *
+     * @param <L>   the type of the left value
+     * @param <R>   the type of the right value
+     * @param value the non-null right value
+     */
+    record Right<L, R>(R value) implements Either<L, R> {
+        /** Validates that {@code value} is non-null. */
+        public Right {
+            Objects.requireNonNull(value, "Right value must not be null");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@link Left} instance wrapping the given value.
+     *
+     * @param <L>   the left type
+     * @param <R>   the right type
+     * @param value the non-null left value
+     * @return an {@code Either} containing the left value
+     * @throws NullPointerException if {@code value} is {@code null}
+     */
+    static <L, R> Either<L, R> left(L value) {
+        return new Left<>(value);
+    }
+
+    /**
+     * Creates a {@link Right} instance wrapping the given value.
+     *
+     * @param <L>   the left type
+     * @param <R>   the right type
+     * @param value the non-null right value
+     * @return an {@code Either} containing the right value
+     * @throws NullPointerException if {@code value} is {@code null}
+     */
+    static <L, R> Either<L, R> right(R value) {
+        return new Right<>(value);
+    }
+
+    // -------------------------------------------------------------------------
+    // Predicates
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if this is a {@link Left}.
+     *
+     * @return {@code true} for {@code Left}, {@code false} for {@code Right}
+     */
+    default boolean isLeft() {
+        return this instanceof Left;
+    }
+
+    /**
+     * Returns {@code true} if this is a {@link Right}.
+     *
+     * @return {@code true} for {@code Right}, {@code false} for {@code Left}
+     */
+    default boolean isRight() {
+        return this instanceof Right;
+    }
+
+    // -------------------------------------------------------------------------
+    // Extraction
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the left value.
+     *
+     * @return the left value
+     * @throws NoSuchElementException if this is a {@link Right}
+     */
+    default L getLeft() {
+        return switch (this) {
+            case Left<L, R> left -> left.value();
+            case Right<L, R> _ -> throw new NoSuchElementException("No left value present. This Either is Right.");
+        };
+    }
+
+    /**
+     * Returns the right value.
+     *
+     * @return the right value
+     * @throws NoSuchElementException if this is a {@link Left}
+     */
+    default R getRight() {
+        return switch (this) {
+            case Right<L, R> right -> right.value();
+            case Left<L, R> _ -> throw new NoSuchElementException("No right value present. This Either is Left.");
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies {@code onLeft} if this is {@link Left}, or {@code onRight} if this is
+     * {@link Right}, and returns the result.
+     *
+     * @param <T>     the result type
+     * @param onLeft  function applied to the left value
+     * @param onRight function applied to the right value
+     * @return the result of whichever function was applied
+     */
+    default <T> T fold(
+            Function<? super L, ? extends T> onLeft,
+            Function<? super R, ? extends T> onRight) {
+        Objects.requireNonNull(onLeft, "onLeft");
+        Objects.requireNonNull(onRight, "onRight");
+        return switch (this) {
+            case Left<L, R> left   -> onLeft.apply(left.value());
+            case Right<L, R> right -> onRight.apply(right.value());
+        };
+    }
+
+    /**
+     * Maps the right value using {@code mapper}, leaving a {@link Left} unchanged.
+     *
+     * @param <R2>   the new right type
+     * @param mapper function applied to the right value
+     * @return a new {@code Either} with the mapped right value, or the original {@code Left}
+     */
+    default <R2> Either<L, R2> map(Function<? super R, ? extends R2> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return switch (this) {
+            case Left<L, R> left   -> Either.left(left.value());
+            case Right<L, R> right -> Either.right(mapper.apply(right.value()));
+        };
+    }
+
+    /**
+     * Maps the left value using {@code mapper}, leaving a {@link Right} unchanged.
+     *
+     * @param <L2>   the new left type
+     * @param mapper function applied to the left value
+     * @return a new {@code Either} with the mapped left value, or the original {@code Right}
+     */
+    default <L2> Either<L2, R> mapLeft(Function<? super L, ? extends L2> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return switch (this) {
+            case Left<L, R> left   -> Either.left(mapper.apply(left.value()));
+            case Right<L, R> right -> Either.right(right.value());
+        };
+    }
+
+    /**
+     * Applies {@code mapper} to the right value and returns the resulting {@code Either},
+     * leaving a {@link Left} unchanged. This is the monadic bind for the right track.
+     *
+     * @param <R2>   the new right type
+     * @param mapper function that returns an {@code Either} for the right value
+     * @return the result of {@code mapper} applied to the right value, or the original {@code Left}
+     */
+    default <R2> Either<L, R2> flatMap(
+            Function<? super R, ? extends Either<? extends L, ? extends R2>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return switch (this) {
+            case Left<L, R> left   -> Either.left(left.value());
+            case Right<L, R> right -> {
+                @SuppressWarnings("unchecked")
+                Either<L, R2> result = (Either<L, R2>) mapper.apply(right.value());
+                yield result;
+            }
+        };
+    }
+
+    /**
+     * Swaps the two sides: {@link Left} becomes {@link Right} and vice-versa.
+     *
+     * @return an {@code Either<R,L>} with the sides swapped
+     */
+    default Either<R, L> swap() {
+        return switch (this) {
+            case Left<L, R> left   -> Either.right(left.value());
+            case Right<L, R> right -> Either.left(right.value());
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Executes {@code action} if this is a {@link Right}, then returns {@code this} unchanged.
+     *
+     * @param action consumer applied to the right value
+     * @return this {@code Either}
+     */
+    default Either<L, R> peek(Consumer<? super R> action) {
+        Objects.requireNonNull(action, "action");
+        if (this instanceof Right<L, R>(R value)) {
+            action.accept(value);
+        }
+        return this;
+    }
+
+    /**
+     * Executes {@code action} if this is a {@link Left}, then returns {@code this} unchanged.
+     *
+     * @param action consumer applied to the left value
+     * @return this {@code Either}
+     */
+    default Either<L, R> peekLeft(Consumer<? super L> action) {
+        Objects.requireNonNull(action, "action");
+        if (this instanceof Left<L, R>(L value)) {
+            action.accept(value);
+        }
+        return this;
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion
+    // -------------------------------------------------------------------------
+
+    /**
+     * Converts this {@code Either} to an {@link Option}: {@link Right} becomes
+     * {@link Option#some(Object)}, {@link Left} becomes {@link Option#none()}.
+     *
+     * @return an {@code Option} containing the right value, or empty
+     */
+    default Option<R> toOption() {
+        return switch (this) {
+            case Right<L, R> right -> Option.some(right.value());
+            case Left<L, R> _      -> Option.none();
+        };
+    }
+
+    /**
+     * Converts this {@code Either} to a {@link Result}.
+     *
+     * <p>{@link Right} maps to {@link Result.Ok}; {@link Left} maps to {@link Result.Err}.
+     * This is the inverse of {@link Result#toEither()}.
+     *
+     * @return a {@code Result<R, L>} equivalent of this {@code Either}
+     */
+    default Result<R, L> toResult() {
+        return switch (this) {
+            case Right<L, R> right -> Result.ok(right.value());
+            case Left<L, R> left   -> Result.err(left.value());
+        };
+    }
+
+    /**
+     * Converts this {@code Either} to a {@link Validated}.
+     *
+     * <p>{@link Right} maps to {@link Validated#valid}; {@link Left} maps to
+     * {@link Validated#invalid}. Useful for bringing a neutral {@code Either} into
+     * the error-accumulating validation world.
+     *
+     * @return a {@code Validated<L, R>} equivalent of this {@code Either}
+     */
+    default Validated<L, R> toValidated() {
+        return switch (this) {
+            case Right<L, R> right -> Validated.valid(right.value());
+            case Left<L, R> left   -> Validated.invalid(left.value());
+        };
+    }
+}

--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -529,6 +529,27 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     }
 
     /**
+     * Converts this {@code Option} to an {@link Either}.
+     *
+     * <p>{@code Some(v)} maps to {@link Either#right(Object)}; {@code None} maps to
+     * {@link Either#left(Object)} using the supplied left value. Mirrors the
+     * existing {@link #toResult(Object)} overload for the neutral two-track type.
+     *
+     * @param <L>        the left type
+     * @param leftIfNone the value to use as the {@link Either.Left} when this is {@code None};
+     *                   must not be {@code null}
+     * @return an {@code Either<L, Value>} equivalent of this {@code Option}
+     * @throws NullPointerException if {@code leftIfNone} is {@code null}
+     */
+    default <L> Either<L, Value> toEither(L leftIfNone) {
+        Objects.requireNonNull(leftIfNone, "leftIfNone");
+        return switch (this) {
+            case Some<Value> s -> Either.right(s.value());
+            case None<Value> _ -> Either.left(leftIfNone);
+        };
+    }
+
+    /**
      * Converts a {@link Result} into an {@link Option}.
      * <p>
      * If the given {@code result} represents a successful value (i.e., {@code isOk()} returns true),

--- a/lib/src/main/java/dmx/fun/Result.java
+++ b/lib/src/main/java/dmx/fun/Result.java
@@ -531,6 +531,22 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     }
 
     /**
+     * Converts this {@code Result} to an {@link Either}.
+     *
+     * <p>{@code Ok(v)} maps to {@code Either.right(v)}; {@code Err(e)} maps to
+     * {@code Either.left(e)}. The resulting {@code Either<Error, Value>} preserves
+     * the right-bias convention: the success value is on the right track.
+     *
+     * @return an {@code Either<Error, Value>} representing this result
+     */
+    default Either<Error, Value> toEither() {
+        return switch (this) {
+            case Ok<Value, Error>  ok  -> Either.right(ok.value());
+            case Err<Value, Error> err -> Either.left(err.error());
+        };
+    }
+
+    /**
      * Converts an {@link Option} to a {@link Result}.
      *
      * @param <V>         The type of the value contained in the {@link Option}.

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -734,11 +734,19 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * {@link Either#left(Object)}. This reflects the natural equivalence between
      * {@code Try<V>} and {@code Either<Throwable, V>}.
      *
+     * <p><strong>Note:</strong> unlike {@link #toOption()}, this method does not tolerate a
+     * {@code null} success value, because {@link Either} enforces non-null values on both
+     * tracks. If this {@code Try} is a {@code Success} wrapping {@code null} (e.g. a
+     * {@code Try<Void>}), a {@link NullPointerException} will be thrown.
+     *
      * @return an {@code Either<Throwable, Value>} equivalent of this {@code Try}
+     * @throws NullPointerException if this is a {@code Success} whose value is {@code null}
      */
     default Either<Throwable, Value> toEither() {
         return switch (this) {
-            case Success<Value> s -> Either.right(s.value());
+            case Success<Value> s -> Either.right(
+                Objects.requireNonNull(s.value(), "Cannot convert Success(null) to Either; Either does not allow null values")
+            );
             case Failure<Value> f -> Either.left(f.cause());
         };
     }

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -728,6 +728,22 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     }
 
     /**
+     * Converts this {@code Try} to an {@link Either}.
+     *
+     * <p>{@code Success(v)} maps to {@link Either#right(Object)}; {@code Failure(t)} maps to
+     * {@link Either#left(Object)}. This reflects the natural equivalence between
+     * {@code Try<V>} and {@code Either<Throwable, V>}.
+     *
+     * @return an {@code Either<Throwable, Value>} equivalent of this {@code Try}
+     */
+    default Either<Throwable, Value> toEither() {
+        return switch (this) {
+            case Success<Value> s -> Either.right(s.value());
+            case Failure<Value> f -> Either.left(f.cause());
+        };
+    }
+
+    /**
      * Converts this {@code Try} into an already-completed {@link CompletableFuture}.
      *
      * <p>If this is a {@code Success}, returns a future completed normally with the value.

--- a/lib/src/main/java/dmx/fun/Validated.java
+++ b/lib/src/main/java/dmx/fun/Validated.java
@@ -304,6 +304,22 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
     }
 
     /**
+     * Converts this {@code Validated} to an {@link Either}.
+     *
+     * <p>{@link Valid} maps to {@link Either#right}; {@link Invalid} maps to {@link Either#left}.
+     * Useful as an escape hatch from error-accumulating validation into the short-circuiting
+     * {@code Either} world, for example to apply {@code flatMap} after validation succeeds.
+     *
+     * @return an {@code Either<E, A>} equivalent of this {@code Validated}
+     */
+    default Either<E, A> toEither() {
+        return switch (this) {
+            case Valid<E, A> v     -> Either.right(v.value());
+            case Invalid<E, A> inv -> Either.left(inv.error());
+        };
+    }
+
+    /**
      * Converts a {@link Result} to a {@code Validated}.
      * {@link Result.Ok} maps to {@link Valid}; {@link Result.Err} maps to {@link Invalid}.
      *

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -18,6 +18,7 @@
  *   <li>{@link dmx.fun.QuadFunction} — function accepting four arguments</li>
  *   <li>{@link dmx.fun.Lazy}         — lazily evaluated, memoized value</li>
  *   <li>{@link dmx.fun.NonEmptyList} — list guaranteed to contain at least one element</li>
+ *   <li>{@link dmx.fun.Either}       — neutral disjoint union of two value types</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/EitherTest.java
+++ b/lib/src/test/java/dmx/fun/EitherTest.java
@@ -47,7 +47,7 @@ class EitherTest {
 
     @Test
     void getLeft_shouldReturnValue_whenLeft() {
-        assertThat(Either.left("error").<String, Integer>getLeft()).isEqualTo("error");
+        assertThat(Either.<String, Integer>left("error").getLeft()).isEqualTo("error");
     }
 
     @Test
@@ -188,6 +188,14 @@ class EitherTest {
         Either<String, Integer> e = Either.right(1);
         assertThatThrownBy(() -> e.flatMap(null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperReturnsNull() {
+        Either<String, Integer> e = Either.right(1);
+        assertThatThrownBy(() -> e.flatMap(v -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper returned null");
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/test/java/dmx/fun/EitherTest.java
+++ b/lib/src/test/java/dmx/fun/EitherTest.java
@@ -1,0 +1,353 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EitherTest {
+
+    // -------------------------------------------------------------------------
+    // Factory: left / right
+    // -------------------------------------------------------------------------
+
+    @Test
+    void left_shouldCreateLeftInstance() {
+        Either<String, Integer> e = Either.left("error");
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.isRight()).isFalse();
+    }
+
+    @Test
+    void right_shouldCreateRightInstance() {
+        Either<String, Integer> e = Either.right(42);
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.isLeft()).isFalse();
+    }
+
+    @Test
+    void left_shouldThrowNPE_whenValueIsNull() {
+        assertThatThrownBy(() -> Either.left(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("Left value");
+    }
+
+    @Test
+    void right_shouldThrowNPE_whenValueIsNull() {
+        assertThatThrownBy(() -> Either.right(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("Right value");
+    }
+
+    // -------------------------------------------------------------------------
+    // getLeft / getRight
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getLeft_shouldReturnValue_whenLeft() {
+        assertThat(Either.left("error").<String, Integer>getLeft()).isEqualTo("error");
+    }
+
+    @Test
+    void getRight_shouldReturnValue_whenRight() {
+        assertThat(Either.<String, Integer>right(42).getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void getLeft_shouldThrow_whenRight() {
+        Either<String, Integer> e = Either.right(42);
+        assertThatThrownBy(e::getLeft)
+            .isInstanceOf(java.util.NoSuchElementException.class)
+            .hasMessageContaining("Right");
+    }
+
+    @Test
+    void getRight_shouldThrow_whenLeft() {
+        Either<String, Integer> e = Either.left("error");
+        assertThatThrownBy(e::getRight)
+            .isInstanceOf(java.util.NoSuchElementException.class)
+            .hasMessageContaining("Left");
+    }
+
+    // -------------------------------------------------------------------------
+    // fold
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fold_shouldApplyOnLeft_whenLeft() {
+        Either<String, Integer> e = Either.left("error");
+        String result = e.fold(l -> "LEFT:" + l, r -> "RIGHT:" + r);
+        assertThat(result).isEqualTo("LEFT:error");
+    }
+
+    @Test
+    void fold_shouldApplyOnRight_whenRight() {
+        Either<String, Integer> e = Either.right(42);
+        String result = e.fold(l -> "LEFT:" + l, r -> "RIGHT:" + r);
+        assertThat(result).isEqualTo("RIGHT:42");
+    }
+
+    @Test
+    void fold_shouldThrowNPE_whenOnLeftIsNull() {
+        Either<String, Integer> e = Either.left("x");
+        assertThatThrownBy(() -> e.fold(null, r -> r.toString()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fold_shouldThrowNPE_whenOnRightIsNull() {
+        Either<String, Integer> e = Either.right(1);
+        assertThatThrownBy(() -> e.fold(l -> l, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // map
+    // -------------------------------------------------------------------------
+
+    @Test
+    void map_shouldTransformRight_whenRight() {
+        Either<String, Integer> e = Either.<String, Integer>right(5).map(v -> v * 2);
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(10);
+    }
+
+    @Test
+    void map_shouldLeaveLeft_unchanged() {
+        Either<String, Integer> e = Either.<String, Integer>left("err").map(v -> v * 2);
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("err");
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        Either<String, Integer> e = Either.right(1);
+        assertThatThrownBy(() -> e.map(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // mapLeft
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapLeft_shouldTransformLeft_whenLeft() {
+        Either<String, Integer> e = Either.<String, Integer>left("error").mapLeft(String::toUpperCase);
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("ERROR");
+    }
+
+    @Test
+    void mapLeft_shouldLeaveRight_unchanged() {
+        Either<String, Integer> e = Either.<String, Integer>right(7).mapLeft(String::toUpperCase);
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(7);
+    }
+
+    @Test
+    void mapLeft_shouldThrowNPE_whenMapperIsNull() {
+        Either<String, Integer> e = Either.left("x");
+        assertThatThrownBy(() -> e.mapLeft(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // flatMap
+    // -------------------------------------------------------------------------
+
+    @Test
+    void flatMap_shouldChain_whenRight() {
+        Either<String, Integer> result = Either.<String, Integer>right(5)
+            .flatMap(v -> v > 0 ? Either.right(v * 10) : Either.left("negative"));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight()).isEqualTo(50);
+    }
+
+    @Test
+    void flatMap_shouldShortCircuit_whenLeft() {
+        List<String> called = new ArrayList<>();
+        Either<String, Integer> result = Either.<String, Integer>left("err")
+            .flatMap(v -> { called.add("called"); return Either.right(v); });
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("err");
+        assertThat(called).isEmpty();
+    }
+
+    @Test
+    void flatMap_shouldReturnLeft_whenMapperReturnsLeft() {
+        Either<String, Integer> result = Either.<String, Integer>right(5)
+            .flatMap(v -> Either.left("too small"));
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("too small");
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperIsNull() {
+        Either<String, Integer> e = Either.right(1);
+        assertThatThrownBy(() -> e.flatMap(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // swap
+    // -------------------------------------------------------------------------
+
+    @Test
+    void swap_shouldTurnLeftIntoRight() {
+        Either<Integer, String> swapped = Either.<String, Integer>left("hello").swap();
+        assertThat(swapped.isRight()).isTrue();
+        assertThat(swapped.getRight()).isEqualTo("hello");
+    }
+
+    @Test
+    void swap_shouldTurnRightIntoLeft() {
+        Either<String, Integer> swapped = Either.<Integer, String>right("world").swap();
+        assertThat(swapped.isLeft()).isTrue();
+        assertThat(swapped.getLeft()).isEqualTo("world");
+    }
+
+    @Test
+    void swap_shouldBeInvolution() {
+        Either<String, Integer> original = Either.right(99);
+        assertThat(original.swap().swap().getRight()).isEqualTo(99);
+    }
+
+    // -------------------------------------------------------------------------
+    // peek / peekLeft
+    // -------------------------------------------------------------------------
+
+    @Test
+    void peek_shouldExecuteAction_whenRight() {
+        List<Integer> seen = new ArrayList<>();
+        Either<String, Integer> e = Either.<String, Integer>right(42).peek(seen::add);
+        assertThat(seen).containsExactly(42);
+        assertThat(e.getRight()).isEqualTo(42); // unchanged
+    }
+
+    @Test
+    void peek_shouldNotExecuteAction_whenLeft() {
+        List<Integer> seen = new ArrayList<>();
+        Either.<String, Integer>left("err").peek(seen::add);
+        assertThat(seen).isEmpty();
+    }
+
+    @Test
+    void peek_shouldThrowNPE_whenActionIsNull() {
+        Either<String, Integer> e = Either.right(1);
+        assertThatThrownBy(() -> e.peek(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void peekLeft_shouldExecuteAction_whenLeft() {
+        List<String> seen = new ArrayList<>();
+        Either<String, Integer> e = Either.<String, Integer>left("err").peekLeft(seen::add);
+        assertThat(seen).containsExactly("err");
+        assertThat(e.getLeft()).isEqualTo("err"); // unchanged
+    }
+
+    @Test
+    void peekLeft_shouldNotExecuteAction_whenRight() {
+        List<String> seen = new ArrayList<>();
+        Either.<String, Integer>right(1).peekLeft(seen::add);
+        assertThat(seen).isEmpty();
+    }
+
+    @Test
+    void peekLeft_shouldThrowNPE_whenActionIsNull() {
+        Either<String, Integer> e = Either.left("x");
+        assertThatThrownBy(() -> e.peekLeft(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // toOption
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toOption_shouldReturnSome_whenRight() {
+        Option<Integer> opt = Either.<String, Integer>right(7).toOption();
+        assertThat(opt.isDefined()).isTrue();
+        assertThat(opt.get()).isEqualTo(7);
+    }
+
+    @Test
+    void toOption_shouldReturnNone_whenLeft() {
+        Option<Integer> opt = Either.<String, Integer>left("err").toOption();
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Either.toResult
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toResult_shouldMapRightToOk() {
+        Result<Integer, String> result = Either.<String, Integer>right(42).toResult();
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get()).isEqualTo(42);
+    }
+
+    @Test
+    void toResult_shouldMapLeftToErr() {
+        Result<Integer, String> result = Either.<String, Integer>left("fail").toResult();
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("fail");
+    }
+
+    // -------------------------------------------------------------------------
+    // Either.toValidated
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toValidated_shouldMapRightToValid() {
+        Validated<String, Integer> v = Either.<String, Integer>right(99).toValidated();
+        assertThat(v.isValid()).isTrue();
+        assertThat(v.get()).isEqualTo(99);
+    }
+
+    @Test
+    void toValidated_shouldMapLeftToInvalid() {
+        Validated<String, Integer> v = Either.<String, Integer>left("err").toValidated();
+        assertThat(v.isInvalid()).isTrue();
+        assertThat(v.getError()).isEqualTo("err");
+    }
+
+    // -------------------------------------------------------------------------
+    // Result.toEither conversion
+    // -------------------------------------------------------------------------
+
+    @Test
+    void result_toEither_shouldMapOkToRight() {
+        Result<Integer, String> ok = Result.ok(42);
+        Either<String, Integer> e = ok.toEither();
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void result_toEither_shouldMapErrToLeft() {
+        Result<Integer, String> err = Result.err("fail");
+        Either<String, Integer> e = err.toEither();
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("fail");
+    }
+
+    // -------------------------------------------------------------------------
+    // Neutral semantics demo: neither side is an error
+    // -------------------------------------------------------------------------
+
+    @Test
+    void eitherShouldModel_neutralBranching_withoutErrorSemantics() {
+        Either<String, Integer> adminId = Either.left("admin-001");
+        Either<String, Integer> userId  = Either.right(42);
+
+        String labelAdmin = adminId.fold(a -> "Admin: " + a, u -> "User #" + u);
+        String labelUser  = userId.fold(a  -> "Admin: " + a, u -> "User #" + u);
+
+        assertThat(labelAdmin).isEqualTo("Admin: admin-001");
+        assertThat(labelUser).isEqualTo("User #42");
+    }
+}

--- a/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/lib/src/test/java/dmx/fun/OptionTest.java
@@ -574,4 +574,27 @@ class OptionTest {
 
         assertThat(left).isEqualTo(right);
     }
+
+    // ---------- toEither ----------
+
+    @Test
+    void toEither_shouldReturnRight_whenSome() {
+        Either<String, Integer> e = Option.some(42).toEither("missing");
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void toEither_shouldReturnLeft_whenNone() {
+        Either<String, Integer> e = Option.<Integer>none().toEither("missing");
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("missing");
+    }
+
+    @Test
+    void toEither_shouldThrowNPE_whenLeftIfNoneIsNull() {
+        assertThatThrownBy(() -> Option.some(1).toEither(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("leftIfNone");
+    }
 }

--- a/lib/src/test/java/dmx/fun/TryTest.java
+++ b/lib/src/test/java/dmx/fun/TryTest.java
@@ -1100,4 +1100,12 @@ class TryTest {
         assertThat(e.isLeft()).isTrue();
         assertThat(e.getLeft()).isSameAs(ex);
     }
+
+    @Test
+    void toEither_shouldThrowNPE_whenSuccessValueIsNull() {
+        Try<String> nullSuccess = Try.success(null);
+        assertThatThrownBy(nullSuccess::toEither)
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("null");
+    }
 }

--- a/lib/src/test/java/dmx/fun/TryTest.java
+++ b/lib/src/test/java/dmx/fun/TryTest.java
@@ -1083,4 +1083,21 @@ class TryTest {
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(thrown);
     }
+
+    // ---------- toEither ----------
+
+    @Test
+    void toEither_shouldReturnRight_whenSuccess() {
+        Either<Throwable, Integer> e = Try.success(42).toEither();
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void toEither_shouldReturnLeft_whenFailure() {
+        RuntimeException ex = new RuntimeException("boom");
+        Either<Throwable, Integer> e = Try.<Integer>failure(ex).toEither();
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isSameAs(ex);
+    }
 }

--- a/lib/src/test/java/dmx/fun/ValidatedTest.java
+++ b/lib/src/test/java/dmx/fun/ValidatedTest.java
@@ -419,4 +419,20 @@ class ValidatedTest {
         assertThatThrownBy(() -> Validated.traverseCollector(n -> Validated.valid(n), null))
             .isInstanceOf(NullPointerException.class);
     }
+
+    // ---------- toEither ----------
+
+    @Test
+    void toEither_shouldReturnRight_whenValid() {
+        Either<String, Integer> e = Validated.<String, Integer>valid(42).toEither();
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void toEither_shouldReturnLeft_whenInvalid() {
+        Either<String, Integer> e = Validated.<String, Integer>invalid("bad").toEither();
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("bad");
+    }
 }


### PR DESCRIPTION
  Introduce Either<L,R> as a neutral disjoint union for cases where neither
  side carries error semantics. Kept intentionally separate from Result to
  preserve semantic clarity (Result remains the opinionated error-handling type).

  - Either<L,R>: sealed interface with Left/Right records, factory methods
    left()/right(), isLeft/isRight, getLeft/getRight, fold, map, mapLeft,
    flatMap, swap, peek, peekLeft, toOption, toResult, toValidated
  - Result.toEither(): Ok→Right, Err→Left (inverse of Either.toResult)
  - Option.toEither(leftIfNone): Some→Right, None→Left
  - Try.toEither(): Success→Right(value), Failure→Left(cause)
  - Validated.toEither(): Valid→Right, Invalid→Left
  - Full unit tests for all methods including null-contract coverage
  - Either, Option, Try, Validated new methods at 100% instruction coverage

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #119

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an Either type (Left/Right) with fold, map/mapLeft, flatMap, swap, and peek/peekLeft hooks
  * Added conversions: Option→Either, Result→Either, Try→Either, Validated→Either

* **Tests**
  * Added comprehensive unit tests covering construction, null-safety, mapping/flatMap, swap, peek, fold, and conversions

* **Documentation**
  * Updated module docs to include Either among core FP types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->