### PR TITLE
build: add aggregated test and coverage reports at the root project level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ reporting {
 }
 
 tasks.named('check') {
-    dependsOn tasks.named('testAggregateTestReport', TestReport)
-    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+    dependsOn tasks.named('testAggregateTestReport')
+    dependsOn tasks.named('testCodeCoverageReport')
 }
 
 tasks.register('aggregateJavadoc', Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,41 @@
 plugins {
-    id 'java-base'
+    id 'dmx-fun.java-module'
+    id 'test-report-aggregation'
+    id 'jacoco-report-aggregation'
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
+}
+
+dependencies {
+    def modules = [
+        ':lib',
+        ':assertj',
+        ':jackson'
+    ]
+
+    modules.each {
+        testReportAggregation project(it)
+        jacocoAggregation project(it)
+    }
+}
+
+reporting {
+    reports {
+        testAggregateTestReport(AggregateTestReport) {
+        }
+        testCodeCoverageReport(JacocoCoverageReport) {
+            testSuiteName = "test"
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('testAggregateTestReport', TestReport)
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
 }
 
 tasks.register('aggregateJavadoc', Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
 plugins {
-    id 'dmx-fun.java-module'
+    id 'java-library'
+    id 'jacoco'
     id 'test-report-aggregation'
     id 'jacoco-report-aggregation'
+}
+
+repositories {
+    mavenCentral()
 }
 
 java {


### PR DESCRIPTION
  Configure test-report-aggregation and jacoco-report-aggregation plugins
  on the root project to produce a unified test report and a combined
  JaCoCo coverage report across lib, assertj, and jackson modules.
  Wire both reports into the root check task.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #164

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled aggregated test and code-coverage reporting across project modules.
  * Added a central repository declaration for dependency resolution.
  * Integrated aggregated reports into the verification flow so tests and coverage are produced during checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->