### PR TITLE
docs(readme): rewrite README to reflect current library state (close #206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A Java library of functional types that make failures, absence, and validation e
 
 All modules are published to Maven Central. Add only what you need.
 
+| Module        | Latest version                                                                                                                                    |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fun`         | [![Maven Central](https://img.shields.io/maven-central/v/codes.domix/fun)](https://central.sonatype.com/artifact/codes.domix/fun)                 |
+| `fun-jackson` | [![Maven Central](https://img.shields.io/maven-central/v/codes.domix/fun-jackson)](https://central.sonatype.com/artifact/codes.domix/fun-jackson) |
+| `fun-assertj` | [![Maven Central](https://img.shields.io/maven-central/v/codes.domix/fun-assertj)](https://central.sonatype.com/artifact/codes.domix/fun-assertj) |
+
+Replace `LATEST_VERSION` with the version shown in the badge above.
+
 ### Core library
 
 **Maven**
@@ -19,13 +27,13 @@ All modules are published to Maven Central. Add only what you need.
 <dependency>
     <groupId>codes.domix</groupId>
     <artifactId>fun</artifactId>
-    <version>0.0.12</version>
+    <version>LATEST_VERSION</version>
 </dependency>
 ```
 
 **Gradle**
 ```groovy
-implementation("codes.domix:fun:0.0.12")
+implementation("codes.domix:fun:LATEST_VERSION")
 ```
 
 ### Jackson integration (optional)
@@ -37,13 +45,13 @@ Serializers and deserializers for all dmx-fun types.
 <dependency>
     <groupId>codes.domix</groupId>
     <artifactId>fun-jackson</artifactId>
-    <version>0.0.12</version>
+    <version>LATEST_VERSION</version>
 </dependency>
 ```
 
 **Gradle**
 ```groovy
-implementation("codes.domix:fun-jackson:0.0.12")
+implementation("codes.domix:fun-jackson:LATEST_VERSION")
 ```
 
 ### AssertJ integration (optional, test scope)
@@ -55,14 +63,14 @@ Fluent custom assertions for all dmx-fun types.
 <dependency>
     <groupId>codes.domix</groupId>
     <artifactId>fun-assertj</artifactId>
-    <version>0.0.12</version>
+    <version>LATEST_VERSION</version>
     <scope>test</scope>
 </dependency>
 ```
 
 **Gradle**
 ```groovy
-testImplementation("codes.domix:fun-assertj:0.0.12")
+testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 ```
 
 ---
@@ -88,6 +96,7 @@ testImplementation("codes.domix:fun-assertj:0.0.12")
 import dmx.fun.Result;
 import dmx.fun.Try;
 import dmx.fun.Validated;
+import dmx.fun.NonEmptyList;
 
 // Wrap a legacy API that throws
 Try<RawUser> raw = Try.of(() -> externalService.fetchUser(id));

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ testImplementation("codes.domix:fun-assertj:0.0.12")
 
 ## Types
 
-| Type | Tag | When to use |
-|---|---|---|
-| `Option<T>` | Nullability | A value that may or may not be present. The null-safe alternative to `@Nullable`. |
-| `Result<V, E>` | Error handling | An operation that can succeed or fail with a typed error. |
-| `Try<V>` | Exception handling | Wraps a computation that may throw. Turns exceptions into values. |
-| `Validated<E, A>` | Validation | Like `Result` but accumulates all errors instead of failing on the first. |
-| `Either<L, R>` | Disjoint union | A value that is one of two types with no success/failure semantics. |
-| `Lazy<T>` | Deferred computation | A value computed at most once, on first access. Thread-safe memoization. |
-| `Tuple2/3/4` | Product types | Typed heterogeneous tuples without a dedicated class. |
-| `NonEmptyList<T>` | Collections | A list guaranteed to have at least one element at compile time. |
+| Type              | Tag                  | When to use                                                                       |
+|-------------------|----------------------|-----------------------------------------------------------------------------------|
+| `Option<T>`       | Nullability          | A value that may or may not be present. The null-safe alternative to `@Nullable`. |
+| `Result<V, E>`    | Error handling       | An operation that can succeed or fail with a typed error.                         |
+| `Try<V>`          | Exception handling   | Wraps a computation that may throw. Turns exceptions into values.                 |
+| `Validated<E, A>` | Validation           | Like `Result` but accumulates all errors instead of failing on the first.         |
+| `Either<L, R>`    | Disjoint union       | A value that is one of two types with no success/failure semantics.               |
+| `Lazy<T>`         | Deferred computation | A value computed at most once, on first access. Thread-safe memoization.          |
+| `Tuple2/3/4`      | Product types        | Typed heterogeneous tuples without a dedicated class.                             |
+| `NonEmptyList<T>` | Collections          | A list guaranteed to have at least one element at compile time.                   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,20 @@
-
-# λ dmx-fun: Functional Programming Constructions in Java
+# dmx-fun
 
 <img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/cab675c2-c8ca-4017-903f-6790309750e8" />
 
-This repository contains a collection of implementations and experiments exploring **functional programming constructions in Java**. The goal is to demonstrate how functional paradigms—such as immutability, pure functions, higher-order functions, currying, and more—can be expressed in Java, a traditionally object-oriented language.
+A Java library of functional types that make failures, absence, and validation explicit in the type system — without ceremony.
 
-## 🔍 Purpose
+`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, and `NonEmptyList<T>` — each designed to compose cleanly with the others and with the Java standard library.
 
-While Java is not a purely functional language, modern features like lambda expressions, streams, and the `Optional` and `CompletableFuture` APIs allow for elegant and expressive functional-style programming. This project aims to:
+---
 
-- Explore functional programming principles in Java
-- Showcase reusable constructions inspired by functional languages
-- Experiment with Java libraries that support functional programming
-- Serve as a reference and learning resource for developers
+## Installation
 
-## 📦 What's Included
+All modules are published to Maven Central. Add only what you need.
 
-Examples and implementations may include:
+### Core library
 
-- Function composition and higher-order functions  
-- Currying and partial application  
-- Immutable data structures  
-- Functional error handling (e.g., using `Try`, `Result`, or `Option`)  
-- Lazy evaluation  
-- Monads and functors (in a Java-friendly context)  
-- Functional streams and pipelines  
-
-## 🛠 Technologies
-
-- Java 25+
-- Gradle
-- Spock for testing  
-- [Vavr](https://www.vavr.io/) or similar libraries for functional data types (optional)  
-
-## 🤝 Contributions
-
-Contributions, discussions, and suggestions are welcome! Feel free to open issues or submit pull requests.
-
-## 📄 License
-
-This project is licensed under the Apache License. See the [LICENSE](./LICENSE) file for more details.
-
-## 🛠️ Usage
-
-
-### Installation
-
-This library is available on Maven Central. To use it, include the following dependency to your project's configuration file:
-
-#### Maven
-
+**Maven**
 ```xml
 <dependency>
     <groupId>codes.domix</groupId>
@@ -58,80 +23,112 @@ This library is available on Maven Central. To use it, include the following dep
 </dependency>
 ```
 
-#### Gradle
-
+**Gradle**
 ```groovy
 implementation("codes.domix:fun:0.0.12")
 ```
-### Usage
 
-Assuming you have imported the library, you can start using it in your code.
+### Jackson integration (optional)
 
-Let's start with a simple example. You have a method that validates a user's email, in a method like this:
+Serializers and deserializers for all dmx-fun types.
 
-```java
-    protected Result<CreateUserCommand, String> isValidEmail(
-        CreateUserCommand command
-    ) {
-        var email = command.email();
-        if (email == null || email.isBlank()) {
-            return Result.err("Provided email is either null or blank");
-        }
-        boolean emailMatches = EMAIL_PATTERN
-            .matcher(email)
-            .matches();
-
-        if (!emailMatches) {
-            return Result.err("Invalid email");
-        }
-
-        return Result.ok(command);
-    }
+**Maven**
+```xml
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-jackson</artifactId>
+    <version>0.0.12</version>
+</dependency>
 ```
 
-In the previous example, we are using the `Result` type from the `fun` library. This type is a simple wrapper around an `Optional` that provides additional methods for handling errors.
-
-In a nutshell, the `Result` type allows you to express a computation that may fail, and handle the error case in a type-safe way.
-
-If everything goes well, the `Result` will contain the original value, in case of error, it will contain an error message.
-
-Now you want to validate the user's password, with similar logic. You can create a new method like this:
-
-```java
-    protected Result<CreateUserCommand, String> isValidPassword(
-        CreateUserCommand command
-    ) {
-
-        var password = command.password();
-        if (password == null) {
-            return Result.err("Provided password is null");
-        }
-        boolean validPassword = PASSWORD_PATTERN
-            .matcher(password)
-            .matches();
-
-        if (!validPassword) {
-            return Result.err("Invalid password.");
-        }
-
-        return Result.ok(command);
-    }
+**Gradle**
+```groovy
+implementation("codes.domix:fun-jackson:0.0.12")
 ```
 
-As you can see, the `Result` type is used to express the result of the validation. 
+### AssertJ integration (optional, test scope)
 
-Now we can combine both validations in a single method. You can do it like this:
+Fluent custom assertions for all dmx-fun types.
 
-```java
-    public Result<User, String> createUser(CreateUserCommand command) {
-        return this.isValidEmail(command)
-            .flatMap(this::isValidPassword)
-            .flatMap(this.userRepository::createUser);
-    }
+**Maven**
+```xml
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-assertj</artifactId>
+    <version>0.0.12</version>
+    <scope>test</scope>
+</dependency>
 ```
 
-In this case, the validation is performed in two steps, and the result of the first step is used as the input for the second step.
+**Gradle**
+```groovy
+testImplementation("codes.domix:fun-assertj:0.0.12")
+```
 
-In the end, the result of the whole validation process is used to create the user in the database.
+---
 
-The main benefit of this approach is that the validation logic is encapsulated in a single method, and it can be reused in other places.
+## Types
+
+| Type | Tag | When to use |
+|---|---|---|
+| `Option<T>` | Nullability | A value that may or may not be present. The null-safe alternative to `@Nullable`. |
+| `Result<V, E>` | Error handling | An operation that can succeed or fail with a typed error. |
+| `Try<V>` | Exception handling | Wraps a computation that may throw. Turns exceptions into values. |
+| `Validated<E, A>` | Validation | Like `Result` but accumulates all errors instead of failing on the first. |
+| `Either<L, R>` | Disjoint union | A value that is one of two types with no success/failure semantics. |
+| `Lazy<T>` | Deferred computation | A value computed at most once, on first access. Thread-safe memoization. |
+| `Tuple2/3/4` | Product types | Typed heterogeneous tuples without a dedicated class. |
+| `NonEmptyList<T>` | Collections | A list guaranteed to have at least one element at compile time. |
+
+---
+
+## Quick example
+
+```java
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Validated;
+
+// Wrap a legacy API that throws
+Try<RawUser> raw = Try.of(() -> externalService.fetchUser(id));
+
+// Convert to Result for typed error handling
+Result<User, RegistrationError> user = raw
+    .toResult(e -> RegistrationError.fetchFailed(id, e))
+    .flatMap(this::parseUser)
+    .flatMap(this::enrichWithDefaults);
+
+// Validate all fields at once — accumulate every error, not just the first
+Validated<NonEmptyList<String>, ValidUser> validated = user
+    .map(this::validate)
+    .getOrElse(Validated.invalidNel("user could not be loaded"));
+
+validated
+    .onValid(userRepository::save)
+    .onInvalid(errors -> log.warn("Registration rejected: {}", errors));
+```
+
+---
+
+## Documentation
+
+Full developer guide, API reference, and composition patterns:
+**https://domix.github.io/dmx-fun/**
+
+---
+
+## Requirements
+
+- Java 25 or later
+
+---
+
+## Contributing
+
+Bug reports, feature requests, and pull requests are welcome. Please open an issue before submitting a large change.
+
+---
+
+## License
+
+Apache License 2.0 — see [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
  Replace the outdated "experiments" framing with a clear library pitch.
  Update Maven coordinates to codes.domix, add fun-jackson and fun-assertj
  modules, add type overview table, replace dated usage example with an
  idiomatic composition snippet, and link prominently to the documentation
  site. Remove references to Vavr, Spock, and the old group ID.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #206

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project overview and description
  * Clarified Maven Central artifact installation with version details for core and optional integrations
  * Updated Java version requirement to 25 or later
  * Added link to full documentation
  * Simplified quick-start example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->