### PR TITLE
docs(guide): implement Result<V,E> guide page and fix shared table styles

### DIFF
--- a/site/src/data/code/guide/result/checking-state-switch.mdx
+++ b/site/src/data/code/guide/result/checking-state-switch.mdx
@@ -1,0 +1,10 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+switch (result) {
+    case Result.Ok<User, String>(var user) -> System.out.println("ok: " + user.name());
+    case Result.Err<User, String>(var err) -> System.out.println("err: " + err);
+}
+```

--- a/site/src/data/code/guide/result/checking-state.mdx
+++ b/site/src/data/code/guide/result/checking-state.mdx
@@ -1,0 +1,8 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+result.isSuccess()  // true if Ok
+result.isError()    // true if Err
+```

--- a/site/src/data/code/guide/result/creating-instances.mdx
+++ b/site/src/data/code/guide/result/creating-instances.mdx
@@ -1,0 +1,8 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Result<User, String> ok  = Result.ok(user);
+Result<User, String> err = Result.err("user not found");
+```

--- a/site/src/data/code/guide/result/extracting-values.mdx
+++ b/site/src/data/code/guide/result/extracting-values.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// fold — the preferred extractor: both branches are forced
+String response = result.fold(
+    user  -> "Welcome, " + user.name(),
+    error -> "Error: " + error
+);
+
+// Eager fallback
+User user = result.getOrElse(User.anonymous());
+
+// Lazy fallback (supplier called only on Err)
+User user = result.getOrElseGet(() -> userRepo.defaultUser());
+
+// Throw a domain exception when an error is a programming error
+User user = result.getOrThrow(e -> new IllegalStateException("Unexpected: " + e));
+```

--- a/site/src/data/code/guide/result/interop-conversions.mdx
+++ b/site/src/data/code/guide/result/interop-conversions.mdx
@@ -1,0 +1,18 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Result -> Option (discards the error)
+Option<User> user = result.toOption();
+
+// Result -> Try (maps error with a function)
+Try<User> tried = result.toTry(err -> new RuntimeException(err));
+
+// Result -> Either (Ok becomes right, Err becomes left)
+Either<String, User> either = result.toEither();
+
+// Option -> Result (supplies error when None)
+Result<User, String> result = Option.fromOptional(optional)
+    .toResult(() -> "not found");
+```

--- a/site/src/data/code/guide/result/pitfalls-ignoring-error.mdx
+++ b/site/src/data/code/guide/result/pitfalls-ignoring-error.mdx
@@ -1,0 +1,14 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Bad: silently discards the error track
+String name = result.getOrElse(User.anonymous()).name();
+
+// Good: make both branches explicit
+String name = result.fold(
+    user  -> user.name(),
+    error -> { log.warn("Using anonymous due to: {}", error); return "anonymous"; }
+);
+```

--- a/site/src/data/code/guide/result/pitfalls-nested.mdx
+++ b/site/src/data/code/guide/result/pitfalls-nested.mdx
@@ -1,0 +1,13 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Bad: creates Result<Result<Profile, String>, String>
+Result<Result<Profile, String>, String> nested =
+    findUser(id).map(user -> loadProfile(user));
+
+// Good: flat result
+Result<Profile, String> profile =
+    findUser(id).flatMap(user -> loadProfile(user));
+```

--- a/site/src/data/code/guide/result/real-world-example.mdx
+++ b/site/src/data/code/guide/result/real-world-example.mdx
@@ -1,0 +1,18 @@
+---
+fileName: 'OrderService.java'
+---
+
+```java
+sealed interface OrderError {
+    record InvalidItems(List<String> reasons) implements OrderError {}
+    record PaymentFailed(String code)         implements OrderError {}
+    record ShippingUnavailable(String region) implements OrderError {}
+}
+
+public Result<OrderConfirmation, OrderError> placeOrder(OrderRequest req) {
+    return validateItems(req.items())          // Result<List<Item>, OrderError>
+        .flatMap(items -> charge(req.payment(), items))  // Result<Receipt, OrderError>
+        .flatMap(receipt -> ship(req.address(), receipt)) // Result<Shipment, OrderError>
+        .map(shipment -> new OrderConfirmation(shipment.trackingId()));
+}
+```

--- a/site/src/data/code/guide/result/recovery.mdx
+++ b/site/src/data/code/guide/result/recovery.mdx
@@ -1,0 +1,13 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// recover: Err -> Ok using the error value
+Result<User, String> result =
+    findUser(id).recover(err -> User.guest());
+
+// recoverWith: Err -> Result (may itself fail)
+Result<User, String> result =
+    findUser(id).recoverWith(err -> findUserByEmail(err));
+```

--- a/site/src/data/code/guide/result/sequence-traverse.mdx
+++ b/site/src/data/code/guide/result/sequence-traverse.mdx
@@ -1,0 +1,17 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequence: List<Result<V,E>> -> Result<List<V>, E>
+// Stops at the first Err (fail-fast)
+List<Result<User, String>> lookups = ids.stream()
+    .map(userRepo::findById)
+    .toList();
+
+Result<List<User>, String> allOrFirst = Result.sequence(lookups);
+
+// traverse: applies a fallible mapper to each element and collects
+Result<List<String>, String> names =
+    Result.traverse(ids, id -> userRepo.findById(id).map(User::name));
+```

--- a/site/src/data/code/guide/result/transforming-filter.mdx
+++ b/site/src/data/code/guide/result/transforming-filter.mdx
@@ -1,0 +1,13 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Filter with a static error value
+Result<User, String> active =
+    result.filter(User::isActive, "account is inactive");
+
+// Filter with a dynamic error derived from the value
+Result<User, String> active =
+    result.filter(User::isActive, u -> "account " + u.id() + " is inactive");
+```

--- a/site/src/data/code/guide/result/transforming-flatmap.mdx
+++ b/site/src/data/code/guide/result/transforming-flatmap.mdx
@@ -1,0 +1,9 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Result<Profile, String> profile =
+    findUser(id)                       // Result<User, String>
+        .flatMap(user -> loadProfile(user)); // returns Result<Profile, String>
+```

--- a/site/src/data/code/guide/result/transforming-map-error.mdx
+++ b/site/src/data/code/guide/result/transforming-map-error.mdx
@@ -1,0 +1,9 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Translate the error type while preserving the value track
+Result<User, OrderError> translated =
+    result.mapError(msg -> new OrderError(msg));
+```

--- a/site/src/data/code/guide/result/transforming-map.mdx
+++ b/site/src/data/code/guide/result/transforming-map.mdx
@@ -1,0 +1,8 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Result<String, String> name = result.map(User::name);
+// Ok("Alice") or the original Err unchanged
+```

--- a/site/src/data/code/guide/result/transforming-peek.mdx
+++ b/site/src/data/code/guide/result/transforming-peek.mdx
@@ -1,0 +1,10 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+result
+    .peek(user  -> log.info("Processing user {}", user.id()))    // on Ok
+    .peekError(err -> log.warn("Request failed: {}", err))       // on Err
+    .map(User::name);
+```

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -494,6 +494,42 @@ const GA_MEASUREMENT_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
         padding: 0;
     }
 
+    /* Shared guide table styles */
+    .api-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.875rem;
+        margin: 1rem 0 1.5rem;
+    }
+
+    .api-table th,
+    .api-table td {
+        border: 1px solid var(--color-border);
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+        vertical-align: top;
+        line-height: 1.5;
+    }
+
+    .api-table th {
+        background-color: var(--color-surface);
+        font-weight: 700;
+        white-space: nowrap;
+    }
+
+    .api-table td code {
+        white-space: nowrap;
+    }
+
+    .table-wrap {
+        overflow-x: auto;
+        margin: 1rem 0 1.5rem;
+    }
+
+    .table-wrap .api-table {
+        margin: 0;
+    }
+
     /* Prism syntax highlighting */
     pre[class*="language-"] {
         background-color: var(--color-code-bg);

--- a/site/src/pages/guide/option.astro
+++ b/site/src/pages/guide/option.astro
@@ -112,7 +112,7 @@ const base = import.meta.env.BASE_URL;
         <section id="extracting">
             <h2>Extracting values</h2>
 
-            <table class="api-table">
+            <div class="table-wrap"><table class="api-table">
                 <thead>
                     <tr>
                         <th>Method</th>
@@ -152,7 +152,7 @@ const base = import.meta.env.BASE_URL;
                         <td>The most expressive extractor: forces you to handle both branches.</td>
                     </tr>
                 </tbody>
-            </table>
+            </table></div>
 
             <ExtractingValues/>
         </section>
@@ -232,7 +232,7 @@ const base = import.meta.env.BASE_URL;
         <section id="interop">
             <h2>Interoperability</h2>
 
-            <table class="api-table">
+            <div class="table-wrap"><table class="api-table">
                 <thead>
                     <tr><th>Conversion</th><th>Method</th></tr>
                 </thead>
@@ -245,7 +245,7 @@ const base = import.meta.env.BASE_URL;
                     <tr><td><code>Try</code> &rarr; <code>Option</code></td><td><code>tryVal.toOption()</code></td></tr>
                     <tr><td><code>Optional</code> &rarr; <code>Option</code></td><td><code>Option.fromOptional(optional)</code></td></tr>
                 </tbody>
-            </table>
+            </table></div>
 
             <InteropConversions/>
 
@@ -259,7 +259,7 @@ const base = import.meta.env.BASE_URL;
         <section id="comparison">
             <h2>Option vs null vs Optional</h2>
 
-            <table class="api-table">
+            <div class="table-wrap"><table class="api-table">
                 <thead>
                     <tr>
                         <th></th>
@@ -300,7 +300,7 @@ const base = import.meta.env.BASE_URL;
                         <td>No</td>
                     </tr>
                 </tbody>
-            </table>
+            </table></div>
         </section>
 
         <!-- Common pitfalls -->
@@ -403,32 +403,6 @@ const base = import.meta.env.BASE_URL;
     .toc li {
         line-height: 1.9;
         font-size: 0.9rem;
-    }
-
-    /* API table */
-    .api-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.875rem;
-        margin: 1rem 0 1.5rem;
-    }
-
-    .api-table th,
-    .api-table td {
-        border: 1px solid var(--color-border);
-        padding: 0.5rem 0.75rem;
-        text-align: left;
-        vertical-align: top;
-        line-height: 1.5;
-    }
-
-    .api-table th {
-        background-color: var(--color-surface);
-        font-weight: 700;
-    }
-
-    .api-table td code {
-        white-space: nowrap;
     }
 
     /* Page navigation */

--- a/site/src/pages/guide/result.astro
+++ b/site/src/pages/guide/result.astro
@@ -1,26 +1,409 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import {Content as CreatingInstances}    from '../../data/code/guide/result/creating-instances.mdx';
+import {Content as CheckingState}        from '../../data/code/guide/result/checking-state.mdx';
+import {Content as CheckingStateSwitch}  from '../../data/code/guide/result/checking-state-switch.mdx';
+import {Content as ExtractingValues}     from '../../data/code/guide/result/extracting-values.mdx';
+import {Content as TransformingMap}      from '../../data/code/guide/result/transforming-map.mdx';
+import {Content as TransformingMapError} from '../../data/code/guide/result/transforming-map-error.mdx';
+import {Content as TransformingFlatMap}  from '../../data/code/guide/result/transforming-flatmap.mdx';
+import {Content as TransformingFilter}   from '../../data/code/guide/result/transforming-filter.mdx';
+import {Content as TransformingPeek}     from '../../data/code/guide/result/transforming-peek.mdx';
+import {Content as Recovery}             from '../../data/code/guide/result/recovery.mdx';
+import {Content as SequenceTraverse}     from '../../data/code/guide/result/sequence-traverse.mdx';
+import {Content as InteropConversions}   from '../../data/code/guide/result/interop-conversions.mdx';
+import {Content as PitfallsNested}       from '../../data/code/guide/result/pitfalls-nested.mdx';
+import {Content as PitfallsIgnoringError} from '../../data/code/guide/result/pitfalls-ignoring-error.mdx';
+import {Content as RealWorldExample}     from '../../data/code/guide/result/real-world-example.mdx';
 const base = import.meta.env.BASE_URL;
 ---
-<DocsLayout title="Result" description="Developer Guide — Result">
+<DocsLayout
+    title="Result<V,E> — Developer Guide"
+    description="Comprehensive guide to Result<V,E>: modelling typed failures, transforming, composing, and real-world pipelines."
+>
     <div class="guide-content">
         <h1>Result&lt;V, E&gt;</h1>
-        <div class="coming-soon">
-            <p>This page is under active development. Full content is coming soon.</p>
-            <p>In the meantime, explore the <a href={`${base}javadoc/index.html`} target="_blank" rel="noopener">API documentation</a> or return to the <a href={`${base}guide`}>Guide index</a>.</p>
+
+        <nav class="toc" aria-label="Table of contents">
+            <ol>
+                <li><a href="#what-is-result">What is Result&lt;V, E&gt;?</a></li>
+                <li><a href="#creating">Creating instances</a></li>
+                <li><a href="#checking-state">Checking state</a></li>
+                <li><a href="#extracting">Extracting values</a></li>
+                <li><a href="#transforming">Transforming values</a></li>
+                <li><a href="#recovery">Recovery and fallbacks</a></li>
+                <li><a href="#sequence-traverse">sequence and traverse</a></li>
+                <li><a href="#interop">Interoperability</a></li>
+                <li><a href="#comparison">Result vs Try vs exceptions</a></li>
+                <li><a href="#pitfalls">Common pitfalls</a></li>
+                <li><a href="#real-world">Real-world example</a></li>
+            </ol>
+        </nav>
+
+        <!-- What is Result<V,E>? -->
+        <section id="what-is-result">
+            <h2>What is Result&lt;V, E&gt;?</h2>
+            <p>
+                <code>Result&lt;V, E&gt;</code> models a computation that either succeeds with a value of type <code>V</code>
+                or fails with a <strong>typed error</strong> of type <code>E</code>.
+                It is a sealed interface with two implementations:
+            </p>
+            <ul>
+                <li><code>Ok&lt;V, E&gt;</code> — holds a non-null success value.</li>
+                <li><code>Err&lt;V, E&gt;</code> — holds a non-null typed error.</li>
+            </ul>
+            <p>
+                The key distinction from <code>Try&lt;V&gt;</code> is that the error type is
+                <em>explicit and domain-specific</em> — not a raw <code>Throwable</code>.
+                This forces callers to acknowledge the error domain and handle it by type,
+                rather than catching a generic exception.
+            </p>
+            <p>
+                Use <code>Result</code> when you <em>own the error type</em> and callers need to
+                branch on it. Use <code>Try</code> when wrapping legacy or third-party code that throws.
+            </p>
+        </section>
+
+        <!-- Creating instances -->
+        <section id="creating">
+            <h2>Creating instances</h2>
+            <CreatingInstances/>
+            <p>
+                Both <code>Ok</code> and <code>Err</code> reject <code>null</code> — pass a non-null
+                value. If the success case has no meaningful value, use <code>Result&lt;Void, E&gt;</code>
+                with <code>Result.ok(null)</code> not applicable — use a sentinel like
+                <code>Result.ok(Boolean.TRUE)</code> or a dedicated unit type instead.
+            </p>
+        </section>
+
+        <!-- Checking state -->
+        <section id="checking-state">
+            <h2>Checking state</h2>
+            <p>Predicates are available, but prefer structural operations in most cases:</p>
+            <CheckingState/>
+            <p>Use <strong>exhaustive pattern matching</strong> in a switch expression to handle both tracks:</p>
+            <CheckingStateSwitch/>
+        </section>
+
+        <!-- Extracting values -->
+        <section id="extracting">
+            <h2>Extracting values</h2>
+
+            <div class="table-wrap"><table class="api-table">
+                <thead>
+                    <tr>
+                        <th>Method</th>
+                        <th>When <code>Err</code></th>
+                        <th>Notes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>get()</code></td>
+                        <td>Throws <code>NoSuchElementException</code></td>
+                        <td>Only safe after an <code>isSuccess()</code> check; prefer alternatives.</td>
+                    </tr>
+                    <tr>
+                        <td><code>getOrElse(fallback)</code></td>
+                        <td>Returns <code>fallback</code></td>
+                        <td>Fallback is always evaluated — use <code>getOrElseGet</code> for expensive defaults.</td>
+                    </tr>
+                    <tr>
+                        <td><code>getOrElseGet(supplier)</code></td>
+                        <td>Calls supplier</td>
+                        <td>Lazily computed fallback.</td>
+                    </tr>
+                    <tr>
+                        <td><code>getOrNull()</code></td>
+                        <td>Returns <code>null</code></td>
+                        <td>Bridge to null-expecting APIs. Avoid propagating the null further.</td>
+                    </tr>
+                    <tr>
+                        <td><code>getOrThrow(exMapper)</code></td>
+                        <td>Throws exception from mapper</td>
+                        <td>Maps the error to an exception — good for domain boundary re-throws.</td>
+                    </tr>
+                    <tr>
+                        <td><code>fold(onSuccess, onError)</code></td>
+                        <td>Calls <code>onError</code></td>
+                        <td>The most expressive extractor: forces both tracks to be handled.</td>
+                    </tr>
+                </tbody>
+            </table></div>
+
+            <ExtractingValues/>
+        </section>
+
+        <!-- Transforming values -->
+        <section id="transforming">
+            <h2>Transforming values</h2>
+
+            <h3><code>map(mapper)</code></h3>
+            <p>
+                Transforms the success value. The error track passes through unchanged.
+            </p>
+            <TransformingMap/>
+
+            <h3><code>mapError(mapper)</code></h3>
+            <p>
+                Transforms the error value. The success track passes through unchanged.
+                Useful for translating between error domains at architectural boundaries.
+            </p>
+            <TransformingMapError/>
+
+            <h3><code>flatMap(mapper)</code></h3>
+            <p>
+                Like <code>map</code>, but the mapper itself returns a <code>Result</code>.
+                Use this to chain fallible operations without nesting.
+            </p>
+            <TransformingFlatMap/>
+
+            <h3><code>filter(predicate, error)</code></h3>
+            <p>
+                Converts an <code>Ok</code> to <code>Err</code> when the predicate fails.
+                Accepts a static error value or a function that derives the error from the value.
+            </p>
+            <TransformingFilter/>
+
+            <h3><code>peek</code> / <code>peekError</code></h3>
+            <p>
+                Side-effecting operations (logging, metrics) that do not alter the <code>Result</code>.
+                Return <code>this</code> for chaining.
+            </p>
+            <TransformingPeek/>
+
+            <h3><code>match(onSuccess, onError)</code></h3>
+            <p>
+                Terminal side-effecting variant of <code>fold</code>. Both consumers return void.
+                Use for logging, metrics, or dispatching to side-effecting systems.
+            </p>
+        </section>
+
+        <!-- Recovery and fallbacks -->
+        <section id="recovery">
+            <h2>Recovery and fallbacks</h2>
+            <p>
+                Recovery operations convert an <code>Err</code> back to an <code>Ok</code>
+                by inspecting the error value.
+            </p>
+            <Recovery/>
+            <p>
+                For a simple static fallback without inspecting the error, use <code>orElse</code>:
+            </p>
+        </section>
+
+        <!-- sequence and traverse -->
+        <section id="sequence-traverse">
+            <h2><code>sequence</code> and <code>traverse</code></h2>
+            <p>
+                Both operations apply <strong>fail-fast semantics</strong>: they stop at the first
+                <code>Err</code> and return it immediately, without consuming the rest of the stream.
+                This is implemented internally with a Stream Gatherer.
+            </p>
+            <SequenceTraverse/>
+            <p>
+                If you need all results regardless of failure, use <code>Result.partitioningBy()</code>
+                as a <code>Collector</code> — it separates <code>Ok</code> values and errors into
+                two lists, consuming the entire stream.
+            </p>
+        </section>
+
+        <!-- Interoperability -->
+        <section id="interop">
+            <h2>Interoperability</h2>
+
+            <div class="table-wrap"><table class="api-table">
+                <thead>
+                    <tr><th>Conversion</th><th>Method</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>Result</code> &rarr; <code>Option</code></td><td><code>result.toOption()</code></td></tr>
+                    <tr><td><code>Result</code> &rarr; <code>Try</code></td><td><code>result.toTry(errorMapper)</code></td></tr>
+                    <tr><td><code>Result</code> &rarr; <code>Either</code></td><td><code>result.toEither()</code></td></tr>
+                    <tr><td><code>Result</code> &rarr; <code>CompletableFuture</code></td><td><code>result.toFuture()</code></td></tr>
+                    <tr><td><code>Option</code> &rarr; <code>Result</code></td><td><code>option.toResult(errorSupplier)</code></td></tr>
+                    <tr><td><code>Try</code> &rarr; <code>Result</code></td><td><code>tryVal.toResult()</code></td></tr>
+                    <tr><td><code>Optional</code> &rarr; <code>Result</code></td><td><code>Result.fromOptional(optional)</code></td></tr>
+                    <tr><td><code>CompletableFuture</code> &rarr; <code>Result</code></td><td><code>Result.fromFuture(future)</code></td></tr>
+                </tbody>
+            </table></div>
+
+            <InteropConversions/>
+
+            <p>
+                See the <a href={`${base}guide/combining-types`}>Combining Types</a> page for the full
+                conversion matrix and composition patterns.
+            </p>
+        </section>
+
+        <!-- Comparison table -->
+        <section id="comparison">
+            <h2>Result vs Try vs exceptions</h2>
+
+            <div class="table-wrap"><table class="api-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Exceptions</th>
+                        <th><code>Try&lt;V&gt;</code></th>
+                        <th><code>Result&lt;V, E&gt;</code></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Error type</td>
+                        <td><code>Throwable</code> — implicit</td>
+                        <td><code>Throwable</code> — explicit value</td>
+                        <td>Any type — explicit and domain-specific</td>
+                    </tr>
+                    <tr>
+                        <td>Forces handling</td>
+                        <td>Only checked exceptions</td>
+                        <td>Yes — via API</td>
+                        <td>Yes — via API and switch patterns</td>
+                    </tr>
+                    <tr>
+                        <td>Branch on error subtype</td>
+                        <td>Via <code>catch</code> clauses</td>
+                        <td>Via <code>instanceof</code></td>
+                        <td>Via sealed subtype and switch patterns</td>
+                    </tr>
+                    <tr>
+                        <td>Interop with throwing code</td>
+                        <td>Native</td>
+                        <td>Excellent — <code>Try.of(() -&gt; ...)</code></td>
+                        <td>Indirect — wrap with Try first</td>
+                    </tr>
+                    <tr>
+                        <td>Best for</td>
+                        <td>Truly exceptional situations</td>
+                        <td>Wrapping legacy/third-party code</td>
+                        <td>Domain logic with typed failure modes</td>
+                    </tr>
+                </tbody>
+            </table></div>
+        </section>
+
+        <!-- Common pitfalls -->
+        <section id="pitfalls">
+            <h2>Common pitfalls</h2>
+
+            <h3>Nested Results</h3>
+            <p>
+                <code>Result&lt;Result&lt;V, E&gt;, E&gt;</code> almost always indicates a mistake.
+                Use <code>flatMap</code> instead of <code>map</code> when the mapper returns a <code>Result</code>.
+            </p>
+            <PitfallsNested/>
+
+            <h3>Ignoring the error track</h3>
+            <p>
+                Calling <code>getOrElse</code> silently discards the error.
+                Use <code>fold</code> or <code>match</code> to make both branches explicit,
+                especially in production code paths.
+            </p>
+            <PitfallsIgnoringError/>
+
+            <h3>Using Result for truly exceptional situations</h3>
+            <p>
+                If the error represents a bug or unrecoverable system failure (out of memory, corrupted state),
+                an exception is still the right tool. <code>Result</code> is for expected,
+                recoverable failure modes that callers are designed to handle.
+            </p>
+
+            <h3>Result as a method parameter</h3>
+            <p>
+                Like <code>Option</code>, <code>Result</code> is designed for <em>return types</em>.
+                Prefer overloaded methods or a nullable/typed parameter over a
+                <code>Result</code>-typed parameter.
+            </p>
+        </section>
+
+        <!-- Real-world example -->
+        <section id="real-world">
+            <h2>Real-world example</h2>
+            <p>
+                A typed order placement pipeline. Each step is a fallible operation returning
+                a domain-specific error — the compiler enforces that every error case is handled
+                at the call site.
+            </p>
+            <RealWorldExample/>
+            <p>
+                Every step propagates its <code>Err</code> automatically via <code>flatMap</code>.
+                The caller receives a single <code>Result&lt;OrderConfirmation, OrderError&gt;</code>
+                and branches on the sealed <code>OrderError</code> subtypes.
+            </p>
+        </section>
+
+        <div class="page-nav">
+            <a href={`${base}guide/option`}>&larr; Option&lt;T&gt;</a>
+            <a href={`${base}guide/try`}>Try&lt;V&gt; &rarr;</a>
         </div>
     </div>
 </DocsLayout>
+
 <style>
-    .guide-content { max-width: 800px; }
-    h1 { border-bottom: 2px solid var(--color-border); padding-bottom: 0.5rem; }
-    .coming-soon {
-        background-color: var(--color-surface);
-        padding: 1.5rem;
-        border-radius: 8px;
-        border-left: 4px solid var(--color-primary);
-        margin: 2rem 0;
+    .guide-content {
+        max-width: 860px;
     }
-    .coming-soon p { margin: 0 0 0.75rem; line-height: 1.7; }
-    .coming-soon p:last-child { margin-bottom: 0; }
+
+    h1 {
+        border-bottom: 2px solid var(--color-border);
+        padding-bottom: 0.5rem;
+    }
+
+    h2 {
+        margin-top: 3rem;
+        border-bottom: 1px solid var(--color-border);
+        padding-bottom: 0.5rem;
+    }
+
+    h3 {
+        margin-top: 1.75rem;
+        margin-bottom: 0.5rem;
+    }
+
+    p {
+        line-height: 1.7;
+    }
+
+    ul {
+        line-height: 1.8;
+    }
+
+    /* TOC */
+    .toc {
+        background-color: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        padding: 1.25rem 1.5rem;
+        margin: 2rem 0;
+        display: inline-block;
+        min-width: 260px;
+    }
+
+    .toc ol {
+        margin: 0;
+        padding-left: 1.25rem;
+    }
+
+    .toc li {
+        line-height: 1.9;
+        font-size: 0.9rem;
+    }
+
+    /* Page navigation */
+    .page-nav {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 4rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-size: 0.9rem;
+    }
+
+    @media (max-width: 600px) {
+        .toc {
+            display: block;
+        }
+    }
 </style>


### PR DESCRIPTION
  Add a comprehensive Result<V,E> guide page (issue #132) with 15 MDX
  code snippets covering all sections: factory methods, state predicates,
  value extraction, transformations, recovery, sequence/traverse, interop,
  comparison table, pitfalls, and a real-world order pipeline example.

  Move .api-table styles to DocsLayout as global rules and introduce a
  .table-wrap div with overflow-x: auto so all guide tables render
  consistently across pages and remain scrollable on narrow screens

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #132

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Result type developer guide with detailed sections on creating instances, checking state with pattern matching, extracting and transforming values, error recovery mechanisms, batch operations, interoperability conversions, common pitfall patterns, and a practical real-world order-placement example.
  * Enhanced API table styling across documentation pages for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->