### PR TITLE
docs(guide): add AssertJ integration guide page (close #159)

### DIFF
--- a/site/src/data/code/guide/assertj/dependency.mdx
+++ b/site/src/data/code/guide/assertj/dependency.mdx
@@ -1,0 +1,26 @@
+---
+fileName: 'build.gradle / pom.xml'
+---
+
+```groovy
+// Gradle — test scope only
+testImplementation("codes.domix:fun-assertj:0.0.12")
+// AssertJ itself — bring your own version (3.21.x – 3.27.x)
+testImplementation("org.assertj:assertj-core:3.27.7")
+```
+
+```xml
+<!-- Maven — test scope only -->
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-assertj</artifactId>
+    <version>0.0.12</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.assertj</groupId>
+    <artifactId>assertj-core</artifactId>
+    <version>3.27.7</version>
+    <scope>test</scope>
+</dependency>
+```

--- a/site/src/data/code/guide/assertj/option-assertions.mdx
+++ b/site/src/data/code/guide/assertj/option-assertions.mdx
@@ -1,0 +1,21 @@
+---
+fileName: 'OptionTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Assert presence and value
+assertThat(Option.some(42))
+    .isSome()
+    .containsValue(42);
+
+// Assert absence
+assertThat(Option.<String>none())
+    .isNone();
+
+// Assert the value satisfies a condition without extracting it
+assertThat(Option.some("hello"))
+    .isSome()
+    .hasValueSatisfying(v -> assertThat(v).startsWith("hel").hasSize(5));
+```

--- a/site/src/data/code/guide/assertj/result-assertions.mdx
+++ b/site/src/data/code/guide/assertj/result-assertions.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'ResultTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Assert Ok and its value
+assertThat(Result.ok("hello"))
+    .isOk()
+    .containsValue("hello");
+
+// Assert Err and its error
+assertThat(Result.<String, String>err("oops"))
+    .isErr()
+    .containsError("oops");
+
+// Combining with standard AssertJ — both static imports coexist
+assertThat(Result.ok(List.of(1, 2, 3)))
+    .isOk()
+    .containsValue(List.of(1, 2, 3));
+```

--- a/site/src/data/code/guide/assertj/try-assertions.mdx
+++ b/site/src/data/code/guide/assertj/try-assertions.mdx
@@ -1,0 +1,26 @@
+---
+fileName: 'TryTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Assert success and value
+assertThat(Try.success("data"))
+    .isSuccess()
+    .containsValue("data");
+
+// Assert failure — just check it failed
+assertThat(Try.failure(new RuntimeException("boom")))
+    .isFailure();
+
+// Assert failure with a specific exception type
+assertThat(Try.of(() -> { throw new IOException("disk full"); }))
+    .isFailure()
+    .failsWith(IOException.class);
+
+// Assert a computation succeeds
+assertThat(Try.of(() -> Integer.parseInt("42")))
+    .isSuccess()
+    .containsValue(42);
+```

--- a/site/src/data/code/guide/assertj/tuple-assertions.mdx
+++ b/site/src/data/code/guide/assertj/tuple-assertions.mdx
@@ -1,0 +1,25 @@
+---
+fileName: 'TupleTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Tuple2
+assertThat(new Tuple2<>("Alice", 30))
+    .hasFirst("Alice")
+    .hasSecond(30);
+
+// Tuple3
+assertThat(Tuple3.of("Alice", 30, true))
+    .hasFirst("Alice")
+    .hasSecond(30)
+    .hasThird(true);
+
+// Tuple4
+assertThat(Tuple4.of("Alice", 30, true, 1.75))
+    .hasFirst("Alice")
+    .hasSecond(30)
+    .hasThird(true)
+    .hasFourth(1.75);
+```

--- a/site/src/data/code/guide/assertj/validated-assertions.mdx
+++ b/site/src/data/code/guide/assertj/validated-assertions.mdx
@@ -1,0 +1,25 @@
+---
+fileName: 'ValidatedTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Assert valid and value
+assertThat(Validated.valid("ok"))
+    .isValid()
+    .containsValue("ok");
+
+// Assert invalid and error
+assertThat(Validated.<String, String>invalid("bad input"))
+    .isInvalid()
+    .hasError("bad input");
+
+// Assert NEL-based validation result
+Validated<NonEmptyList<String>, Integer> result =
+    Validated.invalidNel("must be positive");
+
+assertThat(result)
+    .isInvalid()
+    .hasError(NonEmptyList.singleton("must be positive"));
+```

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -1,0 +1,94 @@
+---
+title: "AssertJ Integration — Developer Guide"
+description: "How to use the optional fun-assertj module: fluent assertions for Option, Result, Try, Validated, and Tuple types via DmxFunAssertions.assertThat."
+order: 13
+h1: "AssertJ Integration"
+---
+
+import {Content as Dependency}           from '../code/guide/assertj/dependency.mdx';
+import {Content as OptionAssertions}     from '../code/guide/assertj/option-assertions.mdx';
+import {Content as ResultAssertions}     from '../code/guide/assertj/result-assertions.mdx';
+import {Content as TryAssertions}        from '../code/guide/assertj/try-assertions.mdx';
+import {Content as ValidatedAssertions}  from '../code/guide/assertj/validated-assertions.mdx';
+import {Content as TupleAssertions}      from '../code/guide/assertj/tuple-assertions.mdx';
+
+The `fun-assertj` module provides fluent AssertJ custom assertions for all
+dmx-fun types. It is an **optional test-only dependency** — the core `fun`
+library has no runtime dependency on AssertJ.
+
+## Adding the dependency
+
+`fun-assertj` declares `assertj-core` as `compileOnly`. You must add
+`assertj-core` explicitly to your own test classpath. Any version from
+**3.21.x through 3.27.x** is supported (see [version compatibility](#version-compatibility) below).
+
+<Dependency/>
+
+## Entry point
+
+All assertions are accessed through a single overloaded static method:
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+```
+
+`DmxFunAssertions.assertThat` coexists with
+`org.assertj.core.api.Assertions.assertThat` — both can be statically imported
+in the same test class without naming conflict, because the argument types differ.
+
+> **Note**: `fun-assertj` cannot be used inside the `:lib` module's own tests
+> due to a circular dependency. Use it only in consumer projects or in the
+> `:assertj` module's own test suite.
+
+## Assertions reference
+
+| Type | Methods |
+|------|---------|
+| `Option<T>` | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)` |
+| `Result<V, E>` | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)` |
+| `Try<V>` | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)` |
+| `Validated<E, A>` | `isValid()`, `isInvalid()`, `containsValue(expected)`, `hasError(expected)` |
+| `Tuple2<A, B>` | `hasFirst(expected)`, `hasSecond(expected)` |
+| `Tuple3<A, B, C>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)` |
+| `Tuple4<A, B, C, D>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`, `hasFourth(expected)` |
+
+## `Option<T>` assertions
+
+<OptionAssertions/>
+
+## `Result<V, E>` assertions
+
+<ResultAssertions/>
+
+## `Try<V>` assertions
+
+<TryAssertions/>
+
+## `Validated<E, A>` assertions
+
+<ValidatedAssertions/>
+
+## `Tuple2/3/4` assertions
+
+<TupleAssertions/>
+
+## Version compatibility
+
+The module is tested in CI against the following AssertJ versions on every pull
+request that touches the `assertj/` module:
+
+| AssertJ version | Status  |
+|-----------------|---------|
+| 3.21.x          | tested  |
+| 3.22.x          | tested  |
+| 3.23.x          | tested  |
+| 3.24.x          | tested  |
+| 3.25.x          | tested  |
+| 3.26.x          | tested  |
+| 3.27.x          | tested  |
+
+To run the tests locally against a specific version:
+
+```bash
+./gradlew :assertj:test -PassertjVersion=3.25.3
+```

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -86,6 +86,14 @@ const modules = [
         avoidWhen: 'You are not using Jackson — the module is optional and has no effect without it.',
         tag: 'JSON',
     },
+    {
+        name: 'AssertJ integration',
+        href: `${base}guide/assertj`,
+        summary: 'Fluent AssertJ custom assertions for Option, Result, Try, Validated, and Tuple types.',
+        whenToUse: 'You want expressive, type-safe assertions for dmx-fun types in your test suite.',
+        avoidWhen: 'You are not using AssertJ — the module is optional and test-scoped.',
+        tag: 'Testing',
+    },
 ];
 ---
 


### PR DESCRIPTION
  Add the fun-assertj module guide covering dependency setup, the
  DmxFunAssertions.assertThat entry point, per-type assertion examples
  (Option, Result, Try, Validated, Tuple2/3/4), circular-dependency
  warning, and a version-compatibility table matching the CI matrix
  (3.21.x–3.27.x). Code snippets are externalized as individual MDX
  files. Register the AssertJ card in the Modules section of the guide
  index.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #159

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AssertJ integration guide with Gradle and Maven setup instructions
  * Included assertion examples for Option, Result, Try, Validated, and Tuple types
  * Updated guide index with new AssertJ module entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->