### PR TITLE
docs(guide): add Combining Types cross-composition guide (#138)

### DIFF
--- a/site/src/data/code/guide/combining-types/antipattern.mdx
+++ b/site/src/data/code/guide/combining-types/antipattern.mdx
@@ -1,0 +1,30 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Bad: unnecessary chain of conversions — each conversion loses information
+// and makes the pipeline harder to follow.
+Result<String, AppError> result =
+    Try.of(() -> fetchValue())
+       .toOption()                          // discards the exception — why?
+       .toTry(() -> new RuntimeException()) // re-wraps into a less informative exception
+       .toResult(AppError::from);           // finally converts to Result
+
+// Good: stay in Try and convert directly to Result at the end
+Result<String, AppError> result2 =
+    Try.of(() -> fetchValue())
+       .toResult(AppError::from);
+
+// Bad: converting to Option mid-pipeline just to call getOrElseGet
+String value = Try.of(() -> fetchValue())
+    .toOption()                             // exception silently discarded
+    .getOrElseGet(() -> "default");
+
+// Good: use Try's own recovery methods — the exception is still accessible
+String value2 = Try.of(() -> fetchValue())
+    .getOrElse("default");
+// or, if you need the exception:
+String value3 = Try.of(() -> fetchValue())
+    .recover(ex -> "default (error: " + ex.getMessage() + ")");
+```

--- a/site/src/data/code/guide/combining-types/conversion-cheat-sheet.mdx
+++ b/site/src/data/code/guide/combining-types/conversion-cheat-sheet.mdx
@@ -1,0 +1,31 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Option<T> → Result<T, E>
+Result<String, String> r1 = option.toResult("value was absent");
+// or with a computed error:
+Result<String, AppError> r2 = option.fold(Result::ok, () -> Result.err(AppError.MISSING));
+
+// Option<T> → Try<T>
+Try<String> t1 = option.toTry(() -> new NoSuchElementException("absent"));
+
+// Try<T> → Result<T, Throwable>
+Result<String, Throwable> r3 = tryValue.toResult();
+
+// Try<T> → Result<T, E>  (map the exception to a domain error)
+Result<String, AppError> r4 = tryValue.toResult(ex -> AppError.from(ex));
+
+// Try<T> → Option<T>
+Option<String> o1 = tryValue.toOption(); // Some on success, None on failure
+
+// Result<T, E> → Option<T>  (discards the error)
+Option<String> o2 = result.toOption();   // Some(value) or None
+
+// Result<T, E> → Try<T>
+Try<String> t2 = result.toTry(AppError::toException);
+
+// Validated<E, A> → Result<A, E>
+Result<UserForm, List<String>> r5 = validated.toResult();
+```

--- a/site/src/data/code/guide/combining-types/pattern-chain-types.mdx
+++ b/site/src/data/code/guide/combining-types/pattern-chain-types.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Chain Option → Try → Result in a single pipeline.
+// Convert at the boundary where the next operation's type demands it.
+
+Option<Config>   config = configStore.load();          // absent = not configured
+
+// Option → Try: treat absence as an exceptional state for this path
+Try<Connection> conn = config
+    .toTry(() -> new MissingConfigException("database config not found"))
+    .flatMap(cfg -> Try.of(() -> DataSource.connect(cfg.dbUrl())));
+
+// Try → Result: surface a domain error to the caller
+Result<Data, String> data = conn
+    .toResult(ex -> "Connection failed: " + ex.getMessage())
+    .flatMap(c -> fetchData(c));   // fetchData returns Result<Data, String>
+```

--- a/site/src/data/code/guide/combining-types/pattern-fanout-tuple.mdx
+++ b/site/src/data/code/guide/combining-types/pattern-fanout-tuple.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Run two independent validated computations and combine their results
+// into a Tuple2 — errors from both are accumulated via NonEmptyList::concat.
+
+Validated<NonEmptyList<String>, Email>    emailV    = validateEmail(req.email());
+Validated<NonEmptyList<String>, Username> usernameV = validateUsername(req.username());
+
+Validated<NonEmptyList<String>, Tuple2<Email, Username>> combined =
+    emailV.combine(usernameV, NonEmptyList::concat, Tuple2::new);
+
+// Collapse the tuple into a domain object once both values are valid
+Validated<NonEmptyList<String>, UserDraft> draft =
+    emailV.combine(usernameV, NonEmptyList::concat,
+        (email, username) -> new UserDraft(email, username));
+```

--- a/site/src/data/code/guide/combining-types/pattern-traverse.mdx
+++ b/site/src/data/code/guide/combining-types/pattern-traverse.mdx
@@ -1,0 +1,25 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Option.traverse — apply a function that may return None; short-circuits on first None
+List<Long> userIds = List.of(1L, 2L, 3L);
+
+Option<List<User>> users = Option.traverse(userIds, id -> userRepo.findById(id));
+// Some([user1, user2, user3]) if all are found; None if any id is missing
+
+// Result.traverse — apply a function that may return Err; short-circuits on first Err
+List<String> orderRefs = List.of("ORD-1", "ORD-2", "ORD-3");
+
+Result<List<Order>, String> orders =
+    Result.traverse(orderRefs, ref -> orderService.load(ref));
+// Ok([order1, order2, order3]) if all succeed; Err("...") on first failure
+
+// Try.traverse — apply a checked operation to each element; stops on first exception
+List<Path> paths = List.of(Paths.get("a.txt"), Paths.get("b.txt"));
+
+Try<List<String>> contents =
+    Try.traverse(paths, path -> Try.of(() -> Files.readString(path)));
+// Success([...]) if all reads succeed; Failure(IOException) on first error
+```

--- a/site/src/data/code/guide/combining-types/pattern-validate-then-persist.mdx
+++ b/site/src/data/code/guide/combining-types/pattern-validate-then-persist.mdx
@@ -1,0 +1,23 @@
+---
+fileName: 'UserService.java'
+---
+
+```java
+// Validate with Validated — accumulate ALL errors, then hand off to the
+// repository which speaks Result (fail-fast, single error path).
+
+public Result<User, List<String>> register(RegistrationRequest req) {
+
+    Validated<NonEmptyList<String>, RegistrationForm> validation =
+        validateEmail(req.email())
+            .combine(validatePassword(req.password()), NonEmptyList::concat, RegistrationForm::new);
+
+    // Convert Validated → Result before hitting the database
+    return switch (validation) {
+        case Validated.Valid<?, RegistrationForm>(var form) ->
+            userRepository.save(form);          // returns Result<User, List<String>>
+        case Validated.Invalid<NonEmptyList<String>, ?>(var errors) ->
+            Result.err(errors.toList());        // surface all validation errors
+    };
+}
+```

--- a/site/src/data/code/guide/combining-types/pattern-wrap-legacy.mdx
+++ b/site/src/data/code/guide/combining-types/pattern-wrap-legacy.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Wrap a legacy checked API with Try, then convert to Result at the service boundary.
+// The caller receives a typed domain error — not a raw exception.
+
+Result<Report, AppError> report =
+    Try.of(() -> legacyReportService.generate(params))   // CheckedSupplier
+       .toResult(ex -> AppError.from("report-generation-failed", ex));
+
+// The same pattern for Optional-returning legacy APIs:
+Result<Config, AppError> config =
+    Try.of(() -> legacyConfigLoader.load())              // may throw or return null
+       .flatMap(cfg -> cfg != null
+           ? Try.success(cfg)
+           : Try.failure(new MissingConfigException()))
+       .toResult(AppError::from);
+```

--- a/site/src/data/guide/combining-types.mdx
+++ b/site/src/data/guide/combining-types.mdx
@@ -1,13 +1,99 @@
 ---
 title: "Combining Types — Developer Guide"
-description: "Developer Guide — Combining Types: conversion matrix and composition patterns across Option, Result, Try, and Either."
+description: "Recipes for composing Option, Result, Try, Validated, and Either together: conversion cheat sheet, pipeline patterns, traverse, and anti-patterns."
 order: 10
 h1: "Combining Types"
 ---
 
-export const base = import.meta.env.BASE_URL;
+import {Content as ConversionCheatSheet}       from '../code/guide/combining-types/conversion-cheat-sheet.mdx';
+import {Content as PatternValidateThenPersist} from '../code/guide/combining-types/pattern-validate-then-persist.mdx';
+import {Content as PatternChainTypes}          from '../code/guide/combining-types/pattern-chain-types.mdx';
+import {Content as PatternFanoutTuple}         from '../code/guide/combining-types/pattern-fanout-tuple.mdx';
+import {Content as PatternTraverse}            from '../code/guide/combining-types/pattern-traverse.mdx';
+import {Content as PatternWrapLegacy}          from '../code/guide/combining-types/pattern-wrap-legacy.mdx';
+import {Content as Antipattern}                from '../code/guide/combining-types/antipattern.mdx';
 
-<div class="coming-soon">
-  <p>This page is under active development. Full content is coming soon.</p>
-  <p>In the meantime, explore the <a href={`${base}javadoc/index.html`} target="_blank" rel="noopener">API documentation</a> or return to the <a href={`${base}guide`}>Guide index</a>.</p>
-</div>
+Each type in dmx-fun solves a specific problem in isolation. Real applications
+combine them: a `Validated` pipeline feeds a `Result`-based repository; a `Try`
+wraps a legacy API before being converted to `Option` for a lookup; a
+`NonEmptyList` carries errors collected by `Validated.traverseNel`.
+
+This page covers the conversion paths between types, common composition patterns,
+and the anti-patterns to avoid.
+
+## Type conversion cheat sheet
+
+| From                  | To                        | Method                                          |
+|-----------------------|---------------------------|-------------------------------------------------|
+| `Option<T>`           | `Result<T, E>`            | `option.toResult(errorIfNone)`                  |
+| `Option<T>`           | `Try<T>`                  | `option.toTry(exceptionSupplier)`               |
+| `Try<T>`              | `Result<T, Throwable>`    | `tryValue.toResult()`                           |
+| `Try<T>`              | `Result<T, E>`            | `tryValue.toResult(errorMapper)`                |
+| `Try<T>`              | `Option<T>`               | `tryValue.toOption()`                           |
+| `Result<T, E>`        | `Option<T>`               | `result.toOption()`                             |
+| `Result<T, E>`        | `Try<T>`                  | `result.toTry(errorToThrowable)`                |
+| `Validated<E, A>`     | `Result<A, E>`            | `validated.toResult()`                          |
+
+<ConversionCheatSheet/>
+
+**General rule**: stay in one type for as long as possible, and convert only at
+the boundary where the next operation demands a different type. Each conversion
+may discard information (e.g. `toOption()` silently drops the error).
+
+## Pattern: validate then persist
+
+Use `Validated` to accumulate all errors up front, then convert to `Result`
+before calling the repository or service that operates in fail-fast mode.
+
+<PatternValidateThenPersist/>
+
+`Validated` is the right tool for the validation layer because it accumulates
+every error. `Result` is right for the persistence layer because there is only
+one error path (database failure). Converting at the boundary keeps each layer
+in its natural type.
+
+## Pattern: chain across types
+
+Convert at the exact point where the next operation's type demands it —
+not earlier.
+
+<PatternChainTypes/>
+
+## Pattern: fan-out with `Validated` and `Tuple`
+
+Run two or more independent validations in parallel and combine their results.
+If either is invalid, all errors are accumulated.
+
+<PatternFanoutTuple/>
+
+## Pattern: `traverse` across a collection
+
+`Option.traverse`, `Result.traverse`, and `Try.traverse` apply a function to
+every element of a collection and collect the results into a single wrapper.
+All three short-circuit on the first failure.
+
+<PatternTraverse/>
+
+For `Validated` (which does **not** short-circuit), use `Validated.traverseNel`
+to accumulate errors from every element — see the
+[NonEmptyList guide](/guide/non-empty-list) for details.
+
+## Pattern: wrapping legacy APIs with `Try`
+
+Wrap any checked or null-returning legacy API with `Try`, then convert to your
+domain's error type at the service boundary.
+
+<PatternWrapLegacy/>
+
+## Anti-pattern: unnecessary conversions
+
+Convert only when the next operation requires a different type. Converting
+through multiple types in a single pipeline usually means the wrong type was
+chosen at the start, or that an exception is being silently discarded.
+
+<Antipattern/>
+
+**Rule of thumb**: if you are converting `Try → Option` just to call
+`getOrElseGet`, use `Try.getOrElse` or `Try.recover` directly. If you are
+converting `Result → Try → Result`, there is likely a missing method on `Result`
+— check the API first.


### PR DESCRIPTION
  Add complete guide covering inter-type conversion and composition patterns
  for Option, Result, Try, Validated, and Either, including a conversion cheat
  sheet table, five concrete patterns (validate-then-persist, chain across types,
  fan-out with Tuple, traverse, wrap-legacy-API), and an anti-pattern section
  on unnecessary conversions.

  Externalize all code snippets into seven dedicated MDX files under
  src/data/code/guide/combining-types/ following the same pattern as other guide pages.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #138

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
