### PR TITLE
docs(guide): add Performance guide page and fix introduction links (#170)

### DIFF
--- a/site/src/data/code/guide/performance/jmh-skeleton.mdx
+++ b/site/src/data/code/guide/performance/jmh-skeleton.mdx
@@ -1,0 +1,38 @@
+---
+fileName: 'ResultAllocationBenchmark.java'
+---
+
+```java
+// Minimal JMH skeleton for benchmarking a dmx-fun type.
+// Only submit this alongside a real profiler trace that shows the library
+// as a hot spot — do not benchmark in isolation without application context.
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+public class ResultAllocationBenchmark {
+
+    private int value;
+
+    @Setup
+    public void setup() {
+        value = ThreadLocalRandom.current().nextInt(1, 100);
+    }
+
+    @Benchmark
+    public Result<Integer, String> resultOk() {
+        return Result.ok(value);
+    }
+
+    @Benchmark
+    public int baseline() {
+        return value; // cost of returning a raw int — the lower bound
+    }
+}
+// Run: java -jar benchmarks.jar ResultAllocationBenchmark -prof gc
+// Include the output, JVM version (-version), and flags (-XX:+PrintFlagsFinal)
+// when opening an issue.
+```

--- a/site/src/data/guide/introduction.mdx
+++ b/site/src/data/guide/introduction.mdx
@@ -7,6 +7,8 @@ h1: "Introduction"
 
 import {Content as TasteOfComposition} from '../code/guide/introduction/taste-of-composition.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 ## What is dmx-fun?
 
 **dmx-fun** is a functional programming toolkit for **Java 25+**. It fills the
@@ -46,15 +48,15 @@ without `instanceof` boilerplate, and with destructuring built in.
 
 | Type                    | One-liner                                                  | Guide                              |
 |-------------------------|------------------------------------------------------------|------------------------------------|
-| `Option<T>`             | A value that may or may not be present                     | [Option guide](/guide/option)      |
-| `Result<V, E>`          | Either a success value or a typed domain error             | [Result guide](/guide/result)      |
-| `Try<V>`                | A computation that may throw, turned into a value          | [Try guide](/guide/try)            |
-| `Validated<E, A>`       | Like Result, but accumulates all errors instead of one     | [Validated guide](/guide/validated)|
-| `Either<L, R>`          | A neutral disjoint union — neither side means failure      | [Either guide](/guide/either)      |
-| `Lazy<T>`               | A value computed at most once, cached after first access   | [Lazy guide](/guide/lazy)          |
-| `Tuple2/3/4`            | Typed heterogeneous groupings without a named class        | [Tuples guide](/guide/tuples)      |
-| `NonEmptyList<T>`       | A list with at least one element, enforced at compile time | [NEL guide](/guide/non-empty-list) |
-| Checked interfaces      | `CheckedFunction`, `TriFunction`, `QuadFunction`, and more | [Checked interfaces guide](/guide/checked-interfaces) |
+| `Option<T>`             | A value that may or may not be present                     | <a href={`${base}guide/option`}>Option guide</a>      |
+| `Result<V, E>`          | Either a success value or a typed domain error             | <a href={`${base}guide/result`}>Result guide</a>      |
+| `Try<V>`                | A computation that may throw, turned into a value          | <a href={`${base}guide/try`}>Try guide</a>            |
+| `Validated<E, A>`       | Like Result, but accumulates all errors instead of one     | <a href={`${base}guide/validated`}>Validated guide</a>|
+| `Either<L, R>`          | A neutral disjoint union — neither side means failure      | <a href={`${base}guide/either`}>Either guide</a>      |
+| `Lazy<T>`               | A value computed at most once, cached after first access   | <a href={`${base}guide/lazy`}>Lazy guide</a>          |
+| `Tuple2/3/4`            | Typed heterogeneous groupings without a named class        | <a href={`${base}guide/tuples`}>Tuples guide</a>      |
+| `NonEmptyList<T>`       | A list with at least one element, enforced at compile time | <a href={`${base}guide/non-empty-list`}>NEL guide</a> |
+| Checked interfaces      | `CheckedFunction`, `TriFunction`, `QuadFunction`, and more | <a href={`${base}guide/checked-interfaces`}>Checked interfaces guide</a> |
 
 ## How to read this guide
 
@@ -68,8 +70,10 @@ Each type page follows the same structure:
 6. **Common pitfalls** — the mistakes made most often
 7. **Real-world example** — a concrete, idiomatic usage
 
-Types interoperate — the [Combining Types](/guide/combining-types) page covers the
+Types interoperate — the <a href={`${base}guide/combining-types`}>Combining Types</a> page covers the
 full conversion matrix and cross-type composition patterns.
+
+For performance expectations and design trade-offs, see the <a href={`${base}guide/performance`}>Performance</a> page.
 
 ## A taste of composition
 

--- a/site/src/data/guide/performance.mdx
+++ b/site/src/data/guide/performance.mdx
@@ -1,0 +1,85 @@
+---
+title: "Performance — Developer Guide"
+description: "Performance characteristics of dmx-fun types: why allocation cost is negligible for most code, the two cases where overhead could be observable, and how to report a real performance concern."
+order: 11
+h1: "Performance"
+---
+
+import {Content as JmhSkeleton} from '../code/guide/performance/jmh-skeleton.mdx';
+
+dmx-fun prioritises correctness, type safety, and API ergonomics over raw
+throughput. This page documents what that means in practice, where the two
+observable cost areas are, and how to approach a performance concern if one
+arises.
+
+## Why dmx-fun types are fast enough for most use cases
+
+`Option`, `Result`, `Try`, `Either`, and `Validated` are implemented as
+**sealed interfaces with record variants**. The JVM treats small, short-lived
+records aggressively:
+
+- **Scalar replacement**: the JIT can decompose a record allocation into local
+  variables on the stack, eliminating heap allocation entirely in hot loops.
+- **Inlining**: single-method interfaces (the common case for `map`/`flatMap`
+  lambdas) are inlined after a small number of call-site observations.
+- **Escape analysis**: a `Result.ok(v)` that does not escape the current method
+  frame is optimised away by the JIT — the wrapper never reaches the heap.
+
+In practice, the cost of wrapping a value in `Result.ok(v)` is
+**not measurable against the surrounding I/O, database access, or serialization**
+that makes up the vast majority of application latency. These types are designed
+for use at those boundaries, not inside tight numeric loops.
+
+## Where overhead could be observable
+
+Two specific operations may show measurable cost under extreme conditions:
+
+| Type / operation                               | Condition                                   | Reason                                                        |
+|------------------------------------------------|---------------------------------------------|---------------------------------------------------------------|
+| `Lazy<T>.get()`                                | Very high concurrent thread contention      | Internal `synchronized` block (double-checked locking)        |
+| `Validated.sequence` / `Validated.traverse`    | Collections larger than ~10 000 elements    | Repeated `NonEmptyList::concat` copies the error list on each merge |
+
+**`Lazy<T>` under contention**: the `volatile` read on the happy path (already
+evaluated) is cheap. Cost only appears when many threads race to evaluate the
+same `Lazy` simultaneously. In typical usage — application-scoped singletons
+initialised once at startup — this is never a concern.
+
+**`Validated` over large collections**: `traverseNel` with `NonEmptyList::concat`
+as the error merger creates a new list on every merge of two `Invalid` results.
+For collections of a few hundred or even a few thousand elements this is
+negligible. At very large scales (tens of thousands of elements, all invalid),
+the quadratic copy cost may be visible. In that scenario, consider batching
+the input or streaming errors into a `List` builder instead.
+
+## Why there is no general benchmark suite
+
+The project deliberately does not ship a JMH benchmark suite. The reasons:
+
+- **Micro-benchmarks measure JIT behaviour as much as library code.** Results
+  for thin wrapper types are highly sensitive to JVM version, GC flags, warmup
+  duration, and surrounding context. A number produced in isolation is rarely
+  transferable to a real application.
+- **The value proposition is correctness, not throughput.** A benchmark showing
+  `Result.ok(42)` costs 3 ns more than `return 42` is not actionable — the
+  question is whether that difference is visible in your application's profiler
+  trace, not in a synthetic loop.
+- **Maintenance cost.** Benchmarks must be kept in sync with every API change.
+  That cost is justified when a benchmark is tied to a concrete regression; it
+  is not justified as speculative infrastructure.
+
+The right signal is a **real-world profiler trace** identifying a dmx-fun type
+as a hot spot. That has not been reported.
+
+## How to report a performance concern
+
+If profiling a real application identifies a dmx-fun type as a bottleneck, open
+a GitHub issue with:
+
+1. A reproducible JMH benchmark or profiler output (flame graph / allocation profile).
+2. The JVM version (`java -version`) and relevant flags.
+3. The specific operation, collection size, and concurrency level involved.
+
+A targeted benchmark and optimisation will be scoped from that evidence. The
+skeleton below can be used as a starting point for a JMH report:
+
+<JmhSkeleton/>


### PR DESCRIPTION
  Add a Performance guide page documenting why dmx-fun types are fast enough
  for most use cases (JVM scalar replacement, escape analysis, inlining), the
  two specific areas where overhead could be observable (Lazy<T> under thread
  contention, Validated.traverse over very large collections), the rationale
  for not shipping a general JMH benchmark suite, and instructions for
  reporting a real performance concern with a JMH skeleton snippet.

  Fix all internal guide links in introduction.mdx to use import.meta.env.BASE_URL
  so they resolve correctly under the configured /dmx-fun/ base path.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #170

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
