### PR TITLE
docs(guide): add Jackson integration guide and Modules section in index (#167)

### DIFF
--- a/site/src/data/code/guide/jackson/dependency.mdx
+++ b/site/src/data/code/guide/jackson/dependency.mdx
@@ -1,0 +1,24 @@
+---
+fileName: 'build.gradle / pom.xml'
+---
+
+```groovy
+// Gradle
+implementation("codes.domix:fun-jackson:0.0.12")
+// Jackson itself — bring your own version (2.13.x – 2.21.x)
+implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-jackson</artifactId>
+    <version>0.0.12</version>
+</dependency>
+<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.21.2</version>
+</dependency>
+```

--- a/site/src/data/code/guide/jackson/registration.mdx
+++ b/site/src/data/code/guide/jackson/registration.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Manual registration
+ObjectMapper mapper = new ObjectMapper()
+    .registerModule(new DmxFunModule());
+
+// Auto-discovery (recommended) — works because DmxFunModule is registered
+// as a com.fasterxml.jackson.databind.Module service provider via META-INF
+ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+// Spring Boot — register as a bean; Spring auto-applies it to the mapper
+@Bean
+public DmxFunModule dmxFunModule() {
+    return new DmxFunModule();
+}
+```

--- a/site/src/data/code/guide/jackson/roundtrip-option.mdx
+++ b/site/src/data/code/guide/jackson/roundtrip-option.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+// Serialize
+String some = mapper.writeValueAsString(Option.some("hello")); // "hello"
+String none = mapper.writeValueAsString(Option.none());        // null
+
+// Deserialize — TypeReference required to carry the type parameter
+Option<String> opt = mapper.readValue("\"hello\"",
+    new TypeReference<Option<String>>() {});
+// Some("hello")
+
+Option<String> absent = mapper.readValue("null",
+    new TypeReference<Option<String>>() {});
+// None
+```

--- a/site/src/data/code/guide/jackson/roundtrip-other.mdx
+++ b/site/src/data/code/guide/jackson/roundtrip-other.mdx
@@ -1,0 +1,36 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+// Validated
+String valid   = mapper.writeValueAsString(Validated.valid(42));         // {"valid":42}
+String invalid = mapper.writeValueAsString(Validated.invalid("bad"));    // {"invalid":"bad"}
+
+Validated<String, Integer> v = mapper.readValue("{\"valid\":42}",
+    new TypeReference<Validated<String, Integer>>() {});
+// Valid(42)
+
+// Either
+String right = mapper.writeValueAsString(Either.right("ok")); // {"right":"ok"}
+String left  = mapper.writeValueAsString(Either.left("err")); // {"left":"err"}
+
+Either<String, String> e = mapper.readValue("{\"right\":\"ok\"}",
+    new TypeReference<Either<String, String>>() {});
+// Right("ok")
+
+// Tuple2 / Tuple3 / Tuple4 — serialized as JSON arrays
+String t2 = mapper.writeValueAsString(new Tuple2<>("Alice", 30));             // ["Alice",30]
+String t3 = mapper.writeValueAsString(Tuple3.of("Alice", 30, true));          // ["Alice",30,true]
+String t4 = mapper.writeValueAsString(Tuple4.of("Alice", 30, true, 1.75));    // ["Alice",30,true,1.75]
+
+// NonEmptyList — serialized as a JSON array
+String nel = mapper.writeValueAsString(
+    NonEmptyList.of("a", List.of("b", "c")));    // ["a","b","c"]
+
+NonEmptyList<String> nelBack = mapper.readValue("[\"a\",\"b\",\"c\"]",
+    new TypeReference<NonEmptyList<String>>() {});
+// NonEmptyList["a","b","c"]
+```

--- a/site/src/data/code/guide/jackson/roundtrip-result.mdx
+++ b/site/src/data/code/guide/jackson/roundtrip-result.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+// Serialize
+String ok  = mapper.writeValueAsString(Result.ok(42));        // {"ok":42}
+String err = mapper.writeValueAsString(Result.err("oops"));   // {"err":"oops"}
+
+// Deserialize
+Result<Integer, String> okResult = mapper.readValue("{\"ok\":42}",
+    new TypeReference<Result<Integer, String>>() {});
+// Ok(42)
+
+Result<Integer, String> errResult = mapper.readValue("{\"err\":\"oops\"}",
+    new TypeReference<Result<Integer, String>>() {});
+// Err("oops")
+```

--- a/site/src/data/code/guide/jackson/roundtrip-try.mdx
+++ b/site/src/data/code/guide/jackson/roundtrip-try.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+// Serialize
+String success = mapper.writeValueAsString(Try.success("data")); // "data"
+String failure = mapper.writeValueAsString(
+    Try.failure(new IllegalArgumentException("bad input")));     // {"error":"bad input"}
+
+// Deserialize — success
+Try<String> ok = mapper.readValue("\"data\"",
+    new TypeReference<Try<String>>() {});
+// Success("data")
+
+// Deserialize — failure; always reconstructed as RuntimeException
+Try<String> failed = mapper.readValue("{\"error\":\"bad input\"}",
+    new TypeReference<Try<String>>() {});
+// Failure(RuntimeException("bad input"))
+```

--- a/site/src/data/code/guide/jackson/spring-jaxrs.mdx
+++ b/site/src/data/code/guide/jackson/spring-jaxrs.mdx
@@ -1,0 +1,31 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Spring Boot — declare DmxFunModule as a @Bean; Spring applies it automatically
+// to the auto-configured ObjectMapper.
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public DmxFunModule dmxFunModule() {
+        return new DmxFunModule();
+    }
+}
+
+// Controller returning Result<User, ApiError> — Jackson serializes it transparently
+@GetMapping("/users/{id}")
+public Result<User, ApiError> getUser(@PathVariable Long id) {
+    return userService.findById(id);   // {"ok":{...}} or {"err":{...}}
+}
+
+// JAX-RS — register DmxFunModule on the ObjectMapper provider
+@Provider
+public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
+    private final ObjectMapper mapper =
+        new ObjectMapper().registerModule(new DmxFunModule());
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) { return mapper; }
+}
+```

--- a/site/src/data/guide/jackson.mdx
+++ b/site/src/data/guide/jackson.mdx
@@ -1,0 +1,123 @@
+---
+title: "Jackson Integration — Developer Guide"
+description: "How to serialize and deserialize all dmx-fun types with Jackson: module registration, JSON shapes, TypeReference round-trips, Spring Boot / JAX-RS integration, and known limitations."
+order: 12
+h1: "Jackson Integration"
+---
+
+import {Content as Dependency}      from '../code/guide/jackson/dependency.mdx';
+import {Content as Registration}    from '../code/guide/jackson/registration.mdx';
+import {Content as RoundtripOption} from '../code/guide/jackson/roundtrip-option.mdx';
+import {Content as RoundtripResult} from '../code/guide/jackson/roundtrip-result.mdx';
+import {Content as RoundtripTry}    from '../code/guide/jackson/roundtrip-try.mdx';
+import {Content as RoundtripOther}  from '../code/guide/jackson/roundtrip-other.mdx';
+import {Content as SpringJaxrs}     from '../code/guide/jackson/spring-jaxrs.mdx';
+
+The `fun-jackson` module provides Jackson serializers and deserializers for all
+dmx-fun types. It is an **optional** dependency — the core `fun` library has no
+runtime dependency on Jackson.
+
+## Adding the dependency
+
+`fun-jackson` declares `jackson-databind` as `compileOnly`. You must add
+`jackson-databind` explicitly to your own classpath. Any version from
+**2.13.x through 2.21.x** is supported (see [version compatibility](#version-compatibility) below).
+
+<Dependency/>
+
+## Registering `DmxFunModule`
+
+<Registration/>
+
+`DmxFunModule` is registered as a `com.fasterxml.jackson.databind.Module`
+service provider, so `findAndRegisterModules()` picks it up automatically
+without any explicit wiring.
+
+## JSON shapes
+
+| Type                | Success / present                  | Failure / absent                  |
+|---------------------|------------------------------------|-----------------------------------|
+| `Option<T>`         | `v` (unwrapped)                    | `null`                            |
+| `Result<V, E>`      | `{"ok": v}`                        | `{"err": e}`                      |
+| `Try<V>`            | `v` (unwrapped)                    | `{"error": "message"}`            |
+| `Validated<E, A>`   | `{"valid": a}`                     | `{"invalid": e}`                  |
+| `Either<L, R>`      | `{"right": v}`                     | `{"left": v}`                     |
+| `Tuple2<A, B>`      | `[a, b]`                           | —                                 |
+| `Tuple3<A, B, C>`   | `[a, b, c]`                        | —                                 |
+| `Tuple4<A, B, C, D>`| `[a, b, c, d]`                     | —                                 |
+| `NonEmptyList<T>`   | `[head, ...tail]`                  | —                                 |
+
+## Round-trip examples
+
+### `Option<T>`
+
+<RoundtripOption/>
+
+### `Result<V, E>`
+
+<RoundtripResult/>
+
+### `Try<V>`
+
+<RoundtripTry/>
+
+### `Validated`, `Either`, `Tuple*`, `NonEmptyList`
+
+<RoundtripOther/>
+
+## Spring Boot and JAX-RS
+
+<SpringJaxrs/>
+
+## Version compatibility
+
+The module is tested in CI against the following Jackson versions on every pull
+request that touches the `jackson/` module:
+
+| Jackson version | Status  |
+|-----------------|---------|
+| 2.13.x          | tested  |
+| 2.14.x          | tested  |
+| 2.15.x          | tested  |
+| 2.16.x          | tested  |
+| 2.17.x          | tested  |
+| 2.18.x          | tested  |
+| 2.19.x          | tested  |
+| 2.20.x          | tested  |
+| 2.21.x          | tested  |
+
+To test locally against a specific version:
+
+```bash
+./gradlew :jackson:test -PjacksonVersion=2.15.4
+```
+
+## Known limitations
+
+### `Try.failure` loses the exception type
+
+`Try.failure(ex)` serializes as `{"error": "message"}` — only the exception
+message is preserved. On deserialization, a `RuntimeException` is always
+reconstructed regardless of the original exception class. Stack traces are not
+serialized.
+
+**Workaround**: convert `Try<V>` to `Result<V, String>` via `toResult(Throwable::getMessage)`
+before serializing if the exception type matters to consumers.
+
+### `Try.success` with object values that have a single `"error"` string field
+
+The deserializer detects a `Failure` by checking whether the JSON object has
+exactly one field named `"error"` containing a string. If a success value is a
+POJO that happens to serialize as `{"error": "some text"}` (one string field
+named `"error"`), it will be misread as a `Failure` on deserialization.
+
+**Workaround**: avoid using `Try<V>` for types whose JSON shape is
+`{"error": "<string>"}`. Use `Result<V, E>` instead, which uses an explicit
+`"ok"` / `"err"` envelope that cannot be confused with value content.
+
+### Type parameters require `TypeReference`
+
+Without a `TypeReference`, Jackson loses the generic type information at
+deserialization time and returns raw `LinkedHashMap` / `ArrayList` instead of
+the intended element types. Always use `TypeReference<Option<String>>()`,
+`TypeReference<Result<Integer, String>>()`, etc.

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -76,6 +76,17 @@ const types = [
         tag: 'Interop',
     },
 ];
+
+const modules = [
+    {
+        name: 'Jackson integration',
+        href: `${base}guide/jackson`,
+        summary: 'Serializers and deserializers for all dmx-fun types via the optional fun-jackson module.',
+        whenToUse: 'You need to serialize Option, Result, Try, or any other dmx-fun type to/from JSON.',
+        avoidWhen: 'You are not using Jackson — the module is optional and has no effect without it.',
+        tag: 'JSON',
+    },
+];
 ---
 
 <DocsLayout
@@ -157,12 +168,33 @@ const types = [
             and parallel validation.
         </p>
 
-        <h2>Jackson module</h2>
+        <h2>Modules</h2>
         <p>
-            All types support JSON serialization and deserialization via the optional
-            <code>fun-jackson</code> module.
-            See the <a href={`${base}getting-started`}>Getting Started</a> page for the dependency coordinates.
+            Optional modules extend the library with integrations for popular frameworks and libraries.
+            Each module is an independent dependency — add only what you need.
         </p>
+
+        <div class="type-grid">
+            {modules.map(m => (
+                <a href={m.href} class="type-card">
+                    <div class="type-card-header">
+                        <code class="type-name">{m.name}</code>
+                        <span class="type-tag">{m.tag}</span>
+                    </div>
+                    <p class="type-summary">{m.summary}</p>
+                    <div class="type-meta">
+                        <div class="type-when">
+                            <span class="label">Use when</span>
+                            <span>{m.whenToUse}</span>
+                        </div>
+                        <div class="type-avoid">
+                            <span class="label">Avoid when</span>
+                            <span>{m.avoidWhen}</span>
+                        </div>
+                    </div>
+                </a>
+            ))}
+        </div>
     </div>
 </DocsLayout>
 


### PR DESCRIPTION
  Add complete Jackson integration guide covering dependency setup (Gradle/Maven),
  manual and auto-discovery module registration, JSON shape reference table for all
  nine supported types, per-type round-trip examples with TypeReference, Spring Boot
  and JAX-RS integration patterns, Jackson version compatibility matrix (2.13–2.21),
  and three documented limitations (exception type loss, error-key ambiguity in
  Try.success, TypeReference requirement).

  Externalize all code snippets into seven dedicated MDX files under
  src/data/code/guide/jackson/.

  Add a dedicated Modules section to the guide index with its own card grid,
  separate from the type overview, ready to accommodate additional modules.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #167

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Jackson integration guide covering setup, module registration, and serialization/deserialization examples for supported types.
  * Included Spring Boot and JAX-RS integration examples.
  * Updated guides section to highlight Jackson module availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->