### PR TITLE
docs(guide): add Contributing & Maintainer section with 4 new pages (close #212)

### DIFF
--- a/site/src/data/code/guide/contributing/clone-and-build.mdx
+++ b/site/src/data/code/guide/contributing/clone-and-build.mdx
@@ -1,0 +1,9 @@
+---
+fileName: 'terminal'
+---
+
+```bash
+git clone https://github.com/domix/dmx-fun.git
+cd dmx-fun
+./gradlew build
+```

--- a/site/src/data/code/guide/contributing/run-site.mdx
+++ b/site/src/data/code/guide/contributing/run-site.mdx
@@ -1,0 +1,9 @@
+---
+fileName: 'terminal'
+---
+
+```bash
+cd site
+npm install      # first time only
+npm run dev      # starts dev server at http://localhost:4321/dmx-fun/
+```

--- a/site/src/data/code/guide/contributing/run-tests.mdx
+++ b/site/src/data/code/guide/contributing/run-tests.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'terminal'
+---
+
+```bash
+# Run all tests across all modules
+./gradlew test
+
+# Run tests for a specific module
+./gradlew :lib:test
+./gradlew :jackson:test
+./gradlew :assertj:test
+
+# Run a single test class
+./gradlew :lib:test --tests "dmx.fun.OptionTest"
+```

--- a/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
+++ b/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
@@ -1,0 +1,24 @@
+---
+fileName: 'fun-spring/build.gradle'
+---
+
+```groovy
+plugins {
+    id 'dmx-fun.java-module'
+}
+
+dependencies {
+    api project(':lib')
+    compileOnly libs.spring.context          // optional peer dependency
+    testImplementation libs.spring.context   // or property-driven version
+}
+
+mavenPublishing {
+    coordinates("codes.domix", "fun-spring", "${project.version}")
+
+    pom {
+        name = 'dmx-fun Spring integration'
+        description = 'Optional Spring module for dmx-fun: ...'
+    }
+}
+```

--- a/site/src/data/code/guide/release-process/bump-version.mdx
+++ b/site/src/data/code/guide/release-process/bump-version.mdx
@@ -1,0 +1,11 @@
+---
+fileName: 'gradle.properties'
+---
+
+```properties
+# Before release: bump SNAPSHOT → stable
+version=0.0.13
+
+# After release: bump to next SNAPSHOT
+version=0.0.14-SNAPSHOT
+```

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -1,0 +1,121 @@
+---
+title: "Contributing — Developer Guide"
+description: "How to set up the dmx-fun development environment, run tests, run the site locally, follow code conventions, and open a pull request."
+order: 14
+h1: "Contributing"
+---
+
+import {Content as CloneAndBuild} from '../code/guide/contributing/clone-and-build.mdx';
+import {Content as RunTests}      from '../code/guide/contributing/run-tests.mdx';
+import {Content as RunSite}       from '../code/guide/contributing/run-site.mdx';
+
+Contributions are welcome — bug reports, documentation improvements, and new features alike.
+This page covers everything you need to go from a fresh clone to a passing build and an open PR.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Java | 25+ | Use the Gradle toolchain — no manual install needed if you have a JDK provider |
+| Gradle | wrapper (`./gradlew`) | Never install Gradle globally; always use the wrapper |
+| Node.js | 18+ | Only needed to run or build the documentation site |
+| npm | bundled with Node.js | Run from the `site/` directory |
+
+No other global tools are required.
+
+## Clone and build
+
+<CloneAndBuild/>
+
+`./gradlew build` compiles all modules, runs all tests, and generates the aggregated Javadoc and coverage report.
+
+## Running tests
+
+<RunTests/>
+
+To see the full test report after a run, open `build/reports/tests/testAggregateTestReport/index.html`.
+
+## Running the documentation site locally
+
+<RunSite/>
+
+The dev server watches for changes in `site/src/` and reloads automatically.
+The site is served under the `/dmx-fun/` base path to match GitHub Pages.
+
+> **Note**: `npm run build` in `site/` copies the Javadoc from `build/reports/javadoc/` into the
+> site's `public/` directory. Run `./gradlew aggregateJavadoc` first if you need the full build.
+
+## Code conventions
+
+### No `null` in the public API
+
+All public methods must be annotated with `@NullMarked` (via the package-info or class-level annotation).
+Return `Option<T>` instead of a nullable type; accept `@Nullable` parameters only when the absence is
+meaningful to the implementation.
+
+### Sealed interfaces and records
+
+Every sum type in the library is a sealed interface with record implementations.
+This enables exhaustive pattern matching for callers and removes the need for `instanceof` chains.
+
+```java
+// Correct — sealed + records
+public sealed interface Option<T> permits Option.Some, Option.None {
+    record Some<T>(T value) implements Option<T> {}
+    record None<T>()        implements Option<T> {}
+}
+```
+
+### No checked exceptions in the public API
+
+Checked exceptions must not appear in public method signatures.
+Wrap third-party code that throws in `Try.of(...)` and surface failures through `Result` or `Try`.
+
+### Test naming
+
+Test method names follow the pattern `<condition>_<expected outcome>`, written in `camelCase`:
+
+```java
+@Test
+void emptyOption_mapReturnsNone() { ... }
+```
+
+## Commit convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Type | When to use |
+|---|---|
+| `feat` | New public API or behaviour |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change with no behaviour change |
+| `test` | Adding or updating tests |
+| `chore` | Build, CI, dependencies |
+| `perf` | Performance improvement |
+
+Always reference the issue number: `feat(option): add mapBoth combinator (close #42)`.
+
+## Branch naming
+
+```
+<type>/<short-description>
+feat/option-map-both
+fix/try-recover-npe
+docs/guide/adding-validated-examples
+```
+
+## Opening a pull request
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes — one concern per PR.
+3. Ensure `./gradlew build` passes locally.
+4. Open the PR against `main` with a title following the commit convention.
+5. Link the related issue in the PR description (`close #NNN`).
+
+All PRs run the full CI pipeline (`gradle.yml`) automatically.
+
+## Note on `lib/src/test/resources/`
+
+This directory is intentionally untracked (it appears in `git status` as untracked).
+It is generated at test time and should not be committed.

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -1,0 +1,113 @@
+---
+title: "Adding a New Module — Developer Guide"
+description: "Conventions and checklist for adding a new optional integration module to dmx-fun (e.g. fun-spring, fun-micronaut)."
+order: 17
+h1: "Adding a New Module"
+---
+
+import {Content as NewModuleBuildGradle} from '../code/guide/module-conventions/new-module-build-gradle.mdx';
+
+Optional integration modules follow a consistent pattern established by `fun-jackson` and `fun-assertj`.
+This page is a checklist for maintainers adding a new module.
+
+## When to create a module
+
+Create a new module when the integration requires an optional peer dependency that users may or may not
+have on their classpath. The core `lib` module must never depend on it.
+
+Examples of appropriate modules: `fun-spring`, `fun-micronaut`, `fun-quarkus`, `fun-reactor`.
+
+---
+
+## Checklist
+
+### 1. Create the Gradle subproject
+
+Create the directory and `build.gradle`:
+
+<NewModuleBuildGradle/>
+
+Key rules:
+- Always apply `dmx-fun.java-module` — this pulls in the convention plugin, the Maven publishing
+  configuration, the signing setup, and the JSpecify dependency.
+- Declare the peer dependency as `compileOnly` so users bring their own version.
+- Drive the test dependency version via a Gradle property (e.g. `-PspringVersion=6.1.0`) to enable
+  CI matrix testing, falling back to the version catalog entry.
+
+### 2. Register in `settings.gradle`
+
+```groovy
+include('fun-spring')
+```
+
+### 3. Add to the root `build.gradle` aggregation
+
+The root `build.gradle` aggregates test reports and Javadoc. Add the new module to both:
+
+```groovy
+dependencies {
+    testReportAggregation project(':fun-spring')
+    jacocoAggregation      project(':fun-spring')
+}
+```
+
+And add its source directory to the `aggregateJavadoc` task's `--module-source-path` arguments.
+
+### 4. Expand CI path triggers
+
+Four workflow files reference module paths — update all of them:
+
+| Workflow | Where to add |
+|---|---|
+| `.github/workflows/gradle.yml` | `paths:` block (push) and `dorny/paths-filter` filters |
+| `.github/workflows/publish.yml` | `paths:` block |
+| `.github/workflows/publish-snapshot.yml` | `paths:` block |
+
+### 5. Add a compatibility matrix workflow
+
+If the module has an optional peer dependency, create `.github/workflows/{module}-compatibility.yaml`
+following the pattern of `jackson-compatibility.yaml`:
+
+- Trigger: PR touching `{module}/**` or the workflow file
+- Matrix: one entry per supported version of the peer dependency
+- Run: `./gradlew :{module}:test -P{module}Version={version}`
+
+### 6. Write a `README.md` in the module root
+
+Cover: what the module does, Maven/Gradle coordinates, usage snippet, version compatibility table.
+See `jackson/README.md` or `assertj/README.md` for the expected format.
+
+### 7. Add a guide page
+
+Create `site/src/data/guide/{module-name}.mdx` following the established guide style:
+- `order` should be the next available integer after the last module guide
+- Externalize all code snippets into `site/src/data/code/guide/{module-name}/`
+- Include a version compatibility table matching the CI matrix
+
+### 8. Register in the guide index
+
+Add a card to the `modules` array in `site/src/pages/guide/index.astro`:
+
+```js
+{
+    name: 'Spring integration',
+    href: `${base}guide/fun-spring`,
+    summary: 'Spring-aware adapters for dmx-fun types.',
+    whenToUse: 'You are using Spring and want native dmx-fun support.',
+    avoidWhen: 'You are not using Spring — the module is optional.',
+    tag: 'Spring',
+},
+```
+
+---
+
+## Naming conventions
+
+| Artifact | Pattern | Example |
+|---|---|---|
+| Directory | `{integration-name}` | `fun-spring` |
+| `artifactId` | `fun-{integration-name}` | `fun-spring` |
+| POM `name` | `dmx-fun {Integration} integration` | `dmx-fun Spring integration` |
+| Java module name | `dmx.fun.{integration}` | `dmx.fun.spring` |
+| Base package | `dmx.fun.{integration}` | `dmx.fun.spring` |
+| Guide slug | `{integration-name}` | `/guide/fun-spring` |

--- a/site/src/data/guide/pipelines.mdx
+++ b/site/src/data/guide/pipelines.mdx
@@ -1,0 +1,170 @@
+---
+title: "CI/CD Pipelines — Developer Guide"
+description: "Reference for every GitHub Actions workflow in dmx-fun: triggers, purpose, required secrets, local equivalents, and known gotchas."
+order: 15
+h1: "CI/CD Pipelines"
+---
+
+export const base = import.meta.env.BASE_URL;
+
+All CI/CD is handled by GitHub Actions. The workflows live in `.github/workflows/`.
+
+## Workflow overview
+
+| Workflow file | Trigger | Purpose |
+|---|---|---|
+| `gradle.yml` | push / PR to `main` (code paths) | Full build, tests, coverage, Javadoc, dependency graph submission |
+| `publish.yml` | push to `main` — stable version only | Publish all modules to Maven Central, create git tag and GitHub Release |
+| `publish-snapshot.yml` | push to `main` — SNAPSHOT version only | Publish SNAPSHOT artifacts to Maven Central |
+| `jackson-compatibility.yaml` | PR touching `jackson/**` | Matrix test against Jackson 2.13.x – 2.21.x |
+| `assertj-compatibility.yaml` | PR touching `assertj/**` | Matrix test against AssertJ 3.21.x – 3.27.x |
+| `pages.yml` | push to `main` | Build and deploy the documentation site to GitHub Pages |
+
+---
+
+## `gradle.yml` — Main CI build
+
+**Triggers**: push to `main` on tracked paths, or any PR to `main`.
+
+Uses `dorny/paths-filter` on PRs to skip the build entirely when no relevant file changed
+(e.g. a documentation-only commit).
+
+**What it does**:
+1. Compiles all modules
+2. Runs all tests and uploads the aggregated JaCoCo coverage report to the PR
+3. Generates aggregated Javadoc
+4. Submits the dependency graph to GitHub for Dependabot
+
+**Local equivalent**:
+```bash
+./gradlew build
+```
+
+**Secrets required**: none.
+
+---
+
+## `publish.yml` — Stable release
+
+**Triggers**: push to `main` when any of `lib/**`, `jackson/**`, `assertj/**`, `gradle/**`,
+`gradle.properties`, `gradlew`, `gradlew.bat`, or the workflow file itself changes.
+
+**Gotcha**: the workflow reads `version` from `gradle.properties` at runtime.
+If the version ends with `-SNAPSHOT`, all subsequent steps are skipped — the workflow exits early.
+Only stable versions (e.g. `0.0.13`) proceed.
+
+**What it does**:
+1. Reads the version from `gradle.properties`
+2. Checks whether the git tag `v{version}` already exists — skips if it does (idempotent)
+3. Runs all tests (`./gradlew test`)
+4. Publishes all modules to Maven Central (`./gradlew publishToMavenCentral --no-configuration-cache`)
+5. Creates and pushes the git tag `v{version}`
+6. Creates a GitHub Release with auto-generated release notes
+
+**Secrets required**:
+
+| Secret | Purpose |
+|---|---|
+| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token |
+| `SIGNING_KEY_ID` | GPG key ID (last 8 characters) |
+| `SIGNING_KEY` | GPG private key (armored, base64-encoded) |
+| `SIGNING_KEY_PASSWORD` | Passphrase for the GPG key |
+
+**Local equivalent** (dry-run only — do not publish locally):
+```bash
+./gradlew publishToMavenCentral --no-configuration-cache --dry-run
+```
+
+---
+
+## `publish-snapshot.yml` — SNAPSHOT publish
+
+**Triggers**: same paths as `publish.yml`.
+
+**Gotcha**: mirror of `publish.yml` — only proceeds when the version ends with `-SNAPSHOT`.
+Stable versions cause all steps to be skipped.
+
+**What it does**:
+1. Reads the version; skips if not a SNAPSHOT
+2. Runs all tests
+3. Publishes to Maven Central's snapshot repository via `./gradlew publishToMavenCentral`
+
+**Secrets required**: same five secrets as `publish.yml`.
+
+---
+
+## `jackson-compatibility.yaml` — Jackson matrix
+
+**Triggers**: PR where at least one changed file matches `jackson/**` or the workflow file itself.
+
+Runs only on pull requests — not on push to `main`.
+
+**What it does**: runs `:jackson:test` for each Jackson version in the matrix:
+
+| Jackson version | Status |
+|---|---|
+| 2.13.5 | tested |
+| 2.14.3 | tested |
+| 2.15.4 | tested |
+| 2.16.2 | tested |
+| 2.17.3 | tested |
+| 2.18.2 | tested |
+| 2.19.4 | tested |
+| 2.20.2 | tested |
+| 2.21.2 | tested |
+
+**Local equivalent**:
+```bash
+./gradlew :jackson:test -PjacksonVersion=2.17.3
+```
+
+**Secrets required**: none.
+
+---
+
+## `assertj-compatibility.yaml` — AssertJ matrix
+
+**Triggers**: PR where at least one changed file matches `assertj/**` or the workflow file itself.
+
+Runs only on pull requests — not on push to `main`.
+
+**What it does**: runs `:assertj:test` for each AssertJ version in the matrix:
+
+| AssertJ version | Status |
+|---|---|
+| 3.21.0 | tested |
+| 3.22.0 | tested |
+| 3.23.1 | tested |
+| 3.24.2 | tested |
+| 3.25.3 | tested |
+| 3.26.3 | tested |
+| 3.27.7 | tested |
+
+**Local equivalent**:
+```bash
+./gradlew :assertj:test -PassertjVersion=3.25.3
+```
+
+**Secrets required**: none.
+
+---
+
+## `pages.yml` — Documentation site deploy
+
+**Triggers**: push to `main` (no path filter — any push rebuilds the site).
+
+**What it does**:
+1. Runs `./gradlew aggregateJavadoc` to generate the API reference
+2. Copies the Javadoc output into `site/public/javadoc/`
+3. Runs `npm run build` inside `site/`
+4. Deploys the `dist/` directory to GitHub Pages
+
+**Secrets required**: none (uses `GITHUB_TOKEN` with `pages: write` permission).
+
+**Local equivalent**:
+```bash
+./gradlew aggregateJavadoc
+cd site && npm run build
+# open dist/ in a local static server
+```

--- a/site/src/data/guide/release-process.mdx
+++ b/site/src/data/guide/release-process.mdx
@@ -1,0 +1,107 @@
+---
+title: "Release Process — Developer Guide"
+description: "Step-by-step process for cutting a stable dmx-fun release: version bump, CI publish, tag creation, post-release SNAPSHOT bump, and verification."
+order: 16
+h1: "Release Process"
+---
+
+import {Content as BumpVersion} from '../code/guide/release-process/bump-version.mdx';
+
+Releases are fully automated once the version is bumped and pushed to `main`.
+This page documents the exact steps and what happens at each stage.
+
+## Required repository secrets
+
+Before any release can be published, these five secrets must be configured in
+**GitHub → Settings → Secrets and variables → Actions**:
+
+| Secret | Purpose |
+|---|---|
+| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token |
+| `SIGNING_KEY_ID` | GPG key ID (last 8 hex characters) |
+| `SIGNING_KEY` | GPG private key — armored, base64-encoded |
+| `SIGNING_KEY_PASSWORD` | Passphrase protecting the GPG key |
+
+These secrets are consumed by `publish.yml` and `publish-snapshot.yml`.
+They are never printed in logs.
+
+## Release checklist
+
+### 1. Merge all target PRs
+
+Ensure every issue and PR that should land in the release is merged to `main`
+and the CI build (`gradle.yml`) is green.
+
+### 2. Bump the version to stable
+
+Edit `gradle.properties` — remove the `-SNAPSHOT` suffix:
+
+<BumpVersion/>
+
+Commit with:
+```bash
+git commit -m "chore(release): bump version to 0.0.13" gradle.properties
+git push origin main
+```
+
+### 3. CI publishes automatically
+
+Pushing a stable version to `main` triggers `publish.yml`, which:
+
+1. Detects that `version=0.0.13` is **not** a SNAPSHOT
+2. Checks that the git tag `v0.0.13` does not already exist
+3. Runs `./gradlew test` — all modules
+4. Runs `./gradlew publishToMavenCentral --no-configuration-cache`
+5. Creates and pushes the annotated tag `v0.0.13`
+6. Opens a GitHub Release with auto-generated release notes
+
+Monitor progress at **Actions → Publish to Maven Central**.
+
+### 4. Verify the release on Maven Central
+
+After the workflow completes (typically 5–10 minutes for Maven Central propagation):
+
+- Check the artifact exists: `https://central.sonatype.com/artifact/codes.domix/fun`
+- Verify all three modules are present: `fun`, `fun-jackson`, `fun-assertj`
+- Confirm the POM, sources JAR, and Javadoc JAR are attached
+
+### 5. Bump to the next SNAPSHOT
+
+Immediately after the release, start the next development cycle:
+
+```bash
+# Edit gradle.properties: version=0.0.14-SNAPSHOT
+git commit -m "chore(release): bump version to 0.0.14-SNAPSHOT" gradle.properties
+git push origin main
+```
+
+This triggers `publish-snapshot.yml`, which publishes the SNAPSHOT to Maven Central's
+snapshot repository so early adopters can test against `HEAD`.
+
+### 6. Update README (if needed)
+
+The README uses shields.io Maven Central badges that auto-update.
+If you hardcode version numbers anywhere else, update them now.
+
+---
+
+## Tag format
+
+Tags follow the pattern `v{version}` — e.g. `v0.0.13`.
+Tags are annotated (created with `-a`) and pushed by the CI workflow automatically.
+**Never create release tags manually** — let `publish.yml` manage them to avoid
+triggering a duplicate publish.
+
+---
+
+## Re-running a failed publish
+
+If `publish.yml` fails after the tests but before the tag is pushed:
+
+1. Fix the root cause (e.g. expired signing key, Maven Central outage).
+2. Push any fix to `main`.
+3. The workflow re-runs. The tag-check step will find no existing tag and proceed.
+
+If the workflow fails *after* the tag was pushed but before the GitHub Release was created,
+create the release manually via `gh release create v0.0.13 --generate-notes`.

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -77,6 +77,41 @@ const types = [
     },
 ];
 
+const contributing = [
+    {
+        name: 'Contributing',
+        href: `${base}guide/contributing`,
+        summary: 'Prerequisites, local build and test setup, code conventions, and how to open a PR.',
+        whenToUse: 'You want to contribute a bug fix, feature, or documentation improvement.',
+        avoidWhen: '',
+        tag: 'Contributors',
+    },
+    {
+        name: 'CI/CD Pipelines',
+        href: `${base}guide/pipelines`,
+        summary: 'Reference for all six GitHub Actions workflows: triggers, secrets, local equivalents, and gotchas.',
+        whenToUse: 'You need to understand or debug the CI/CD setup.',
+        avoidWhen: '',
+        tag: 'Maintainers',
+    },
+    {
+        name: 'Release Process',
+        href: `${base}guide/release-process`,
+        summary: 'Step-by-step guide for cutting a stable release: version bump, publish, tag, post-release SNAPSHOT.',
+        whenToUse: 'You are cutting a new release.',
+        avoidWhen: '',
+        tag: 'Maintainers',
+    },
+    {
+        name: 'Adding a New Module',
+        href: `${base}guide/module-conventions`,
+        summary: 'Conventions and checklist for adding a new optional integration module.',
+        whenToUse: 'You are adding a new integration module (e.g. fun-spring).',
+        avoidWhen: '',
+        tag: 'Maintainers',
+    },
+];
+
 const modules = [
     {
         name: 'Jackson integration',
@@ -200,6 +235,24 @@ const modules = [
                             <span>{m.avoidWhen}</span>
                         </div>
                     </div>
+                </a>
+            ))}
+        </div>
+
+        <h2>Contributing &amp; Maintainer</h2>
+        <p>
+            Documentation for working on the library itself: local setup, CI pipelines, release process,
+            and conventions for adding new modules.
+        </p>
+
+        <div class="type-grid">
+            {contributing.map(c => (
+                <a href={c.href} class="type-card">
+                    <div class="type-card-header">
+                        <code class="type-name">{c.name}</code>
+                        <span class="type-tag">{c.tag}</span>
+                    </div>
+                    <p class="type-summary">{c.summary}</p>
                 </a>
             ))}
         </div>


### PR DESCRIPTION
  Add contributing.mdx, pipelines.mdx, release-process.mdx, and
  module-conventions.mdx covering local setup, CI/CD workflow reference,
  step-by-step release process, and new-module checklist. Externalize
  code snippets under src/data/code/guide/{contributing,release-process,
  module-conventions}/. Register a Contributing & Maintainer section in
  the guide index.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #212

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
