### PR TITLE
build: centralize Java version in libs.versions.toml and update Jackson to 2.21.2

### DIFF
--- a/build-logic/src/main/groovy/dmx-fun.java-base.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-base.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java-library'
+    id 'jacoco'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation libs.assertj.core
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+    }
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+    finalizedBy jacocoTestReport, javadoc
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+    }
+}
+

--- a/build-logic/src/main/groovy/dmx-fun.java-base.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-base.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
     }
 }
 

--- a/build-logic/src/main/groovy/dmx-fun.java-module.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-module.gradle
@@ -9,18 +9,16 @@ repositories {
     mavenCentral()
 }
 
-def catalog = versionCatalogs.named("libs")
-
 dependencies {
-    testImplementation(catalog.findLibrary("assertj-core").get())
-    testImplementation(platform(catalog.findLibrary("junit-bom").get()))
-    testImplementation(catalog.findLibrary("junit-jupiter").get())
-    testRuntimeOnly(catalog.findLibrary("junit-platform-launcher").get())
+    testImplementation libs.assertj.core
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
     }
 }
 
@@ -56,7 +54,7 @@ mavenPublishing {
 
     pom {
         inceptionYear = "2025"
-        url = 'https://fun.domix.codes'
+        url = 'https://domix.github.io/dmx-fun/'
         licenses {
             license {
                 name = 'The Apache License, Version 2.0'

--- a/build-logic/src/main/groovy/dmx-fun.java-module.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-module.gradle
@@ -1,25 +1,7 @@
 plugins {
-    id 'java-library'
-    id 'jacoco'
+    id 'dmx-fun.java-base'
     id 'com.github.ben-manes.versions'
     id 'com.vanniktech.maven.publish'
-}
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    testImplementation libs.assertj.core
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
 }
 
 def isNonStable = { String version ->
@@ -31,21 +13,6 @@ def isNonStable = { String version ->
 tasks.named("dependencyUpdates").configure {
     rejectVersionIf { isNonStable(it.candidate.version) }
     gradleReleaseChannel = "current"
-}
-
-test {
-    useJUnitPlatform()
-    testLogging {
-        events "passed", "skipped", "failed"
-    }
-    finalizedBy jacocoTestReport, javadoc
-}
-
-jacocoTestReport {
-    dependsOn test
-    reports {
-        xml.required = true
-    }
 }
 
 mavenPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,7 @@
 plugins {
-    id 'java-library'
-    id 'jacoco'
+    id 'dmx-fun.java-base'
     id 'test-report-aggregation'
     id 'jacoco-report-aggregation'
-}
-
-repositories {
-    mavenCentral()
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,9 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
+java = "25"
 assertj = "3.27.7"
-jackson = "2.18.2"
+jackson = "2.21.2"
 jspecify = "1.0.0"
 junit = "6.0.3"
 


### PR DESCRIPTION
  - Add java = "25" to libs.versions.toml and use it via
    libs.versions.java.get() in both the convention plugin and root
    build.gradle, so the toolchain version is defined in a single place
  - Simplify convention plugin dependency declarations by using libs.*
    accessors directly instead of going through versionCatalogs.named()
  - Update jackson to 2.21.2
  - Update project URL to https://domix.github.io/dmx-fun/

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [x] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Jackson to 2.21.2.
  * Centralized Java toolchain version into the Gradle version catalog (java = 25).
  * Updated project URL in published metadata to https://domix.github.io/dmx-fun/.
  * Consolidated build/configuration into a shared convention to standardize tooling and test/report behavior across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->