### PR TITLE
ci: add AssertJ multi-version compatibility matrix and module README (#194)

### DIFF
--- a/.github/workflows/assertj-compatibility.yaml
+++ b/.github/workflows/assertj-compatibility.yaml
@@ -1,0 +1,32 @@
+# Verifies that the fun-assertj module remains compatible with multiple AssertJ
+# versions. AssertJ is declared as compileOnly so users bring their own version;
+# this matrix catches regressions before they reach main.
+#
+# Triggered only on pull requests that touch the assertj/ module.
+# To run a specific version locally:
+#   ./gradlew :assertj:test -PassertjVersion=3.25.3
+name: AssertJ compatibility
+
+on:
+  pull_request:
+    # Only run when the assertj module itself is modified.
+    paths: ['assertj/**']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Covers the most recent minor release lines still in wide use.
+        # Update this list when a new minor is released or an old one is EOL.
+        assertj-version: ['3.21.0', '3.22.0', '3.23.1', '3.24.2', '3.25.3', '3.26.3', '3.27.7']
+    name: AssertJ ${{ matrix.assertj-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+      # Pass the matrix version as a Gradle property; the build falls back to
+      # the catalog version when the property is absent (local development).
+      - run: ./gradlew :assertj:test -PassertjVersion=${{ matrix.assertj-version }}

--- a/assertj/README.md
+++ b/assertj/README.md
@@ -1,0 +1,132 @@
+# fun-assertj
+
+Fluent AssertJ custom assertions for all [dmx-fun](https://github.com/domix/dmx-fun) types.
+
+## Dependency
+
+```xml
+<!-- Maven -->
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-assertj</artifactId>
+    <version>${dmx-fun.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+```groovy
+// Gradle
+testImplementation("codes.domix:fun-assertj:${dmxFunVersion}")
+```
+
+AssertJ itself is declared `compileOnly` in this module — you must provide
+`org.assertj:assertj-core` on your own classpath.
+Compatible versions: **3.21.x – 3.27.x**.
+
+## Usage
+
+Import the entry point and use `assertThat` with any dmx-fun type:
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+```
+
+`DmxFunAssertions.assertThat` is overloaded for every supported type.
+It coexists with the standard `org.assertj.core.api.Assertions.assertThat` — both
+can be statically imported in the same test class without conflict as long as
+the argument types differ.
+
+## Assertions reference
+
+### `Option<T>`
+
+| Method                         | Description                                                               |
+|--------------------------------|---------------------------------------------------------------------------|
+| `isSome()`                     | Asserts the option is present                                             |
+| `isNone()`                     | Asserts the option is absent                                              |
+| `containsValue(expected)`      | Asserts the option is present and contains the given value                |
+| `hasValueSatisfying(consumer)` | Asserts the option is present and the value satisfies the given condition |
+
+```java
+assertThat(Option.some(42)).isSome().containsValue(42);
+assertThat(Option.none()).isNone();
+assertThat(Option.some("hello")).hasValueSatisfying(v -> assertThat(v).startsWith("hel"));
+```
+
+### `Result<V, E>`
+
+| Method                    | Description                                            |
+|---------------------------|--------------------------------------------------------|
+| `isOk()`                  | Asserts the result is a success                        |
+| `isErr()`                 | Asserts the result is a failure                        |
+| `containsValue(expected)` | Asserts the result is Ok and contains the given value  |
+| `containsError(expected)` | Asserts the result is Err and contains the given error |
+
+```java
+assertThat(Result.ok("hello")).isOk().containsValue("hello");
+assertThat(Result.err("oops")).isErr().containsError("oops");
+```
+
+### `Try<V>`
+
+| Method                     | Description                                                |
+|----------------------------|------------------------------------------------------------|
+| `isSuccess()`              | Asserts the try is a success                               |
+| `isFailure()`              | Asserts the try is a failure                               |
+| `containsValue(expected)`  | Asserts the try is successful and contains the given value |
+| `failsWith(exceptionType)` | Asserts the try failed with an exception of the given type |
+
+```java
+assertThat(Try.success(1)).isSuccess().containsValue(1);
+assertThat(Try.failure(new IOException("boom"))).isFailure().failsWith(IOException.class);
+```
+
+### `Validated<E, A>`
+
+| Method                    | Description                                                   |
+|---------------------------|---------------------------------------------------------------|
+| `isValid()`               | Asserts the validated is valid                                |
+| `isInvalid()`             | Asserts the validated is invalid                              |
+| `containsValue(expected)` | Asserts the validated is valid and contains the given value   |
+| `hasError(expected)`      | Asserts the validated is invalid and contains the given error |
+
+```java
+assertThat(Validated.valid("ok")).isValid().containsValue("ok");
+assertThat(Validated.invalid("bad")).isInvalid().hasError("bad");
+```
+
+### `Tuple2<A, B>` / `Tuple3<A, B, C>` / `Tuple4<A, B, C, D>`
+
+| Method                | Applies to             |
+|-----------------------|------------------------|
+| `hasFirst(expected)`  | Tuple2, Tuple3, Tuple4 |
+| `hasSecond(expected)` | Tuple2, Tuple3, Tuple4 |
+| `hasThird(expected)`  | Tuple3, Tuple4         |
+| `hasFourth(expected)` | Tuple4                 |
+
+```java
+assertThat(new Tuple2<>("Alice", 30)).hasFirst("Alice").hasSecond(30);
+assertThat(Tuple3.of("Alice", 30, true)).hasFirst("Alice").hasSecond(30).hasThird(true);
+assertThat(Tuple4.of("Alice", 30, true, 1.75)).hasFirst("Alice").hasFourth(1.75);
+```
+
+## AssertJ version compatibility
+
+The module is tested in CI against the following AssertJ versions on every pull
+request that touches the `assertj/` module:
+
+| AssertJ version | Status  |
+|-----------------|---------|
+| 3.21.x          | tested  |
+| 3.22.x          | tested  |
+| 3.23.x          | tested  |
+| 3.24.x          | tested  |
+| 3.25.x          | tested  |
+| 3.26.x          | tested  |
+| 3.27.x          | tested  |
+
+To run the tests locally against a specific version:
+
+```bash
+./gradlew :assertj:test -PassertjVersion=3.25.3
+```

--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -4,7 +4,8 @@ plugins {
 
 dependencies {
     api project(':lib')
-    api libs.assertj.core
+    compileOnly libs.assertj.core
+    testImplementation "org.assertj:assertj-core:${findProperty('assertjVersion') ?: libs.versions.assertj.get()}"
 }
 
 compileTestJava {


### PR DESCRIPTION
  Change assertj-core from api to compileOnly so users bring their own version,
  matching the pattern established by fun-jackson. Add property-driven
  testImplementation so the version can be overridden via -PassertjVersion,
  falling back to the catalog version for local development.

  Add .github/workflows/assertj-compatibility.yaml, a pull-request-only pipeline
  that runs the assertj test suite against seven AssertJ versions (3.21.0 through
  3.27.7), with each matrix leg labelled by its AssertJ version in the GitHub UI.

  Add assertj/README.md documenting the module purpose, Maven/Gradle coordinates,
  the compileOnly contract, usage via DmxFunAssertions.assertThat, a full
  assertions reference table for every supported type, and the tested AssertJ
  version compatibility matrix.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #194

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated GitHub Actions workflow to test compatibility across multiple AssertJ versions

* **Documentation**
  * Added module documentation with usage instructions, assertion reference, and compatibility information

* **Chores**
  * Updated build configuration to properly manage AssertJ dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->