### PR TITLE
docs(guide): implement Validated<E,A> guide page with MDX code snippets (closes #134)

### DIFF
--- a/site/src/data/code/guide/validated/checking-state.mdx
+++ b/site/src/data/code/guide/validated/checking-state.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Validated<String, Integer> v = Validated.valid(42);
+
+v.isValid();   // true
+v.isInvalid(); // false
+
+// Exhaustive pattern matching — preferred
+String msg = switch (v) {
+    case Validated.Valid<String, Integer>   ok  -> "Value: "  + ok.value();
+    case Validated.Invalid<String, Integer> err -> "Error: "  + err.error();
+};
+```

--- a/site/src/data/code/guide/validated/combining.mdx
+++ b/site/src/data/code/guide/validated/combining.mdx
@@ -1,0 +1,33 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Validated<List<String>, String>  nameV  = validateName(req.name());
+Validated<List<String>, Integer> ageV   = validateAge(req.age());
+Validated<List<String>, String>  emailV = validateEmail(req.email());
+
+// combine(other, errMerge, valueMerge)
+// Argument order: other → errMerge → valueMerge
+Validated<List<String>, UserForm> form =
+    nameV.combine(
+        ageV,
+        (e1, e2) -> { var merged = new ArrayList<>(e1); merged.addAll(e2); return merged; },
+        (name, age) -> new UserForm(name, age)
+    )
+    .combine(
+        emailV,
+        (e1, e2) -> { var merged = new ArrayList<>(e1); merged.addAll(e2); return merged; },
+        (partial, email) -> partial.withEmail(email)
+    );
+
+// With NonEmptyList error type the merge is just NonEmptyList::concat
+Validated<NonEmptyList<String>, UserForm> nel =
+    Validated.invalidNel("name required")
+        .combine(
+            Validated.invalidNel("age must be positive"),
+            NonEmptyList::concat,
+            (name, age) -> new UserForm(name, age)
+        );
+// nel.getError() → NonEmptyList["name required", "age must be positive"]
+```

--- a/site/src/data/code/guide/validated/creating-instances.mdx
+++ b/site/src/data/code/guide/validated/creating-instances.mdx
@@ -1,0 +1,15 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Successful result
+Validated<String, Integer> valid   = Validated.valid(42);
+
+// Failed result — the error type is explicit
+Validated<String, Integer> invalid = Validated.invalid("must be positive");
+
+// NEL convenience: wraps the error in a singleton NonEmptyList
+// Use this when combining multiple validations so errors accumulate naturally
+Validated<NonEmptyList<String>, Integer> nelInvalid = Validated.invalidNel("must be positive");
+```

--- a/site/src/data/code/guide/validated/extracting-values.mdx
+++ b/site/src/data/code/guide/validated/extracting-values.mdx
@@ -1,0 +1,24 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Validated<String, Integer> v = parse(input);
+
+// fold — the most expressive extractor; forces both branches
+String rendered = v.fold(
+    value -> "Parsed: " + value,
+    error -> "Invalid: " + error
+);
+
+// Safe fallbacks (inherited from Bicontainer)
+int n = v.getOrElse(0);
+int m = v.getOrElseGet(() -> computeDefault());
+
+// Unsafe accessors — throw NoSuchElementException on the wrong track
+int  val = v.get();       // throws if Invalid
+String e = v.getError();  // throws if Valid
+
+// Rethrow as RuntimeException with a custom mapper
+int forced = v.getOrThrow(err -> new IllegalArgumentException(err));
+```

--- a/site/src/data/code/guide/validated/interop-conversions.mdx
+++ b/site/src/data/code/guide/validated/interop-conversions.mdx
@@ -1,0 +1,28 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Validated<String, Integer> v = parseAge(input);
+
+// Validated → Result (Valid→Ok, Invalid→Err)
+Result<Integer, String> result = v.toResult();
+
+// Validated → Try (requires mapping the error to a Throwable)
+Try<Integer> t = v.toTry(err -> new IllegalArgumentException(err));
+
+// Validated → Either (Valid→right, Invalid→left)
+Either<String, Integer> either = v.toEither();
+
+// Validated → Option (discards the error)
+Option<Integer> opt = v.toOption();
+
+// Result → Validated
+Validated<String, Integer> fromResult = Validated.fromResult(result);
+
+// Option → Validated (supply error for the None case)
+Validated<String, Integer> fromOption = Validated.fromOption(opt, "value missing");
+
+// Try → Validated (map exception to error type)
+Validated<String, Integer> fromTry = Validated.fromTry(t, Throwable::getMessage);
+```

--- a/site/src/data/code/guide/validated/nel-pattern.mdx
+++ b/site/src/data/code/guide/validated/nel-pattern.mdx
@@ -1,0 +1,23 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// invalidNel wraps a single error in a NonEmptyList — errors accumulate via NonEmptyList::concat
+Validated<NonEmptyList<String>, String>  nameV  = Validated.invalidNel("name is required");
+Validated<NonEmptyList<String>, Integer> ageV   = Validated.invalidNel("age must be positive");
+Validated<NonEmptyList<String>, String>  emailV = Validated.valid("user@example.com");
+
+Validated<NonEmptyList<String>, RegistrationForm> result =
+    nameV.combine(ageV,   NonEmptyList::concat, (n, a)    -> new PartialForm(n, a))
+         .combine(emailV, NonEmptyList::concat, (pf, em)  -> new RegistrationForm(pf, em));
+
+// result.getError() → NonEmptyList["name is required", "age must be positive"]
+
+// sequenceNel and traverseNel are shorthand — no need to pass the merger
+List<String> rawEmails = List.of("a@b.com", "bad-email", "c@d.com", "also-bad");
+
+Validated<NonEmptyList<String>, List<String>> emails =
+    Validated.traverseNel(rawEmails, email -> validateEmail(email));
+// → Invalid(NonEmptyList["bad-email: invalid format", "also-bad: invalid format"])
+```

--- a/site/src/data/code/guide/validated/pitfalls-combine-order.mdx
+++ b/site/src/data/code/guide/validated/pitfalls-combine-order.mdx
@@ -1,0 +1,15 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// combine(other, errMerge, valueMerge)
+//           ^^^  ^^^^^^^^^  ^^^^^^^^^^^
+//           1st     2nd         3rd
+
+// Bad: arguments in the wrong order — does not compile or produces wrong result
+v1.combine(v2, (a, b) -> new Form(a, b), NonEmptyList::concat); // ← swapped!
+
+// Good: errMerge is ALWAYS the second argument, valueMerge is ALWAYS third
+v1.combine(v2, NonEmptyList::concat, (a, b) -> new Form(a, b));
+```

--- a/site/src/data/code/guide/validated/pitfalls-flatmap.mdx
+++ b/site/src/data/code/guide/validated/pitfalls-flatmap.mdx
@@ -1,0 +1,23 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Bad: flatMap does NOT accumulate — it short-circuits on the first Invalid
+Validated<String, Form> form =
+    validateName(req.name())
+        .flatMap(name -> validateAge(req.age()))   // stops here if name is invalid
+        .flatMap(age  -> validateEmail(req.email())); // never reached if name or age fails
+
+// Good: use combine for independent validations so all errors are collected
+Validated<NonEmptyList<String>, Form> form =
+    Validated.invalidNel(validateName(req.name()).getError())
+        .combine(Validated.invalidNel(validateAge(req.age()).getError()),
+                 NonEmptyList::concat,
+                 (name, age) -> new Form(name, age));
+
+// flatMap is correct only when the second validation depends on the first
+Validated<String, Address> address =
+    validateCountry(req.country())
+        .flatMap(country -> validatePostalCode(req.postalCode(), country));
+```

--- a/site/src/data/code/guide/validated/real-world-example.mdx
+++ b/site/src/data/code/guide/validated/real-world-example.mdx
@@ -1,0 +1,47 @@
+---
+fileName: 'RegistrationService.java'
+---
+
+```java
+// Each field validation returns Validated<NonEmptyList<String>, T>
+// All run independently — all errors are collected
+
+Validated<NonEmptyList<String>, String> nameV =
+    Optional.ofNullable(req.name())
+        .filter(s -> !s.isBlank())
+        .map(Validated::<NonEmptyList<String>, String>valid)
+        .orElseGet(() -> Validated.invalidNel("name is required"));
+
+Validated<NonEmptyList<String>, String> emailV =
+    Optional.ofNullable(req.email())
+        .filter(EMAIL_PATTERN.asPredicate())
+        .map(Validated::<NonEmptyList<String>, String>valid)
+        .orElseGet(() -> Validated.invalidNel("email is invalid"));
+
+Validated<NonEmptyList<String>, Integer> ageV =
+    Try.of(() -> Integer.parseInt(req.age()))
+        .toResult(ex -> NonEmptyList.singleton("age must be a number"))
+        .flatMap(n -> n >= 18
+            ? Result.ok(n)
+            : Result.err(NonEmptyList.singleton("must be 18 or older")))
+        .fold(Validated::valid, Validated::invalid);
+
+Validated<NonEmptyList<String>, String> passwordV =
+    Optional.ofNullable(req.password())
+        .filter(p -> p.length() >= 8)
+        .map(Validated::<NonEmptyList<String>, String>valid)
+        .orElseGet(() -> Validated.invalidNel("password must be at least 8 characters"));
+
+// Combine all — all fields are evaluated; all errors are accumulated
+Validated<NonEmptyList<String>, RegistrationForm> form =
+    nameV
+        .combine(emailV,    NonEmptyList::concat, (n, e)    -> new PartialForm(n, e))
+        .combine(ageV,      NonEmptyList::concat, (pf, a)   -> pf.withAge(a))
+        .combine(passwordV, NonEmptyList::concat, (pf, pwd) -> new RegistrationForm(pf, pwd));
+
+// At the call site
+form.fold(
+    registration -> userService.register(registration),
+    errors       -> Response.unprocessable(errors.toList())
+);
+```

--- a/site/src/data/code/guide/validated/sequence-traverse.mdx
+++ b/site/src/data/code/guide/validated/sequence-traverse.mdx
@@ -1,0 +1,31 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+List<Validated<String, Integer>> items = List.of(
+    Validated.valid(1),
+    Validated.invalid("too small"),
+    Validated.valid(3),
+    Validated.invalid("too large")
+);
+
+// sequence: accumulates ALL errors — does not short-circuit
+BinaryOperator<String> joinErrors = (a, b) -> a + "; " + b;
+
+Validated<String, List<Integer>> result = Validated.sequence(items, joinErrors);
+// → Invalid("too small; too large")
+
+// traverse: map + accumulate in one step
+Validated<String, List<Integer>> parsed =
+    Validated.traverse(
+        List.of("1", "bad", "3", "worse"),
+        s -> parsePositive(s),
+        joinErrors
+    );
+// → Invalid("bad: not a number; worse: not a number")
+
+// As a Stream Collector — composable with other stream operations
+Validated<String, List<Integer>> collected =
+    items.stream().collect(Validated.collector(joinErrors));
+```

--- a/site/src/data/code/guide/validated/transforming.mdx
+++ b/site/src/data/code/guide/validated/transforming.mdx
@@ -1,0 +1,18 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Validated<String, Integer> v = parse(input);
+
+// map — transforms the value; Invalid passes through
+Validated<String, String> hex = v.map(Integer::toHexString);
+
+// mapError — transforms the error; Valid passes through
+Validated<AppError, Integer> typed = v.mapError(msg -> new AppError(msg));
+
+// flatMap — fail-fast sequential composition (does NOT accumulate)
+// Use only when the second validation depends on the first
+Validated<String, Address> address = validateCity(input)
+    .flatMap(city -> validateZip(input, city)); // zip depends on city
+```

--- a/site/src/data/guide/validated.mdx
+++ b/site/src/data/guide/validated.mdx
@@ -1,13 +1,162 @@
 ---
 title: "Validated<E,A> — Developer Guide"
-description: "Developer Guide — Validated<E,A>: accumulating errors instead of short-circuiting."
+description: "Comprehensive guide to Validated<E,A>: accumulating errors, combining independent validations, and the NonEmptyList pattern."
 order: 4
 h1: "Validated<E, A>"
 ---
 
-export const base = import.meta.env.BASE_URL;
+import {Content as CreatingInstances}   from '../code/guide/validated/creating-instances.mdx';
+import {Content as CheckingState}       from '../code/guide/validated/checking-state.mdx';
+import {Content as ExtractingValues}    from '../code/guide/validated/extracting-values.mdx';
+import {Content as Transforming}        from '../code/guide/validated/transforming.mdx';
+import {Content as Combining}           from '../code/guide/validated/combining.mdx';
+import {Content as NelPattern}          from '../code/guide/validated/nel-pattern.mdx';
+import {Content as SequenceTraverse}    from '../code/guide/validated/sequence-traverse.mdx';
+import {Content as InteropConversions}  from '../code/guide/validated/interop-conversions.mdx';
+import {Content as PitfallsCombineOrder} from '../code/guide/validated/pitfalls-combine-order.mdx';
+import {Content as PitfallsFlatMap}     from '../code/guide/validated/pitfalls-flatmap.mdx';
+import {Content as RealWorldExample}    from '../code/guide/validated/real-world-example.mdx';
 
-<div class="coming-soon">
-  <p>This page is under active development. Full content is coming soon.</p>
-  <p>In the meantime, explore the <a href={`${base}javadoc/index.html`} target="_blank" rel="noopener">API documentation</a> or return to the <a href={`${base}guide`}>Guide index</a>.</p>
-</div>
+## What is Validated&lt;E, A&gt;?
+
+`Validated<E, A>` models a validation result that either succeeds with a value
+of type `A` or fails with an error of type `E`.
+It is a sealed interface with two implementations:
+
+- `Valid<E, A>` — holds a non-null success value.
+- `Invalid<E, A>` — holds a non-null error.
+
+The defining feature of `Validated` is **error accumulation**: unlike `Result`,
+which stops at the first error (fail-fast), `Validated` is designed to run all
+independent validations and collect _every_ error before returning.
+This makes it the right choice for form validation, config parsing, and any
+scenario where callers need a complete list of problems, not just the first one.
+
+Use `Validated` when you need **all errors reported at once**.
+Use `Result` when the first error is enough and further computation is meaningless.
+
+## Creating instances
+
+<CreatingInstances/>
+
+Both `Valid` and `Invalid` reject `null`. The `invalidNel` factory is the
+preferred starting point when you plan to combine multiple validations — it
+wraps the error in a `NonEmptyList` so errors can be merged with
+`NonEmptyList::concat`. See the [NonEmptyList pattern](#the-nonemptylist-nel-pattern) section.
+
+## Checking state
+
+<CheckingState/>
+
+Prefer exhaustive switch patterns — the compiler enforces that both tracks are handled.
+
+## Extracting values
+
+| Method                        | When `Invalid`                      | Notes                                                          |
+|-------------------------------|-------------------------------------|----------------------------------------------------------------|
+| `get()`                       | Throws `NoSuchElementException`     | Only safe after an `isValid()` check; prefer alternatives.     |
+| `getError()`                  | N/A — throws if `Valid`             | Retrieves the error; unsafe on the valid track.                |
+| `getOrElse(fallback)`         | Returns `fallback`                  | Fallback is always evaluated eagerly.                          |
+| `getOrElseGet(supplier)`      | Calls supplier                      | Lazily computed fallback.                                      |
+| `getOrNull()`                 | Returns `null`                      | Bridge to null-expecting APIs.                                 |
+| `getOrThrow(exMapper)`        | Throws mapped `RuntimeException`    | Maps the error to an exception at the call site.               |
+| `fold(onValid, onInvalid)`    | Calls `onInvalid`                   | The most expressive extractor: forces both tracks to be handled. |
+
+<ExtractingValues/>
+
+## Transforming values
+
+<Transforming/>
+
+`flatMap` is available but applies **fail-fast** semantics — it does _not_
+accumulate errors. Use it only when the second validation logically depends on
+the first. For independent validations, always use `combine`.
+
+## Combining independent validations
+
+`combine(other, errMerge, valueMerge)` is the core of error accumulation.
+Both this and `other` are always evaluated. When both are `Invalid`, their
+errors are merged by `errMerge`. When both are `Valid`, the values are merged
+by `valueMerge`.
+
+**Argument order — easy to swap accidentally:**
+
+```
+combine(other, errMerge, valueMerge)
+         ^^^  ^^^^^^^^^  ^^^^^^^^^^^
+         1st     2nd         3rd
+```
+
+<Combining/>
+
+`product(other, errMerge)` is the lower-level variant that returns
+`Validated<E, Tuple2<A, B>>` instead of applying a value merger.
+Use `combine` in most cases.
+
+## The NonEmptyList (NEL) pattern
+
+Using `NonEmptyList<E>` as the error type is the idiomatic way to accumulate
+multiple errors. The `invalidNel`, `sequenceNel`, and `traverseNel` factory
+methods eliminate the need to pass `NonEmptyList::concat` manually.
+
+<NelPattern/>
+
+## Accumulating over collections
+
+`sequence` and `traverse` run **all** elements — they do not short-circuit on
+the first `Invalid`. All errors are merged left-to-right using `errMerge`.
+
+<SequenceTraverse/>
+
+A `Collector` variant is available via `Validated.collector(errMerge)` and
+`Validated.traverseCollector(mapper, errMerge)`, compatible with parallel
+streams and the standard `Stream.collect` API.
+
+## Interoperability
+
+| Conversion                           | Method                                         |
+|--------------------------------------|------------------------------------------------|
+| `Validated` → `Result`               | `v.toResult()`                                 |
+| `Validated` → `Try`                  | `v.toTry(errorMapper)`                         |
+| `Validated` → `Either`               | `v.toEither()`                                 |
+| `Validated` → `Option`               | `v.toOption()`                                 |
+| `Result` → `Validated`               | `Validated.fromResult(result)`                 |
+| `Option` → `Validated`               | `Validated.fromOption(option, errorIfNone)`    |
+| `Try` → `Validated`                  | `Validated.fromTry(t, errorMapper)`            |
+
+<InteropConversions/>
+
+See the [Combining Types](combining-types) page for the full conversion matrix.
+
+## Validated vs Result — when to use each
+
+| Scenario                                         | Use              |
+|--------------------------------------------------|------------------|
+| Stop at the first error; further steps depend on success | `Result`  |
+| Collect all errors; report everything at once    | `Validated`      |
+| Wrap throwing legacy code                        | `Try`            |
+| Independent field validations (form, config)     | `Validated`      |
+| Pipeline where each step feeds the next          | `Result`         |
+
+## Common pitfalls
+
+### Wrong argument order in `combine`
+
+`errMerge` is the **second** argument; `valueMerge` is the **third**.
+Swapping them is a common mistake because both are `BiFunction`-like arguments.
+
+<PitfallsCombineOrder/>
+
+### Using `flatMap` instead of `combine` for independent validations
+
+`flatMap` short-circuits — it stops at the first `Invalid`.
+Use `combine` when the validations are independent and all errors should be reported.
+
+<PitfallsFlatMap/>
+
+## Real-world example
+
+A user registration form: name, email, age, and password are all validated
+independently. All errors are accumulated and returned in a single response.
+
+<RealWorldExample/>


### PR DESCRIPTION
  Add a comprehensive Validated<E,A> guide at src/data/guide/validated.mdx with
  11 sections covering creating instances, checking state, extracting values,
  transforming (map/mapError/flatMap), combining independent validations with the
  correct combine(other, errMerge, valueMerge) argument order, the NonEmptyList
  pattern (invalidNel/sequenceNel/traverseNel), sequence/traverse/collector,
  interoperability, a Validated vs Result decision table, common pitfalls, and a
  real-world registration form example. All code snippets are externalized as
  individual MDX files under src/data/code/guide/validated/. Tables use Markdown
  syntax.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #134

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the `Validated` pattern, including detailed explanations and code examples for creating instances, checking state, extracting values, transforming, combining multiple validations, error accumulation with NonEmptyList, sequence/traverse operations, interoperability conversions with other types, common pitfalls, and a real-world registration validation example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->