### PR TITLE
build: add aggregateJavadoc task for unified multi-module Javadoc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,8 @@ on:
       - 'site/**'
       - 'lib/src/test/java/codes/domix/fun/example/**'
       - 'lib/src/main/**'
+      - 'assertj/src/main/**'
+      - 'jackson/src/main/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -46,7 +48,7 @@ jobs:
         working-directory: site
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew javadoc
+        run: ./gradlew aggregateJavadoc
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,12 @@ on:
       - 'lib/src/main/**'
       - 'assertj/src/main/**'
       - 'jackson/src/main/**'
+      - '**/build.gradle'
+      - '**/build.gradle.kts'
+      - 'settings.gradle'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,68 @@
+plugins {
+    id 'java-base'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.register('aggregateJavadoc', Exec) {
+    group = 'documentation'
+    description = 'Generates aggregated multi-module Javadoc covering dmx.fun, dmx.fun.assertj, and dmx.fun.jackson.'
+
+    dependsOn ':lib:compileJava', ':assertj:compileJava', ':jackson:compileJava'
+
+    // Capture all project-relative values at configuration time
+    def javadocToolProvider = javaToolchains.javadocToolFor {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+    def libSrc     = project(':lib').file('src/main/java')
+    def assertjSrc = project(':assertj').file('src/main/java')
+    def jacksonSrc = project(':jackson').file('src/main/java')
+    def destDir    = file('build/reports/javadoc')
+    // Only external dependencies on the module-path; the three documented modules
+    // are found via --module-source-path so their artifacts must NOT appear here.
+    def internalDirs = [
+        project(':lib').projectDir.absolutePath,
+        project(':assertj').projectDir.absolutePath,
+        project(':jackson').projectDir.absolutePath,
+    ]
+    def externalDepsConfigs = [
+        project(':lib').configurations.compileClasspath,
+        project(':assertj').configurations.compileClasspath,
+        project(':jackson').configurations.compileClasspath,
+    ]
+
+    inputs.files fileTree(libSrc), fileTree(assertjSrc), fileTree(jacksonSrc)
+    outputs.dir destDir
+
+    // Build the command at execution time (configs are not yet resolved at configuration time)
+    doFirst {
+        def sep = File.pathSeparator
+
+        def modulePath = externalDepsConfigs
+            .collectMany { cfg ->
+                cfg.files.findAll { f ->
+                    !internalDirs.any { dir -> f.absolutePath.startsWith(dir) }
+                }*.absolutePath
+            }
+            .unique()
+            .join(sep)
+
+        destDir.mkdirs()
+
+        executable javadocToolProvider.get().executablePath.asFile.absolutePath
+        args '--module-path',        modulePath
+        args '--module-source-path', "dmx.fun=${libSrc.absolutePath}"
+        args '--module-source-path', "dmx.fun.assertj=${assertjSrc.absolutePath}"
+        args '--module-source-path', "dmx.fun.jackson=${jacksonSrc.absolutePath}"
+        args '--module',             'dmx.fun,dmx.fun.assertj,dmx.fun.jackson'
+        args '-d',                   destDir.absolutePath
+        args '-doctitle',            'dmx-fun API'
+        args '-windowtitle',         'dmx-fun API'
+        args '-quiet'
+        args '-notimestamp'
+    }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "copy:javadocs": "cp -r ../lib/build/docs/javadoc/ public/",
+    "copy:javadocs": "cp -r ../build/reports/javadoc/ public/",
     "predev": "npm run copy:javadocs",
     "dev": "astro dev",
     "prebuild": "npm run copy:javadocs",


### PR DESCRIPTION
  - Add root build.gradle with an aggregateJavadoc (Exec) task that calls
    the javadoc tool via the Java toolchain, passing one --module-source-path
    per module to avoid a JDK 25 multi-entry parsing ambiguity
  - Filter the --module-path to external dependencies only; the three
    documented modules (dmx.fun, dmx.fun.assertj, dmx.fun.jackson) are
    resolved through --module-source-path so their artifacts must be absent
    from the module-path to prevent duplicate-module conflicts
  - Update pages.yml: replace ./gradlew javadoc with aggregateJavadoc and
    add assertj/jackson source paths to the push trigger

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #168

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation generation pipeline to aggregate Javadocs across multiple modules, consolidating documentation into a centralized location.
  * Enhanced GitHub Pages workflow to trigger documentation rebuilds when changes are detected in additional module directories, ensuring documentation stays synchronized with code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->