### PR TITLE
feat(jackson): add Jackson serialization module for all dmx-fun types

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,11 +2,13 @@
 
 [versions]
 assertj = "3.27.7"
+jackson = "2.18.2"
 jspecify = "1.0.0"
 junit = "6.0.3"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/jackson/build.gradle
+++ b/jackson/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'dmx-fun.java-module'
+}
+
+dependencies {
+    api project(':lib')
+    api libs.jackson.databind
+}
+
+compileTestJava {
+    def mainClassesDirs = sourceSets.main.output.classesDirs
+    def apiDeps = configurations.compileClasspath
+    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
+
+    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
+
+    def modulePath = (mainClassesDirs + apiDeps).asPath
+    options.compilerArgs += [
+        '--module-path', modulePath,
+        '--add-modules', 'dmx.fun.jackson',
+        '--patch-module', "dmx.fun.jackson=${testSrcPath}",
+        '--add-reads', 'dmx.fun.jackson=ALL-UNNAMED',
+    ]
+}
+
+mavenPublishing {
+    coordinates("codes.domix", "fun-jackson", "${project.version}")
+    pom {
+        name = 'Jackson module for dmx-fun types.'
+        description = 'Jackson serializers and deserializers for Option, Result, Try, Validated, Tuple2/3/4, NonEmptyList, and Either.'
+    }
+}

--- a/jackson/build.gradle
+++ b/jackson/build.gradle
@@ -4,7 +4,8 @@ plugins {
 
 dependencies {
     api project(':lib')
-    api libs.jackson.databind
+    compileOnly libs.jackson.databind
+    testImplementation libs.jackson.databind
 }
 
 compileTestJava {

--- a/jackson/src/main/java/dmx/fun/jackson/DmxFunModule.java
+++ b/jackson/src/main/java/dmx/fun/jackson/DmxFunModule.java
@@ -1,0 +1,76 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import dmx.fun.Either;
+import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Tuple2;
+import dmx.fun.Tuple3;
+import dmx.fun.Tuple4;
+import dmx.fun.Validated;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Jackson module that registers serializers and deserializers for all dmx-fun types.
+ *
+ * <p>Register manually:
+ * <pre>{@code
+ * ObjectMapper mapper = new ObjectMapper().registerModule(new DmxFunModule());
+ * }</pre>
+ *
+ * <p>Or rely on auto-discovery:
+ * <pre>{@code
+ * ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+ * }</pre>
+ */
+@NullMarked
+public class DmxFunModule extends SimpleModule {
+
+    /**
+     * Constructs a new instance of DmxFunModule.
+     * <p>
+     * This module extends {@code SimpleModule} and is specifically designed to handle
+     * serialization and deserialization for various dmx-fun types. During construction,
+     * it registers custom serializers and deserializers for types such as {@code Try},
+     * {@code Either}, {@code Option}, {@code Result}, {@code Validated}, {@code Tuple2},
+     * {@code Tuple3}, {@code Tuple4}, and {@code NonEmptyList}.
+     * <p>
+     * It is used to ensure these types are correctly processed by Jackson's {@code ObjectMapper}.
+     * <p>
+     * Typical usage includes registering this module with an {@code ObjectMapper} either manually
+     * or automatically.
+     */
+    public DmxFunModule() {
+        super("DmxFunModule");
+        registerSerializers();
+        registerDeserializers();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerSerializers() {
+        addSerializer(new OptionSerializer());
+        addSerializer(new ResultSerializer());
+        addSerializer(new TrySerializer());
+        addSerializer(new ValidatedSerializer());
+        addSerializer(new EitherSerializer());
+        addSerializer(new Tuple2Serializer());
+        addSerializer(new Tuple3Serializer());
+        addSerializer(new Tuple4Serializer());
+        addSerializer(new NonEmptyListSerializer());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerDeserializers() {
+        addDeserializer(Option.class, new OptionDeserializer());
+        addDeserializer(Result.class, new ResultDeserializer());
+        addDeserializer(Try.class, new TryDeserializer());
+        addDeserializer(Validated.class, new ValidatedDeserializer());
+        addDeserializer(Either.class, new EitherDeserializer());
+        addDeserializer(Tuple2.class, new Tuple2Deserializer());
+        addDeserializer(Tuple3.class, new Tuple3Deserializer());
+        addDeserializer(Tuple4.class, new Tuple4Deserializer());
+        addDeserializer(NonEmptyList.class, new NonEmptyListDeserializer());
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
@@ -1,6 +1,7 @@
 package dmx.fun.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -50,7 +51,12 @@ class EitherDeserializer extends StdDeserializer<Either> implements ContextualDe
 
     @Override
     public Either deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        p.nextToken(); // move to field name
+        if (p.currentToken() != JsonToken.START_OBJECT) {
+            throw ctxt.wrongTokenException(p, Either.class, JsonToken.START_OBJECT, "Expected object");
+        }
+        if (p.nextToken() != JsonToken.FIELD_NAME) {
+            throw ctxt.wrongTokenException(p, Either.class, JsonToken.FIELD_NAME, "Expected field name");
+        }
         String fieldName = p.currentName();
         p.nextToken(); // move to value
 
@@ -65,7 +71,13 @@ class EitherDeserializer extends StdDeserializer<Either> implements ContextualDe
             throw ctxt.weirdStringException(fieldName, Either.class, "Expected 'right' or 'left' field");
         }
 
-        p.nextToken(); // move past END_OBJECT
+        JsonToken next = p.nextToken();
+        if (next == JsonToken.FIELD_NAME) {
+            throw ctxt.weirdStringException(p.currentName(), Either.class, "Unexpected extra field");
+        }
+        if (next != JsonToken.END_OBJECT) {
+            throw ctxt.wrongTokenException(p, Either.class, JsonToken.END_OBJECT, "Expected end of object");
+        }
         return result;
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
@@ -71,12 +71,8 @@ class EitherDeserializer extends StdDeserializer<Either> implements ContextualDe
             throw ctxt.weirdStringException(fieldName, Either.class, "Expected 'right' or 'left' field");
         }
 
-        JsonToken next = p.nextToken();
-        if (next == JsonToken.FIELD_NAME) {
+        if (p.nextToken() == JsonToken.FIELD_NAME) {
             throw ctxt.weirdStringException(p.currentName(), Either.class, "Unexpected extra field");
-        }
-        if (next != JsonToken.END_OBJECT) {
-            throw ctxt.wrongTokenException(p, Either.class, JsonToken.END_OBJECT, "Expected end of object");
         }
         return result;
     }

--- a/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/EitherDeserializer.java
@@ -1,0 +1,71 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Either;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON to {@link Either}.
+ *
+ * <ul>
+ *   <li>{@code {"right": v}} → {@code Either.right(v)}</li>
+ *   <li>{@code {"left": e}}  → {@code Either.left(e)}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class EitherDeserializer extends StdDeserializer<Either> implements ContextualDeserializer {
+
+    private final @Nullable JavaType leftType;
+    private final @Nullable JavaType rightType;
+
+    EitherDeserializer() {
+        super(Either.class);
+        this.leftType = null;
+        this.rightType = null;
+    }
+
+    private EitherDeserializer(@Nullable JavaType leftType, @Nullable JavaType rightType) {
+        super(Either.class);
+        this.leftType = leftType;
+        this.rightType = rightType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 2) {
+            return new EitherDeserializer(contextualType.containedType(0), contextualType.containedType(1));
+        }
+        return this;
+    }
+
+    @Override
+    public Either deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        p.nextToken(); // move to field name
+        String fieldName = p.currentName();
+        p.nextToken(); // move to value
+
+        Either result;
+        if ("right".equals(fieldName)) {
+            Object value = rightType != null ? ctxt.readValue(p, rightType) : p.readValueAs(Object.class);
+            result = Either.right(value);
+        } else if ("left".equals(fieldName)) {
+            Object value = leftType != null ? ctxt.readValue(p, leftType) : p.readValueAs(Object.class);
+            result = Either.left(value);
+        } else {
+            throw ctxt.weirdStringException(fieldName, Either.class, "Expected 'right' or 'left' field");
+        }
+
+        p.nextToken(); // move past END_OBJECT
+        return result;
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/EitherSerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/EitherSerializer.java
@@ -1,0 +1,38 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Either;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Either} to JSON.
+ *
+ * <ul>
+ *   <li>{@code Either.right(v)} → {@code {"right": v}}</li>
+ *   <li>{@code Either.left(e)}  → {@code {"left": e}}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class EitherSerializer extends StdSerializer<Either> {
+
+    EitherSerializer() {
+        super(Either.class);
+    }
+
+    @Override
+    public void serialize(Either value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        if (value.isRight()) {
+            gen.writeFieldName("right");
+            provider.defaultSerializeValue(value.getRight(), gen);
+        } else {
+            gen.writeFieldName("left");
+            provider.defaultSerializeValue(value.getLeft(), gen);
+        }
+        gen.writeEndObject();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/NonEmptyListDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/NonEmptyListDeserializer.java
@@ -1,0 +1,65 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.NonEmptyList;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON array to {@link NonEmptyList}.
+ * Throws {@link InvalidFormatException} for empty arrays.
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class NonEmptyListDeserializer extends StdDeserializer<NonEmptyList> implements ContextualDeserializer {
+
+    private final @Nullable JavaType elementType;
+
+    NonEmptyListDeserializer() {
+        super(NonEmptyList.class);
+        this.elementType = null;
+    }
+
+    private NonEmptyListDeserializer(JavaType elementType) {
+        super(NonEmptyList.class);
+        this.elementType = elementType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() > 0) {
+            return new NonEmptyListDeserializer(contextualType.containedType(0));
+        }
+        return this;
+    }
+
+    @Override
+    public NonEmptyList deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // p is at START_ARRAY
+        List<Object> elements = new ArrayList<>();
+        while (p.nextToken() != JsonToken.END_ARRAY) {
+            Object element = elementType != null ? ctxt.readValue(p, elementType) : p.readValueAs(Object.class);
+            elements.add(element);
+        }
+
+        if (elements.isEmpty()) {
+            throw InvalidFormatException.from(p, "Cannot deserialize NonEmptyList from empty array", null, NonEmptyList.class);
+        }
+
+        Object head = elements.get(0);
+        List<Object> tail = elements.subList(1, elements.size());
+        return NonEmptyList.of(head, tail);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/NonEmptyListDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/NonEmptyListDeserializer.java
@@ -47,7 +47,9 @@ class NonEmptyListDeserializer extends StdDeserializer<NonEmptyList> implements 
 
     @Override
     public NonEmptyList deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        // p is at START_ARRAY
+        if (p.currentToken() != JsonToken.START_ARRAY) {
+            throw ctxt.wrongTokenException(p, NonEmptyList.class, JsonToken.START_ARRAY, "Expected array");
+        }
         List<Object> elements = new ArrayList<>();
         while (p.nextToken() != JsonToken.END_ARRAY) {
             Object element = elementType != null ? ctxt.readValue(p, elementType) : p.readValueAs(Object.class);

--- a/jackson/src/main/java/dmx/fun/jackson/NonEmptyListSerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/NonEmptyListSerializer.java
@@ -1,0 +1,30 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.NonEmptyList;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link NonEmptyList} to a JSON array {@code [head, ...tail]}.
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class NonEmptyListSerializer extends StdSerializer<NonEmptyList> {
+
+    NonEmptyListSerializer() {
+        super(NonEmptyList.class);
+    }
+
+    @Override
+    public void serialize(NonEmptyList value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartArray();
+        provider.defaultSerializeValue(value.head(), gen);
+        for (Object element : value.tail()) {
+            provider.defaultSerializeValue(element, gen);
+        }
+        gen.writeEndArray();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/OptionDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/OptionDeserializer.java
@@ -1,0 +1,62 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Option;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON to {@link Option}.
+ *
+ * <ul>
+ *   <li>{@code null} → {@code Option.none()}</li>
+ *   <li>any value → {@code Option.some(v)}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class OptionDeserializer extends StdDeserializer<Option> implements ContextualDeserializer {
+
+    private final @Nullable JavaType valueType;
+
+    OptionDeserializer() {
+        super(Option.class);
+        this.valueType = null;
+    }
+
+    private OptionDeserializer(JavaType valueType) {
+        super(Option.class);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() > 0) {
+            return new OptionDeserializer(contextualType.containedType(0));
+        }
+        return this;
+    }
+
+    @Override
+    public Option getNullValue(DeserializationContext ctxt) {
+        return Option.none();
+    }
+
+    @Override
+    public Option deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (valueType != null) {
+            Object value = ctxt.readValue(p, valueType);
+            return Option.some(value);
+        }
+        Object value = p.readValueAs(Object.class);
+        return Option.some(value);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/OptionSerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/OptionSerializer.java
@@ -1,0 +1,34 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Option;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Option} to JSON.
+ *
+ * <ul>
+ *   <li>{@code Option.some(v)} → {@code v} (unwrapped)</li>
+ *   <li>{@code Option.none()} → {@code null}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class OptionSerializer extends StdSerializer<Option> {
+
+    OptionSerializer() {
+        super(Option.class);
+    }
+
+    @Override
+    public void serialize(Option value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (value.isEmpty()) {
+            gen.writeNull();
+        } else {
+            provider.defaultSerializeValue(value.get(), gen);
+        }
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
@@ -1,0 +1,72 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Result;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON to {@link Result}.
+ *
+ * <ul>
+ *   <li>{@code {"ok": v}}  → {@code Result.ok(v)}</li>
+ *   <li>{@code {"err": e}} → {@code Result.err(e)}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class ResultDeserializer extends StdDeserializer<Result> implements ContextualDeserializer {
+
+    private final @Nullable JavaType valueType;
+    private final @Nullable JavaType errorType;
+
+    ResultDeserializer() {
+        super(Result.class);
+        this.valueType = null;
+        this.errorType = null;
+    }
+
+    private ResultDeserializer(@Nullable JavaType valueType, @Nullable JavaType errorType) {
+        super(Result.class);
+        this.valueType = valueType;
+        this.errorType = errorType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 2) {
+            return new ResultDeserializer(contextualType.containedType(0), contextualType.containedType(1));
+        }
+        return this;
+    }
+
+    @Override
+    public Result deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        p.nextToken(); // move to field name
+        String fieldName = p.currentName();
+        p.nextToken(); // move to value
+
+        Result result;
+        if ("ok".equals(fieldName)) {
+            Object value = valueType != null ? ctxt.readValue(p, valueType) : p.readValueAs(Object.class);
+            result = Result.ok(value);
+        } else if ("err".equals(fieldName)) {
+            Object error = errorType != null ? ctxt.readValue(p, errorType) : p.readValueAs(Object.class);
+            result = Result.err(error);
+        } else {
+            throw ctxt.weirdStringException(fieldName, Result.class, "Expected 'ok' or 'err' field");
+        }
+
+        p.nextToken(); // move past END_OBJECT
+        return result;
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
@@ -71,12 +71,8 @@ class ResultDeserializer extends StdDeserializer<Result> implements ContextualDe
             throw ctxt.weirdStringException(fieldName, Result.class, "Expected 'ok' or 'err' field");
         }
 
-        JsonToken next = p.nextToken();
-        if (next == JsonToken.FIELD_NAME) {
+        if (p.nextToken() == JsonToken.FIELD_NAME) {
             throw ctxt.weirdStringException(p.currentName(), Result.class, "Unexpected extra field");
-        }
-        if (next != JsonToken.END_OBJECT) {
-            throw ctxt.wrongTokenException(p, Result.class, JsonToken.END_OBJECT, "Expected end of object");
         }
         return result;
     }

--- a/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ResultDeserializer.java
@@ -51,7 +51,12 @@ class ResultDeserializer extends StdDeserializer<Result> implements ContextualDe
 
     @Override
     public Result deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        p.nextToken(); // move to field name
+        if (p.currentToken() != JsonToken.START_OBJECT) {
+            throw ctxt.wrongTokenException(p, Result.class, JsonToken.START_OBJECT, "Expected object");
+        }
+        if (p.nextToken() != JsonToken.FIELD_NAME) {
+            throw ctxt.wrongTokenException(p, Result.class, JsonToken.FIELD_NAME, "Expected field name");
+        }
         String fieldName = p.currentName();
         p.nextToken(); // move to value
 
@@ -66,7 +71,13 @@ class ResultDeserializer extends StdDeserializer<Result> implements ContextualDe
             throw ctxt.weirdStringException(fieldName, Result.class, "Expected 'ok' or 'err' field");
         }
 
-        p.nextToken(); // move past END_OBJECT
+        JsonToken next = p.nextToken();
+        if (next == JsonToken.FIELD_NAME) {
+            throw ctxt.weirdStringException(p.currentName(), Result.class, "Unexpected extra field");
+        }
+        if (next != JsonToken.END_OBJECT) {
+            throw ctxt.wrongTokenException(p, Result.class, JsonToken.END_OBJECT, "Expected end of object");
+        }
         return result;
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/ResultSerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ResultSerializer.java
@@ -1,0 +1,38 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Result;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Result} to JSON.
+ *
+ * <ul>
+ *   <li>{@code Result.ok(v)}  → {@code {"ok": v}}</li>
+ *   <li>{@code Result.err(e)} → {@code {"err": e}}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class ResultSerializer extends StdSerializer<Result> {
+
+    ResultSerializer() {
+        super(Result.class);
+    }
+
+    @Override
+    public void serialize(Result value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        if (value.isOk()) {
+            gen.writeFieldName("ok");
+            provider.defaultSerializeValue(value.get(), gen);
+        } else {
+            gen.writeFieldName("err");
+            provider.defaultSerializeValue(value.getError(), gen);
+        }
+        gen.writeEndObject();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/TryDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/TryDeserializer.java
@@ -1,0 +1,73 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dmx.fun.Try;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON to {@link Try}.
+ *
+ * <ul>
+ *   <li>{@code {"error": "msg"}} → {@code Try.failure(new RuntimeException("msg"))}</li>
+ *   <li>any other value → {@code Try.success(v)}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class TryDeserializer extends StdDeserializer<Try> implements ContextualDeserializer {
+
+    private final @Nullable JavaType valueType;
+
+    TryDeserializer() {
+        super(Try.class);
+        this.valueType = null;
+    }
+
+    private TryDeserializer(JavaType valueType) {
+        super(Try.class);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() > 0) {
+            return new TryDeserializer(contextualType.containedType(0));
+        }
+        return this;
+    }
+
+    @Override
+    public Try deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.currentToken() == JsonToken.START_OBJECT) {
+            ObjectNode node = p.readValueAsTree();
+            if (node.has("error")) {
+                String message = node.get("error").asText();
+                return Try.failure(new RuntimeException(message));
+            }
+            // Object that is not a failure — treat as success
+            if (valueType != null) {
+                Object value = ctxt.readTreeAsValue(node, valueType);
+                return Try.success(value);
+            }
+            return Try.success(node);
+        }
+        // Non-object token: success with value
+        if (valueType != null) {
+            Object value = ctxt.readValue(p, valueType);
+            return Try.success(value);
+        }
+        Object value = p.readValueAs(Object.class);
+        return Try.success(value);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/TryDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/TryDeserializer.java
@@ -51,7 +51,7 @@ class TryDeserializer extends StdDeserializer<Try> implements ContextualDeserial
     public Try deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         if (p.currentToken() == JsonToken.START_OBJECT) {
             ObjectNode node = p.readValueAsTree();
-            if (node.has("error")) {
+            if (node.size() == 1 && node.has("error") && node.get("error").isTextual()) {
                 String message = node.get("error").asText();
                 return Try.failure(new RuntimeException(message));
             }

--- a/jackson/src/main/java/dmx/fun/jackson/TrySerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/TrySerializer.java
@@ -1,0 +1,36 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Try;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Try} to JSON.
+ *
+ * <ul>
+ *   <li>{@code Try.success(v)}  → {@code v} (unwrapped)</li>
+ *   <li>{@code Try.failure(ex)} → {@code {"error": "message"}}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class TrySerializer extends StdSerializer<Try> {
+
+    TrySerializer() {
+        super(Try.class);
+    }
+
+    @Override
+    public void serialize(Try value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (value.isSuccess()) {
+            provider.defaultSerializeValue(value.get(), gen);
+        } else {
+            gen.writeStartObject();
+            gen.writeStringField("error", value.getCause().getMessage());
+            gen.writeEndObject();
+        }
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple2Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple2Deserializer.java
@@ -1,0 +1,57 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Tuple2;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON array {@code [a, b]} to {@link Tuple2}.
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class Tuple2Deserializer extends StdDeserializer<Tuple2> implements ContextualDeserializer {
+
+    private final @Nullable JavaType type1;
+    private final @Nullable JavaType type2;
+
+    Tuple2Deserializer() {
+        super(Tuple2.class);
+        this.type1 = null;
+        this.type2 = null;
+    }
+
+    private Tuple2Deserializer(@Nullable JavaType type1, @Nullable JavaType type2) {
+        super(Tuple2.class);
+        this.type1 = type1;
+        this.type2 = type2;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 2) {
+            return new Tuple2Deserializer(contextualType.containedType(0), contextualType.containedType(1));
+        }
+        return this;
+    }
+
+    @Override
+    public Tuple2 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        // Expect START_ARRAY
+        p.nextToken();
+        Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
+        p.nextToken(); // END_ARRAY
+        return new Tuple2<>(v1, v2);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple2Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple2Deserializer.java
@@ -3,6 +3,7 @@ package dmx.fun.jackson;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -46,12 +47,20 @@ class Tuple2Deserializer extends StdDeserializer<Tuple2> implements ContextualDe
 
     @Override
     public Tuple2 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        // Expect START_ARRAY
-        p.nextToken();
+        if (p.currentToken() != JsonToken.START_ARRAY) {
+            throw ctxt.wrongTokenException(p, Tuple2.class, JsonToken.START_ARRAY, "Expected array");
+        }
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple2 requires exactly 2 elements, got 0", null, Tuple2.class);
+        }
         Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple2 requires exactly 2 elements, got 1", null, Tuple2.class);
+        }
         Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
-        p.nextToken(); // END_ARRAY
+        if (p.nextToken() != JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple2 requires exactly 2 elements, got more", null, Tuple2.class);
+        }
         return new Tuple2<>(v1, v2);
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple2Serializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple2Serializer.java
@@ -1,0 +1,28 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Tuple2;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Tuple2} to a JSON array {@code [a, b]}.
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class Tuple2Serializer extends StdSerializer<Tuple2> {
+
+    Tuple2Serializer() {
+        super(Tuple2.class);
+    }
+
+    @Override
+    public void serialize(Tuple2 value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartArray();
+        provider.defaultSerializeValue(value._1(), gen);
+        provider.defaultSerializeValue(value._2(), gen);
+        gen.writeEndArray();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple3Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple3Deserializer.java
@@ -1,0 +1,63 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Tuple3;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON array {@code [a, b, c]} to {@link Tuple3}.
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class Tuple3Deserializer extends StdDeserializer<Tuple3> implements ContextualDeserializer {
+
+    private final @Nullable JavaType type1;
+    private final @Nullable JavaType type2;
+    private final @Nullable JavaType type3;
+
+    Tuple3Deserializer() {
+        super(Tuple3.class);
+        this.type1 = null;
+        this.type2 = null;
+        this.type3 = null;
+    }
+
+    private Tuple3Deserializer(@Nullable JavaType type1, @Nullable JavaType type2, @Nullable JavaType type3) {
+        super(Tuple3.class);
+        this.type1 = type1;
+        this.type2 = type2;
+        this.type3 = type3;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 3) {
+            return new Tuple3Deserializer(
+                contextualType.containedType(0),
+                contextualType.containedType(1),
+                contextualType.containedType(2));
+        }
+        return this;
+    }
+
+    @Override
+    public Tuple3 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        p.nextToken(); // first element
+        Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v3 = type3 != null ? ctxt.readValue(p, type3) : p.readValueAs(Object.class);
+        p.nextToken(); // END_ARRAY
+        return Tuple3.of(v1, v2, v3);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple3Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple3Deserializer.java
@@ -1,7 +1,9 @@
 package dmx.fun.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -51,13 +53,24 @@ class Tuple3Deserializer extends StdDeserializer<Tuple3> implements ContextualDe
 
     @Override
     public Tuple3 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        p.nextToken(); // first element
+        if (p.currentToken() != JsonToken.START_ARRAY) {
+            throw ctxt.wrongTokenException(p, Tuple3.class, JsonToken.START_ARRAY, "Expected array");
+        }
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple3 requires exactly 3 elements, got 0", null, Tuple3.class);
+        }
         Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple3 requires exactly 3 elements, got 1", null, Tuple3.class);
+        }
         Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple3 requires exactly 3 elements, got 2", null, Tuple3.class);
+        }
         Object v3 = type3 != null ? ctxt.readValue(p, type3) : p.readValueAs(Object.class);
-        p.nextToken(); // END_ARRAY
+        if (p.nextToken() != JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple3 requires exactly 3 elements, got more", null, Tuple3.class);
+        }
         return Tuple3.of(v1, v2, v3);
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple3Serializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple3Serializer.java
@@ -1,0 +1,29 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Tuple3;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Tuple3} to a JSON array {@code [a, b, c]}.
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class Tuple3Serializer extends StdSerializer<Tuple3> {
+
+    Tuple3Serializer() {
+        super(Tuple3.class);
+    }
+
+    @Override
+    public void serialize(Tuple3 value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartArray();
+        provider.defaultSerializeValue(value._1(), gen);
+        provider.defaultSerializeValue(value._2(), gen);
+        provider.defaultSerializeValue(value._3(), gen);
+        gen.writeEndArray();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple4Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple4Deserializer.java
@@ -1,0 +1,73 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Tuple4;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON array {@code [a, b, c, d]} to {@link Tuple4}.
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class Tuple4Deserializer extends StdDeserializer<Tuple4> implements ContextualDeserializer {
+
+    private final @Nullable JavaType type1;
+    private final @Nullable JavaType type2;
+    private final @Nullable JavaType type3;
+    private final @Nullable JavaType type4;
+
+    Tuple4Deserializer() {
+        super(Tuple4.class);
+        this.type1 = null;
+        this.type2 = null;
+        this.type3 = null;
+        this.type4 = null;
+    }
+
+    private Tuple4Deserializer(
+            @Nullable JavaType type1,
+            @Nullable JavaType type2,
+            @Nullable JavaType type3,
+            @Nullable JavaType type4) {
+        super(Tuple4.class);
+        this.type1 = type1;
+        this.type2 = type2;
+        this.type3 = type3;
+        this.type4 = type4;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 4) {
+            return new Tuple4Deserializer(
+                contextualType.containedType(0),
+                contextualType.containedType(1),
+                contextualType.containedType(2),
+                contextualType.containedType(3));
+        }
+        return this;
+    }
+
+    @Override
+    public Tuple4 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        p.nextToken(); // first element
+        Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v3 = type3 != null ? ctxt.readValue(p, type3) : p.readValueAs(Object.class);
+        p.nextToken();
+        Object v4 = type4 != null ? ctxt.readValue(p, type4) : p.readValueAs(Object.class);
+        p.nextToken(); // END_ARRAY
+        return Tuple4.of(v1, v2, v3, v4);
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple4Deserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple4Deserializer.java
@@ -1,7 +1,9 @@
 package dmx.fun.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -59,15 +61,28 @@ class Tuple4Deserializer extends StdDeserializer<Tuple4> implements ContextualDe
 
     @Override
     public Tuple4 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        p.nextToken(); // first element
+        if (p.currentToken() != JsonToken.START_ARRAY) {
+            throw ctxt.wrongTokenException(p, Tuple4.class, JsonToken.START_ARRAY, "Expected array");
+        }
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple4 requires exactly 4 elements, got 0", null, Tuple4.class);
+        }
         Object v1 = type1 != null ? ctxt.readValue(p, type1) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple4 requires exactly 4 elements, got 1", null, Tuple4.class);
+        }
         Object v2 = type2 != null ? ctxt.readValue(p, type2) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple4 requires exactly 4 elements, got 2", null, Tuple4.class);
+        }
         Object v3 = type3 != null ? ctxt.readValue(p, type3) : p.readValueAs(Object.class);
-        p.nextToken();
+        if (p.nextToken() == JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple4 requires exactly 4 elements, got 3", null, Tuple4.class);
+        }
         Object v4 = type4 != null ? ctxt.readValue(p, type4) : p.readValueAs(Object.class);
-        p.nextToken(); // END_ARRAY
+        if (p.nextToken() != JsonToken.END_ARRAY) {
+            throw InvalidFormatException.from(p, "Tuple4 requires exactly 4 elements, got more", null, Tuple4.class);
+        }
         return Tuple4.of(v1, v2, v3, v4);
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/Tuple4Serializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/Tuple4Serializer.java
@@ -1,0 +1,30 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Tuple4;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Tuple4} to a JSON array {@code [a, b, c, d]}.
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class Tuple4Serializer extends StdSerializer<Tuple4> {
+
+    Tuple4Serializer() {
+        super(Tuple4.class);
+    }
+
+    @Override
+    public void serialize(Tuple4 value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartArray();
+        provider.defaultSerializeValue(value._1(), gen);
+        provider.defaultSerializeValue(value._2(), gen);
+        provider.defaultSerializeValue(value._3(), gen);
+        provider.defaultSerializeValue(value._4(), gen);
+        gen.writeEndArray();
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
@@ -71,12 +71,8 @@ class ValidatedDeserializer extends StdDeserializer<Validated> implements Contex
             throw ctxt.weirdStringException(fieldName, Validated.class, "Expected 'valid' or 'invalid' field");
         }
 
-        JsonToken next = p.nextToken();
-        if (next == JsonToken.FIELD_NAME) {
+        if (p.nextToken() == JsonToken.FIELD_NAME) {
             throw ctxt.weirdStringException(p.currentName(), Validated.class, "Unexpected extra field");
-        }
-        if (next != JsonToken.END_OBJECT) {
-            throw ctxt.wrongTokenException(p, Validated.class, JsonToken.END_OBJECT, "Expected end of object");
         }
         return result;
     }

--- a/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
@@ -1,6 +1,7 @@
 package dmx.fun.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -50,7 +51,12 @@ class ValidatedDeserializer extends StdDeserializer<Validated> implements Contex
 
     @Override
     public Validated deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        p.nextToken(); // move to field name
+        if (p.currentToken() != JsonToken.START_OBJECT) {
+            throw ctxt.wrongTokenException(p, Validated.class, JsonToken.START_OBJECT, "Expected object");
+        }
+        if (p.nextToken() != JsonToken.FIELD_NAME) {
+            throw ctxt.wrongTokenException(p, Validated.class, JsonToken.FIELD_NAME, "Expected field name");
+        }
         String fieldName = p.currentName();
         p.nextToken(); // move to value
 
@@ -65,7 +71,13 @@ class ValidatedDeserializer extends StdDeserializer<Validated> implements Contex
             throw ctxt.weirdStringException(fieldName, Validated.class, "Expected 'valid' or 'invalid' field");
         }
 
-        p.nextToken(); // move past END_OBJECT
+        JsonToken next = p.nextToken();
+        if (next == JsonToken.FIELD_NAME) {
+            throw ctxt.weirdStringException(p.currentName(), Validated.class, "Unexpected extra field");
+        }
+        if (next != JsonToken.END_OBJECT) {
+            throw ctxt.wrongTokenException(p, Validated.class, JsonToken.END_OBJECT, "Expected end of object");
+        }
         return result;
     }
 }

--- a/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ValidatedDeserializer.java
@@ -1,0 +1,71 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import dmx.fun.Validated;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deserializes JSON to {@link Validated}.
+ *
+ * <ul>
+ *   <li>{@code {"valid": a}}   → {@code Validated.valid(a)}</li>
+ *   <li>{@code {"invalid": e}} → {@code Validated.invalid(e)}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings({"rawtypes", "unchecked"})
+class ValidatedDeserializer extends StdDeserializer<Validated> implements ContextualDeserializer {
+
+    private final @Nullable JavaType errorType;
+    private final @Nullable JavaType valueType;
+
+    ValidatedDeserializer() {
+        super(Validated.class);
+        this.errorType = null;
+        this.valueType = null;
+    }
+
+    private ValidatedDeserializer(@Nullable JavaType errorType, @Nullable JavaType valueType) {
+        super(Validated.class);
+        this.errorType = errorType;
+        this.valueType = valueType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, @Nullable BeanProperty property) {
+        JavaType contextualType = ctxt.getContextualType();
+        if (contextualType != null && contextualType.containedTypeCount() >= 2) {
+            return new ValidatedDeserializer(contextualType.containedType(0), contextualType.containedType(1));
+        }
+        return this;
+    }
+
+    @Override
+    public Validated deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        p.nextToken(); // move to field name
+        String fieldName = p.currentName();
+        p.nextToken(); // move to value
+
+        Validated result;
+        if ("valid".equals(fieldName)) {
+            Object value = valueType != null ? ctxt.readValue(p, valueType) : p.readValueAs(Object.class);
+            result = Validated.valid(value);
+        } else if ("invalid".equals(fieldName)) {
+            Object error = errorType != null ? ctxt.readValue(p, errorType) : p.readValueAs(Object.class);
+            result = Validated.invalid(error);
+        } else {
+            throw ctxt.weirdStringException(fieldName, Validated.class, "Expected 'valid' or 'invalid' field");
+        }
+
+        p.nextToken(); // move past END_OBJECT
+        return result;
+    }
+}

--- a/jackson/src/main/java/dmx/fun/jackson/ValidatedSerializer.java
+++ b/jackson/src/main/java/dmx/fun/jackson/ValidatedSerializer.java
@@ -1,0 +1,38 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import dmx.fun.Validated;
+import java.io.IOException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializes {@link Validated} to JSON.
+ *
+ * <ul>
+ *   <li>{@code Validated.valid(a)}   → {@code {"valid": a}}</li>
+ *   <li>{@code Validated.invalid(e)} → {@code {"invalid": e}}</li>
+ * </ul>
+ */
+@NullMarked
+@SuppressWarnings("rawtypes")
+class ValidatedSerializer extends StdSerializer<Validated> {
+
+    ValidatedSerializer() {
+        super(Validated.class);
+    }
+
+    @Override
+    public void serialize(Validated value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        if (value.isValid()) {
+            gen.writeFieldName("valid");
+            provider.defaultSerializeValue(value.get(), gen);
+        } else {
+            gen.writeFieldName("invalid");
+            provider.defaultSerializeValue(value.getError(), gen);
+        }
+        gen.writeEndObject();
+    }
+}

--- a/jackson/src/main/java/module-info.java
+++ b/jackson/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+/**
+ * Jackson serializers and deserializers for dmx-fun types.
+ *
+ * <p>Register all codecs by adding {@link dmx.fun.jackson.DmxFunModule} to your
+ * {@code ObjectMapper}, or rely on auto-discovery via {@code ObjectMapper.findAndRegisterModules()}.
+ */
+module dmx.fun.jackson {
+    requires dmx.fun;
+    requires com.fasterxml.jackson.databind;
+    requires org.jspecify;
+
+    exports dmx.fun.jackson;
+
+    provides com.fasterxml.jackson.databind.Module with dmx.fun.jackson.DmxFunModule;
+}

--- a/jackson/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/jackson/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+dmx.fun.jackson.DmxFunModule

--- a/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
+++ b/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
@@ -1,0 +1,523 @@
+package dmx.fun.jackson;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import dmx.fun.Either;
+import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Tuple2;
+import dmx.fun.Tuple3;
+import dmx.fun.Tuple4;
+import dmx.fun.Validated;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DmxFunModuleTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper().registerModule(new DmxFunModule());
+    }
+
+    // -------------------------------------------------------------------------
+    // Option
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class OptionTests {
+
+        @Test
+        void serializeSome() throws Exception {
+            Option<String> some = Option.some("hello");
+            String json = mapper.writeValueAsString(some);
+            assertEquals("\"hello\"", json);
+        }
+
+        @Test
+        void serializeNone() throws Exception {
+            Option<String> none = Option.none();
+            String json = mapper.writeValueAsString(none);
+            assertEquals("null", json);
+        }
+
+        @Test
+        void deserializeSome() throws Exception {
+            Option<String> result = mapper.readValue("\"world\"", new TypeReference<Option<String>>() {});
+            assertTrue(result.isDefined());
+            assertEquals("world", result.get());
+        }
+
+        @Test
+        void deserializeNone() throws Exception {
+            Option<String> result = mapper.readValue("null", new TypeReference<Option<String>>() {});
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void roundTripSome() throws Exception {
+            Option<Integer> original = Option.some(42);
+            String json = mapper.writeValueAsString(original);
+            Option<Integer> deserialized = mapper.readValue(json, new TypeReference<Option<Integer>>() {});
+            assertTrue(deserialized.isDefined());
+            assertEquals(42, deserialized.get());
+        }
+
+        @Test
+        void roundTripNone() throws Exception {
+            Option<Integer> original = Option.none();
+            String json = mapper.writeValueAsString(original);
+            Option<Integer> deserialized = mapper.readValue(json, new TypeReference<Option<Integer>>() {});
+            assertTrue(deserialized.isEmpty());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRawType_coversNullValueTypePath() throws Exception {
+            // No TypeReference → createContextual returns `this` (no type params),
+            // deserialize falls back to p.readValueAs(Object.class)
+            Option<?> result = mapper.readValue("\"raw\"", Option.class);
+            assertTrue(result.isDefined());
+            assertEquals("raw", result.get());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Result
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ResultTests {
+
+        @Test
+        void serializeOk() throws Exception {
+            Result<String, Integer> ok = Result.ok("success");
+            String json = mapper.writeValueAsString(ok);
+            assertEquals("{\"ok\":\"success\"}", json);
+        }
+
+        @Test
+        void serializeErr() throws Exception {
+            Result<String, Integer> err = Result.err(404);
+            String json = mapper.writeValueAsString(err);
+            assertEquals("{\"err\":404}", json);
+        }
+
+        @Test
+        void roundTripOk() throws Exception {
+            Result<String, Integer> original = Result.ok("hello");
+            String json = mapper.writeValueAsString(original);
+            Result<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
+            assertTrue(deserialized.isOk());
+            assertEquals("hello", deserialized.get());
+        }
+
+        @Test
+        void roundTripErr() throws Exception {
+            Result<String, Integer> original = Result.err(500);
+            String json = mapper.writeValueAsString(original);
+            Result<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
+            assertTrue(deserialized.isError());
+            assertEquals(500, deserialized.getError());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeOk_rawType_coversNullValueTypePath() throws Exception {
+            Result<?, ?> result = mapper.readValue("{\"ok\":99}", Result.class);
+            assertTrue(result.isOk());
+            assertEquals(99, result.get());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeErr_rawType_coversNullErrorTypePath() throws Exception {
+            Result<?, ?> result = mapper.readValue("{\"err\":\"oops\"}", Result.class);
+            assertTrue(result.isError());
+            assertEquals("oops", result.getError());
+        }
+
+        @Test
+        void deserializeUnknownField_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"unknown\":42}", new TypeReference<Result<Integer, String>>() {}));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Try
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class TryTests {
+
+        @Test
+        void serializeSuccess() throws Exception {
+            Try<String> success = Try.success("ok");
+            String json = mapper.writeValueAsString(success);
+            assertEquals("\"ok\"", json);
+        }
+
+        @Test
+        void serializeFailure() throws Exception {
+            Try<String> failure = Try.failure(new RuntimeException("boom"));
+            String json = mapper.writeValueAsString(failure);
+            assertEquals("{\"error\":\"boom\"}", json);
+        }
+
+        @Test
+        void roundTripSuccess() throws Exception {
+            Try<Integer> original = Try.success(99);
+            String json = mapper.writeValueAsString(original);
+            Try<Integer> deserialized = mapper.readValue(json, new TypeReference<Try<Integer>>() {});
+            assertTrue(deserialized.isSuccess());
+            assertEquals(99, deserialized.get());
+        }
+
+        @Test
+        void roundTripFailure() throws Exception {
+            Try<Integer> original = Try.failure(new RuntimeException("error message"));
+            String json = mapper.writeValueAsString(original);
+            Try<Integer> deserialized = mapper.readValue(json, new TypeReference<Try<Integer>>() {});
+            assertTrue(deserialized.isFailure());
+            assertEquals("error message", deserialized.getCause().getMessage());
+        }
+
+        @Test
+        void deserializeSuccessObject_coversReadTreeAsValuePath() throws Exception {
+            // When the JSON is a START_OBJECT with no "error" key and valueType is known,
+            // TryDeserializer calls ctxt.readTreeAsValue(node, valueType)
+            String json = "{\"name\":\"alice\"}";
+            Try<Map<String, Object>> result = mapper.readValue(json,
+                new TypeReference<Try<Map<String, Object>>>() {});
+            assertTrue(result.isSuccess());
+            assertEquals("alice", result.get().get("name"));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeSuccessObject_rawType_coversNodeReturnPath() throws Exception {
+            // START_OBJECT, no "error" key, valueType == null → returns Try.success(node)
+            Try<?> result = mapper.readValue("{\"key\":\"v\"}", Try.class);
+            assertTrue(result.isSuccess());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeSuccess_rawType_coversPrimitiveNullTypePath() throws Exception {
+            // Non-object token, valueType == null → p.readValueAs(Object.class)
+            Try<?> result = mapper.readValue("42", Try.class);
+            assertTrue(result.isSuccess());
+            assertEquals(42, result.get());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validated
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ValidatedTests {
+
+        @Test
+        void serializeValid() throws Exception {
+            Validated<String, Integer> valid = Validated.valid(42);
+            String json = mapper.writeValueAsString(valid);
+            assertEquals("{\"valid\":42}", json);
+        }
+
+        @Test
+        void serializeInvalid() throws Exception {
+            Validated<String, Integer> invalid = Validated.invalid("error");
+            String json = mapper.writeValueAsString(invalid);
+            assertEquals("{\"invalid\":\"error\"}", json);
+        }
+
+        @Test
+        void roundTripValid() throws Exception {
+            Validated<String, Integer> original = Validated.valid(7);
+            String json = mapper.writeValueAsString(original);
+            Validated<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Validated<String, Integer>>() {});
+            assertTrue(deserialized.isValid());
+            assertEquals(7, deserialized.get());
+        }
+
+        @Test
+        void roundTripInvalid() throws Exception {
+            Validated<String, Integer> original = Validated.invalid("bad input");
+            String json = mapper.writeValueAsString(original);
+            Validated<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Validated<String, Integer>>() {});
+            assertTrue(deserialized.isInvalid());
+            assertEquals("bad input", deserialized.getError());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeValid_rawType_coversNullValueTypePath() throws Exception {
+            Validated<?, ?> result = mapper.readValue("{\"valid\":7}", Validated.class);
+            assertTrue(result.isValid());
+            assertEquals(7, result.get());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeInvalid_rawType_coversNullErrorTypePath() throws Exception {
+            Validated<?, ?> result = mapper.readValue("{\"invalid\":\"e\"}", Validated.class);
+            assertTrue(result.isInvalid());
+            assertEquals("e", result.getError());
+        }
+
+        @Test
+        void deserializeUnknownField_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"unknown\":42}", new TypeReference<Validated<String, Integer>>() {}));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Either
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class EitherTests {
+
+        @Test
+        void serializeRight() throws Exception {
+            Either<String, Integer> right = Either.right(1);
+            String json = mapper.writeValueAsString(right);
+            assertEquals("{\"right\":1}", json);
+        }
+
+        @Test
+        void serializeLeft() throws Exception {
+            Either<String, Integer> left = Either.left("oops");
+            String json = mapper.writeValueAsString(left);
+            assertEquals("{\"left\":\"oops\"}", json);
+        }
+
+        @Test
+        void roundTripRight() throws Exception {
+            Either<String, Integer> original = Either.right(5);
+            String json = mapper.writeValueAsString(original);
+            Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
+            assertTrue(deserialized.isRight());
+            assertEquals(5, deserialized.getRight());
+        }
+
+        @Test
+        void roundTripLeft() throws Exception {
+            Either<String, Integer> original = Either.left("left value");
+            String json = mapper.writeValueAsString(original);
+            Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
+            assertTrue(deserialized.isLeft());
+            assertEquals("left value", deserialized.getLeft());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRight_rawType_coversNullRightTypePath() throws Exception {
+            Either<?, ?> result = mapper.readValue("{\"right\":5}", Either.class);
+            assertTrue(result.isRight());
+            assertEquals(5, result.getRight());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeLeft_rawType_coversNullLeftTypePath() throws Exception {
+            Either<?, ?> result = mapper.readValue("{\"left\":\"e\"}", Either.class);
+            assertTrue(result.isLeft());
+            assertEquals("e", result.getLeft());
+        }
+
+        @Test
+        void deserializeUnknownField_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"unknown\":42}", new TypeReference<Either<String, Integer>>() {}));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tuple2
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class Tuple2Tests {
+
+        @Test
+        void serialize() throws Exception {
+            Tuple2<String, Integer> t = new Tuple2<>("a", 1);
+            String json = mapper.writeValueAsString(t);
+            assertEquals("[\"a\",1]", json);
+        }
+
+        @Test
+        void roundTrip() throws Exception {
+            Tuple2<String, Integer> original = new Tuple2<>("hello", 42);
+            String json = mapper.writeValueAsString(original);
+            Tuple2<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Tuple2<String, Integer>>() {});
+            assertEquals("hello", deserialized._1());
+            assertEquals(42, deserialized._2());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRawType_coversNullTypePaths() throws Exception {
+            Tuple2<?, ?> result = mapper.readValue("[\"a\",1]", Tuple2.class);
+            assertEquals("a", result._1());
+            assertEquals(1, result._2());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tuple3
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class Tuple3Tests {
+
+        @Test
+        void serialize() throws Exception {
+            Tuple3<String, Integer, Boolean> t = Tuple3.of("a", 1, true);
+            String json = mapper.writeValueAsString(t);
+            assertEquals("[\"a\",1,true]", json);
+        }
+
+        @Test
+        void roundTrip() throws Exception {
+            Tuple3<String, Integer, Boolean> original = Tuple3.of("x", 10, false);
+            String json = mapper.writeValueAsString(original);
+            Tuple3<String, Integer, Boolean> deserialized = mapper.readValue(json, new TypeReference<Tuple3<String, Integer, Boolean>>() {});
+            assertEquals("x", deserialized._1());
+            assertEquals(10, deserialized._2());
+            assertEquals(false, deserialized._3());
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRawType_coversNullTypePaths() throws Exception {
+            Tuple3<?, ?, ?> result = mapper.readValue("[\"a\",1,true]", Tuple3.class);
+            assertEquals("a", result._1());
+            assertEquals(1, result._2());
+            assertEquals(true, result._3());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tuple4
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class Tuple4Tests {
+
+        @Test
+        void serialize() throws Exception {
+            Tuple4<String, Integer, Boolean, Double> t = Tuple4.of("a", 1, true, 3.14);
+            String json = mapper.writeValueAsString(t);
+            assertEquals("[\"a\",1,true,3.14]", json);
+        }
+
+        @Test
+        void roundTrip() throws Exception {
+            Tuple4<String, Integer, Boolean, Double> original = Tuple4.of("z", 7, true, 2.71);
+            String json = mapper.writeValueAsString(original);
+            Tuple4<String, Integer, Boolean, Double> deserialized = mapper.readValue(json, new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {});
+            assertEquals("z", deserialized._1());
+            assertEquals(7, deserialized._2());
+            assertEquals(true, deserialized._3());
+            assertEquals(2.71, deserialized._4(), 0.001);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRawType_coversNullTypePaths() throws Exception {
+            Tuple4<?, ?, ?, ?> result = mapper.readValue("[\"a\",1,true,3.14]", Tuple4.class);
+            assertEquals("a", result._1());
+            assertEquals(1, result._2());
+            assertEquals(true, result._3());
+            assertEquals(3.14, (double) result._4(), 0.001);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // NonEmptyList
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class NonEmptyListTests {
+
+        @Test
+        void serializeSingleElement() throws Exception {
+            NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of());
+            String json = mapper.writeValueAsString(nel);
+            assertEquals("[1]", json);
+        }
+
+        @Test
+        void serializeMultipleElements() throws Exception {
+            NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+            String json = mapper.writeValueAsString(nel);
+            assertEquals("[1,2,3]", json);
+        }
+
+        @Test
+        void roundTrip() throws Exception {
+            NonEmptyList<Integer> original = NonEmptyList.of(1, List.of(2, 3));
+            String json = mapper.writeValueAsString(original);
+            NonEmptyList<Integer> deserialized = mapper.readValue(json, new TypeReference<NonEmptyList<Integer>>() {});
+            assertEquals(1, deserialized.head());
+            assertEquals(List.of(2, 3), deserialized.tail());
+        }
+
+        @Test
+        void emptyArrayThrows() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[]", new TypeReference<NonEmptyList<Integer>>() {}));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void deserializeRawType_coversNullElementTypePath() throws Exception {
+            NonEmptyList<?> result = mapper.readValue("[1,2,3]", NonEmptyList.class);
+            assertEquals(1, result.head());
+            assertEquals(List.of(2, 3), result.tail());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ServiceLoader auto-discovery
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ServiceLoaderTests {
+
+        @Test
+        void autoDiscoveryWorksForOption() throws Exception {
+            ObjectMapper autoMapper = new ObjectMapper().findAndRegisterModules();
+            Option<String> some = Option.some("auto");
+            String json = autoMapper.writeValueAsString(some);
+            assertEquals("\"auto\"", json);
+
+            Option<String> deserialized = autoMapper.readValue("\"auto\"", new TypeReference<Option<String>>() {});
+            assertTrue(deserialized.isDefined());
+            assertEquals("auto", deserialized.get());
+        }
+
+        @Test
+        void autoDiscoveryWorksForResult() throws Exception {
+            ObjectMapper autoMapper = new ObjectMapper().findAndRegisterModules();
+            Result<String, Integer> ok = Result.ok("found");
+            String json = autoMapper.writeValueAsString(ok);
+            assertEquals("{\"ok\":\"found\"}", json);
+        }
+    }
+}

--- a/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
+++ b/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.JsonNode;
 import dmx.fun.Either;
 import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
@@ -149,8 +150,9 @@ class DmxFunModuleTest {
 
         @Test
         void deserializeUnknownField_throws() {
-            assertThrows(JsonMappingException.class, () ->
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Result<Integer, String>>() {}));
+            assertTrue(ex.getMessage().contains("unknown"));
         }
     }
 
@@ -210,6 +212,8 @@ class DmxFunModuleTest {
             // START_OBJECT, no "error" key, valueType == null → returns Try.success(node)
             Try<?> result = mapper.readValue("{\"key\":\"v\"}", Try.class);
             assertTrue(result.isSuccess());
+            assertInstanceOf(JsonNode.class, result.get());
+            assertEquals("v", ((JsonNode) result.get()).get("key").asText());
         }
 
         @Test
@@ -279,8 +283,9 @@ class DmxFunModuleTest {
 
         @Test
         void deserializeUnknownField_throws() {
-            assertThrows(JsonMappingException.class, () ->
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Validated<String, Integer>>() {}));
+            assertTrue(ex.getMessage().contains("unknown"));
         }
     }
 
@@ -341,8 +346,9 @@ class DmxFunModuleTest {
 
         @Test
         void deserializeUnknownField_throws() {
-            assertThrows(JsonMappingException.class, () ->
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Either<String, Integer>>() {}));
+            assertTrue(ex.getMessage().contains("unknown"));
         }
     }
 
@@ -518,6 +524,10 @@ class DmxFunModuleTest {
             Result<String, Integer> ok = Result.ok("found");
             String json = autoMapper.writeValueAsString(ok);
             assertEquals("{\"ok\":\"found\"}", json);
+
+            Result<String, Integer> deserialized = autoMapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
+            assertTrue(deserialized.isOk());
+            assertEquals("found", deserialized.get());
         }
     }
 }

--- a/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
+++ b/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
@@ -154,6 +154,25 @@ class DmxFunModuleTest {
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Result<Integer, String>>() {}));
             assertTrue(ex.getMessage().contains("unknown"));
         }
+
+        @Test
+        void deserializeFromNonObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("42", new TypeReference<Result<Integer, String>>() {}));
+        }
+
+        @Test
+        void deserializeEmptyObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Result<Integer, String>>() {}));
+        }
+
+        @Test
+        void deserializeExtraField_throws() {
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"ok\":1,\"extra\":2}", new TypeReference<Result<Integer, String>>() {}));
+            assertTrue(ex.getMessage().contains("extra"));
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -287,6 +306,25 @@ class DmxFunModuleTest {
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Validated<String, Integer>>() {}));
             assertTrue(ex.getMessage().contains("unknown"));
         }
+
+        @Test
+        void deserializeFromNonObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("42", new TypeReference<Validated<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeEmptyObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Validated<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeExtraField_throws() {
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"valid\":1,\"extra\":2}", new TypeReference<Validated<String, Integer>>() {}));
+            assertTrue(ex.getMessage().contains("extra"));
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -350,6 +388,25 @@ class DmxFunModuleTest {
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Either<String, Integer>>() {}));
             assertTrue(ex.getMessage().contains("unknown"));
         }
+
+        @Test
+        void deserializeFromNonObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("42", new TypeReference<Either<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeEmptyObject_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Either<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeExtraField_throws() {
+            JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{\"right\":1,\"extra\":2}", new TypeReference<Either<String, Integer>>() {}));
+            assertTrue(ex.getMessage().contains("extra"));
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -381,6 +438,30 @@ class DmxFunModuleTest {
             Tuple2<?, ?> result = mapper.readValue("[\"a\",1]", Tuple2.class);
             assertEquals("a", result._1());
             assertEquals(1, result._2());
+        }
+
+        @Test
+        void deserializeFromNonArray_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Tuple2<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_zero_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[]", new TypeReference<Tuple2<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_one_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1]", new TypeReference<Tuple2<String, Integer>>() {}));
+        }
+
+        @Test
+        void deserializeTooManyElements_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2,3]", new TypeReference<Tuple2<String, Integer>>() {}));
         }
     }
 
@@ -415,6 +496,36 @@ class DmxFunModuleTest {
             assertEquals("a", result._1());
             assertEquals(1, result._2());
             assertEquals(true, result._3());
+        }
+
+        @Test
+        void deserializeFromNonArray_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Tuple3<String, Integer, Boolean>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_zero_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[]", new TypeReference<Tuple3<String, Integer, Boolean>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_one_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1]", new TypeReference<Tuple3<String, Integer, Boolean>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_two_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2]", new TypeReference<Tuple3<String, Integer, Boolean>>() {}));
+        }
+
+        @Test
+        void deserializeTooManyElements_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2,3,4]", new TypeReference<Tuple3<String, Integer, Boolean>>() {}));
         }
     }
 
@@ -451,6 +562,42 @@ class DmxFunModuleTest {
             assertEquals(1, result._2());
             assertEquals(true, result._3());
             assertEquals(3.14, (double) result._4(), 0.001);
+        }
+
+        @Test
+        void deserializeFromNonArray_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("{}", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_zero_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[]", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_one_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1]", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_two_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2]", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
+        }
+
+        @Test
+        void deserializeTooFewElements_three_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2,3]", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
+        }
+
+        @Test
+        void deserializeTooManyElements_throws() {
+            assertThrows(InvalidFormatException.class, () ->
+                mapper.readValue("[1,2,3,4,5]", new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {}));
         }
     }
 
@@ -496,6 +643,12 @@ class DmxFunModuleTest {
             NonEmptyList<?> result = mapper.readValue("[1,2,3]", NonEmptyList.class);
             assertEquals(1, result.head());
             assertEquals(List.of(2, 3), result.tail());
+        }
+
+        @Test
+        void deserializeFromNonArray_throws() {
+            assertThrows(JsonMappingException.class, () ->
+                mapper.readValue("42", new TypeReference<NonEmptyList<Integer>>() {}));
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,3 +7,4 @@ rootProject.name = 'dmx-fun'
 includeBuild('build-logic')
 include('lib')
 include('assertj')
+include('jackson')


### PR DESCRIPTION
  New Gradle subproject `jackson` (module `dmx.fun.jackson`) providing Jackson
  serializers and deserializers for every core type in the library.

  Types covered: Option, Result, Try, Validated, Either, NonEmptyList,
  Tuple2, Tuple3, Tuple4.

  - DmxFunModule extends SimpleModule and wires all codecs; auto-discovered
    via ServiceLoader (META-INF/services + JPMS `provides` directive)
  - Each type has a dedicated serializer and contextual deserializer;
    deserializers use createContextual() to extract type parameters from
    TypeReference so generic round-trips are fully typed
  - All classes are @NullMarked; serializers/deserializers are package-private
  - 53 tests covering serialize, deserialize, round-trip, raw-type fallback
    paths, unknown-field exceptions, and ServiceLoader auto-discovery
  - 100% instruction coverage across all 19 classes

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #121

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jackson JSON support for Option, Result, Try, Validated, Either, Tuple2–Tuple4, and NonEmptyList; module auto-discovery via service provider.

* **Chores**
  * Added a dedicated Jackson module to the build and a Jackson dependency mapping (version 2.18.2).

* **Tests**
  * Comprehensive round‑trip and edge‑case tests for all supported types, including raw‑type and service‑loader discovery checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->