### PR TITLE
ci(publish): support multi-module publish and SNAPSHOT workflow (close #157, close #172)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,76 @@
+# Publishes SNAPSHOT artifacts to Maven Central's snapshot repository on every
+# push to main, but only when the version in gradle.properties ends with
+# "-SNAPSHOT". The com.vanniktech.maven.publish plugin automatically routes
+# SNAPSHOT versions to https://central.sonatype.com/repository/maven-snapshots/.
+#
+# Stable release publishing is handled separately by publish.yml.
+# This workflow runs independently of publish.yml; both may fire on the same
+# push, but only the snapshot workflow will proceed when the version is a
+# SNAPSHOT, and vice-versa.
+
+name: Publish SNAPSHOT to Maven Central
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'lib/**'
+      - 'jackson/**'
+      - 'assertj/**'
+      - 'settings.gradle'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - '.github/workflows/publish-snapshot.yml'
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Read version from gradle.properties
+        id: version
+        run: |
+          VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2 | tr -d '[:space:]')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: $VERSION"
+
+      - name: Check whether version is a SNAPSHOT
+        id: snapshot_check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+            echo "Version $VERSION is a SNAPSHOT — will publish."
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+            echo "Version $VERSION is not a SNAPSHOT — skipping."
+          fi
+
+      - name: Set up JDK
+        if: steps.snapshot_check.outputs.is_snapshot == 'true'
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        if: steps.snapshot_check.outputs.is_snapshot == 'true'
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run tests
+        if: steps.snapshot_check.outputs.is_snapshot == 'true'
+        run: ./gradlew test
+
+      - name: Publish SNAPSHOT to Maven Central
+        if: steps.snapshot_check.outputs.is_snapshot == 'true'
+        run: ./gradlew publish --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'lib/**'
+      - 'jackson/**'
+      - 'assertj/**'
       - 'settings.gradle'
       - 'gradle.properties'
       - 'gradle/**'
@@ -51,15 +53,15 @@ jobs:
 
       - name: Setup Gradle
         if: steps.tag_check.outputs.exists == 'false'
-        uses: gradle/actions/setup-gradle@da187c8e6ffbd3802e00f2477aa5a822b25f2dda # v4.4.4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run tests
         if: steps.tag_check.outputs.exists == 'false'
-        run: ./gradlew :lib:test
+        run: ./gradlew test
 
-      - name: Publish to Maven Central
+      - name: Publish all modules to Maven Central
         if: steps.tag_check.outputs.exists == 'false'
-        run: ./gradlew :lib:publishToMavenCentral --no-configuration-cache
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
  Update publish.yml to run the root-level publishToMavenCentral task so
  all modules (lib, jackson, assertj) are published in a single job; expand
  path triggers to include jackson/** and assertj/**; run the full test
  suite instead of :lib:test only; upgrade gradle/actions/setup-gradle to v6.

  Add publish-snapshot.yml that triggers on push to main whenever the
  version in gradle.properties ends with -SNAPSHOT, runs all tests, and
  publishes to Maven Central's snapshot repository via ./gradlew publish.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #157
Closes #172

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
