### PR TITLE
ci: update GitHub Actions versions and expand gradle.yml path filters (#196)

### DIFF
--- a/.github/workflows/assertj-compatibility.yaml
+++ b/.github/workflows/assertj-compatibility.yaml
@@ -2,14 +2,14 @@
 # versions. AssertJ is declared as compileOnly so users bring their own version;
 # this matrix catches regressions before they reach main.
 #
-# Triggered only on pull requests that touch the assertj/ module.
+# Triggered only on pull requests that touch assertj/** or this workflow file.
 # To run a specific version locally:
 #   ./gradlew :assertj:test -PassertjVersion=3.25.3
 name: AssertJ compatibility
 
 on:
   pull_request:
-    # Only run when the assertj module itself is modified.
+    # Run when the assertj module or this workflow file is modified.
     paths:
       - 'assertj/**'
       - '.github/workflows/assertj-compatibility.yaml'

--- a/.github/workflows/assertj-compatibility.yaml
+++ b/.github/workflows/assertj-compatibility.yaml
@@ -10,7 +10,9 @@ name: AssertJ compatibility
 on:
   pull_request:
     # Only run when the assertj module itself is modified.
-    paths: ['assertj/**']
+    paths:
+      - 'assertj/**'
+      - '.github/workflows/assertj-compatibility.yaml'
 
 jobs:
   test:
@@ -22,8 +24,8 @@ jobs:
         assertj-version: ['3.21.0', '3.22.0', '3.23.1', '3.24.2', '3.25.3', '3.26.3', '3.27.7']
     name: AssertJ ${{ matrix.assertj-version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -64,7 +64,7 @@ jobs:
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build
@@ -108,4 +108,4 @@ jobs:
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
+      uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,6 +12,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'lib/**'
+      - 'assertj/**'
+      - 'jackson/**'
       - 'settings.gradle'
       - 'gradle.properties'
       - 'gradle/**'
@@ -27,13 +29,15 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
             relevant:
               - 'lib/**'
+              - 'assertj/**'
+              - 'jackson/**'
               - 'settings.gradle'
               - 'gradle.properties'
               - 'gradle/**'
@@ -50,9 +54,9 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -60,7 +64,7 @@ jobs:
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build
@@ -79,7 +83,7 @@ jobs:
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
     #
     # - name: Setup Gradle
-    #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    #   uses: gradle/actions/setup-gradle@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
     #   with:
     #     gradle-version: '8.9'
     #
@@ -94,9 +98,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -104,4 +108,4 @@ jobs:
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/dependency-submission@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4

--- a/.github/workflows/jackson-compatibility.yaml
+++ b/.github/workflows/jackson-compatibility.yaml
@@ -11,7 +11,9 @@ name: Jackson compatibility
 on:
   pull_request:
     # Only run when the jackson module itself is modified.
-    paths: ['jackson/**']
+    paths:
+      - 'jackson/**'
+      - '.github/workflows/jackson-compatibility.yaml'
 
 jobs:
   test:
@@ -23,8 +25,8 @@ jobs:
         jackson-version: ['2.13.5', '2.14.3', '2.15.4', '2.16.2', '2.17.3', '2.18.2', '2.19.4', '2.20.2', '2.21.2']
     name: Jackson ${{ matrix.jackson-version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/jackson-compatibility.yaml
+++ b/.github/workflows/jackson-compatibility.yaml
@@ -3,14 +3,14 @@
 # this matrix catches regressions against older (but still supported) releases
 # before they reach main.
 #
-# Triggered only on pull requests that touch the jackson/ module.
+# Triggered only on pull requests that touch jackson/** or this workflow file.
 # To run a specific version locally:
 #   ./gradlew :jackson:test -PjacksonVersion=2.15.4
 name: Jackson compatibility
 
 on:
   pull_request:
-    # Only run when the jackson module itself is modified.
+    # Run when the jackson module or this workflow file is modified.
     paths:
       - 'jackson/**'
       - '.github/workflows/jackson-compatibility.yaml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,17 +34,17 @@ jobs:
       PUBLIC_GA_MEASUREMENT_ID: "G-9C4WZNE7JJ"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: site/package-lock.json
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -63,7 +63,7 @@ jobs:
           GITHUB_PAGES: "true"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: ./site/dist
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write  # required to push the release tag
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # fetch all history and tags
 
@@ -44,14 +44,14 @@ jobs:
 
       - name: Set up JDK
         if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle
         if: steps.tag_check.outputs.exists == 'false'
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+        uses: gradle/actions/setup-gradle@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
 
       - name: Run tests
         if: steps.tag_check.outputs.exists == 'false'
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}


### PR DESCRIPTION
  Update all GitHub Actions references across five workflow files to their
  latest versions to resolve deprecation warnings:
    - actions/checkout v4 → v6.0.2
    - actions/setup-java v4 → v5.2.0
    - actions/setup-node v4 → v6.3.0
    - actions/upload-pages-artifact v3 → v5.0.0
    - actions/deploy-pages v4 → v5.0.0
    - softprops/action-gh-release v2 → v3.0.0
    - dorny/paths-filter v3 → v4.0.1
    - gradle/actions/* SHA af1da67 (v4.0.0) → da187c8 (v4.4.4)

  Expand gradle.yml push paths and dorny/paths-filter filters to include
  assertj/** and jackson/** so CI triggers when either module changes.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #196

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer action releases and modernized setup steps for checkout, Java, Node and deployment tooling.
  * Broadened workflow triggers and path filters to run for additional project areas.
  * Maintained existing build, test and release behavior while improving toolchain stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->