### PR TITLE
feature/non empty map set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Java library of functional types that make failures, absence, and validation explicit in the type system — without ceremony.
 
-`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, and `NonEmptyList<T>` — each designed to compose cleanly with the others and with the Java standard library.
+`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, `NonEmptyList<T>`, `NonEmptyMap<K, V>`, and `NonEmptySet<T>` — each designed to compose cleanly with the others and with the Java standard library.
 
 ---
 
@@ -77,16 +77,18 @@ testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 
 ## Types
 
-| Type              | Tag                  | When to use                                                                       |
-|-------------------|----------------------|-----------------------------------------------------------------------------------|
-| `Option<T>`       | Nullability          | A value that may or may not be present. The null-safe alternative to `@Nullable`. |
-| `Result<V, E>`    | Error handling       | An operation that can succeed or fail with a typed error.                         |
-| `Try<V>`          | Exception handling   | Wraps a computation that may throw. Turns exceptions into values.                 |
-| `Validated<E, A>` | Validation           | Like `Result` but accumulates all errors instead of failing on the first.         |
-| `Either<L, R>`    | Disjoint union       | A value that is one of two types with no success/failure semantics.               |
-| `Lazy<T>`         | Deferred computation | A value computed at most once, on first access. Thread-safe memoization.          |
-| `Tuple2/3/4`      | Product types        | Typed heterogeneous tuples without a dedicated class.                             |
-| `NonEmptyList<T>` | Collections          | A list guaranteed to have at least one element at compile time.                   |
+| Type               | Tag                   | When to use                                                                                              |
+|--------------------|-----------------------|----------------------------------------------------------------------------------------------------------|
+| `Option<T>`        | Nullability           | A value that may or may not be present. The null-safe alternative to `@Nullable`.                        |
+| `Result<V, E>`     | Error handling        | An operation that can succeed or fail with a typed error.                                                |
+| `Try<V>`           | Exception handling    | Wraps a computation that may throw. Turns exceptions into values.                                        |
+| `Validated<E, A>`  | Validation            | Like `Result` but accumulates all errors instead of failing on the first.                                |
+| `Either<L, R>`     | Disjoint union        | A value that is one of two types with no success/failure semantics.                                      |
+| `Lazy<T>`          | Deferred computation  | A value computed at most once, on first access. Thread-safe memoization.                                 |
+| `Tuple2/3/4`       | Product types         | Typed heterogeneous tuples without a dedicated class.                                                    |
+| `NonEmptyList<T>`  | Collections           | A list guaranteed to have at least one element at compile time.                                          |
+| `NonEmptyMap<K,V>` | Collections           | A map guaranteed to have at least one entry at compile time. Insertion order preserved.                  |
+| `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved. |
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ tasks.register('aggregateJavadoc', Exec) {
 
     // Capture all project-relative values at configuration time
     def javadocToolProvider = javaToolchains.javadocToolFor {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
     }
     def libSrc     = project(':lib').file('src/main/java')
     def assertjSrc = project(':assertj').file('src/main/java')

--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -3,8 +3,10 @@ package dmx.fun;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -210,6 +212,18 @@ public final class NonEmptyList<T> implements Iterable<T> {
     // -------------------------------------------------------------------------
     // Interop
     // -------------------------------------------------------------------------
+
+    /**
+     * Converts this list to a {@link NonEmptySet}, preserving the head element and
+     * deduplicating the tail in insertion order.
+     * Duplicate elements are silently dropped; the head is always retained.
+     *
+     * @return a {@code NonEmptySet<T>} with the same distinct elements
+     */
+    public NonEmptySet<T> toNonEmptySet() {
+        Set<T> tailAsSet = new LinkedHashSet<>(tail);
+        return NonEmptySet.of(head, tailAsSet);
+    }
 
     /**
      * Returns a sequential {@link Stream} of all elements (head first, then tail).

--- a/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -1,0 +1,315 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An immutable, non-empty map: a map guaranteed at construction time to contain
+ * at least one entry.
+ *
+ * <p>This type makes the non-emptiness constraint part of the static type system.
+ * APIs that require at least one entry can declare {@code NonEmptyMap<K, V>} instead of
+ * {@code Map<K, V>} and eliminate runtime emptiness checks entirely.
+ *
+ * <p>Insertion order is preserved (backed by {@link LinkedHashMap}). The first entry
+ * inserted is the {@link #headKey()} / {@link #headValue()}.
+ *
+ * <p>This class is {@code @NullMarked}: all keys, values, and parameters are non-null
+ * by default.
+ *
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ */
+@NullMarked
+public final class NonEmptyMap<K, V> {
+
+    private final K headKey;
+    private final V headValue;
+    private final Map<K, V> tail; // unmodifiable, does NOT include headKey
+
+    private NonEmptyMap(K headKey, V headValue, Map<K, V> tail) {
+        this.headKey   = headKey;
+        this.headValue = headValue;
+        this.tail      = tail;
+    }
+
+    // -------------------------------------------------------------------------
+    // Smart constructors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@code NonEmptyMap} with the given head entry and additional entries.
+     *
+     * <p>If {@code rest} contains {@code key}, that duplicate is ignored — the provided
+     * {@code value} is always used for the head key.
+     *
+     * @param key   the head key; must not be {@code null}
+     * @param value the head value; must not be {@code null}
+     * @param rest  additional entries; must not be {@code null}; keys and values must not be {@code null}
+     * @param <K>   the key type
+     * @param <V>   the value type
+     * @return a new {@code NonEmptyMap}
+     * @throws NullPointerException if {@code key}, {@code value}, {@code rest}, or any
+     *                              key/value inside {@code rest} is {@code null}
+     */
+    public static <K, V> NonEmptyMap<K, V> of(K key, V value, Map<? extends K, ? extends V> rest) {
+        Objects.requireNonNull(key,   "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        Objects.requireNonNull(rest,  "rest must not be null");
+        Map<K, V> tail = new LinkedHashMap<>();
+        rest.forEach((k, v) -> {
+            Objects.requireNonNull(k, "rest keys must not be null");
+            Objects.requireNonNull(v, "rest values must not be null");
+            if (!k.equals(key)) {
+                tail.put(k, v);
+            }
+        });
+        return new NonEmptyMap<>(key, value, Collections.unmodifiableMap(tail));
+    }
+
+    /**
+     * Creates a {@code NonEmptyMap} containing exactly one entry.
+     *
+     * @param key   the sole key; must not be {@code null}
+     * @param value the sole value; must not be {@code null}
+     * @param <K>   the key type
+     * @param <V>   the value type
+     * @return a singleton {@code NonEmptyMap}
+     * @throws NullPointerException if {@code key} or {@code value} is {@code null}
+     */
+    public static <K, V> NonEmptyMap<K, V> singleton(K key, V value) {
+        Objects.requireNonNull(key,   "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        return new NonEmptyMap<>(key, value, Map.of());
+    }
+
+    /**
+     * Attempts to construct a {@code NonEmptyMap} from a plain {@link Map}.
+     *
+     * @param map  the source map; must not be {@code null}; keys and values must not be {@code null}
+     * @param <K>  the key type
+     * @param <V>  the value type
+     * @return {@link Option#some(Object)} wrapping the {@code NonEmptyMap} if the map is
+     *         non-empty, or {@link Option#none()} if the map is empty
+     * @throws NullPointerException if {@code map} or any key/value is {@code null}
+     */
+    public static <K, V> Option<NonEmptyMap<K, V>> fromMap(Map<? extends K, ? extends V> map) {
+        Objects.requireNonNull(map, "map must not be null");
+        if (map.isEmpty()) {
+            return Option.none();
+        }
+        map.forEach((k, v) -> {
+            Objects.requireNonNull(k, "map keys must not be null");
+            Objects.requireNonNull(v, "map values must not be null");
+        });
+        return Option.some(fromMapUnsafe(map));
+    }
+
+    /** Internal: builds from a known-non-empty map without Option wrapping. */
+    private static <K, V> NonEmptyMap<K, V> fromMapUnsafe(Map<? extends K, ? extends V> map) {
+        Iterator<? extends Map.Entry<? extends K, ? extends V>> it = map.entrySet().iterator();
+        Map.Entry<? extends K, ? extends V> first = it.next();
+        K headKey   = first.getKey();
+        V headValue = first.getValue();
+        Map<K, V> tail = new LinkedHashMap<>();
+        while (it.hasNext()) {
+            Map.Entry<? extends K, ? extends V> entry = it.next();
+            tail.put(entry.getKey(), entry.getValue());
+        }
+        return new NonEmptyMap<>(headKey, headValue, Collections.unmodifiableMap(tail));
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the guaranteed head key of this map.
+     *
+     * @return the head key (never {@code null})
+     */
+    public K headKey() {
+        return headKey;
+    }
+
+    /**
+     * Returns the value associated with the head key.
+     *
+     * @return the head value (never {@code null})
+     */
+    public V headValue() {
+        return headValue;
+    }
+
+    /**
+     * Returns the number of entries in this map. Always &ge; 1.
+     *
+     * @return the size
+     */
+    public int size() {
+        return 1 + tail.size();
+    }
+
+    /**
+     * Returns the value associated with {@code key}, or {@link Option#none()} if absent.
+     *
+     * @param key the key to look up; must not be {@code null}
+     * @return {@code Some(value)} if the key is present, {@code None} otherwise
+     * @throws NullPointerException if {@code key} is {@code null}
+     */
+    public Option<V> get(K key) {
+        Objects.requireNonNull(key, "key must not be null");
+        if (headKey.equals(key)) return Option.some(headValue);
+        return Option.ofNullable(tail.get(key));
+    }
+
+    /**
+     * Returns {@code true} if this map contains an entry for {@code key}.
+     *
+     * @param key the key to test; must not be {@code null}
+     * @return {@code true} if the key is present
+     * @throws NullPointerException if {@code key} is {@code null}
+     */
+    public boolean containsKey(K key) {
+        Objects.requireNonNull(key, "key must not be null");
+        return headKey.equals(key) || tail.containsKey(key);
+    }
+
+    /**
+     * Returns an unmodifiable {@link Map} containing all entries (head entry first,
+     * then tail entries in insertion order).
+     *
+     * @return a new unmodifiable map with all entries
+     */
+    public Map<K, V> toMap() {
+        Map<K, V> result = new LinkedHashMap<>();
+        result.put(headKey, headValue);
+        result.putAll(tail);
+        return Collections.unmodifiableMap(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies {@code mapper} to every value and returns a new {@code NonEmptyMap}
+     * with the same keys and mapped values.
+     *
+     * @param mapper a non-null function to apply to each value; must not return {@code null}
+     * @param <R>    the result value type
+     * @return a new {@code NonEmptyMap} with mapped values
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    public <R> NonEmptyMap<K, R> mapValues(Function<? super V, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        R newHead = Objects.requireNonNull(mapper.apply(headValue), "mapper must not return null");
+        Map<K, R> newTail = new LinkedHashMap<>();
+        tail.forEach((k, v) ->
+            newTail.put(k, Objects.requireNonNull(mapper.apply(v), "mapper must not return null")));
+        return new NonEmptyMap<>(headKey, newHead, Collections.unmodifiableMap(newTail));
+    }
+
+    /**
+     * Applies {@code mapper} to every key and returns a new {@code NonEmptyMap}
+     * with the mapped keys and the original values.
+     *
+     * <p>If multiple keys map to the same new key, last-write-wins semantics apply
+     * (same as building a {@link LinkedHashMap} in encounter order). The head key is
+     * always processed first.
+     *
+     * @param mapper a non-null function to apply to each key; must not return {@code null}
+     * @param <R>    the result key type
+     * @return a new {@code NonEmptyMap} with mapped keys
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    public <R> NonEmptyMap<R, V> mapKeys(Function<? super K, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        R newHeadKey = Objects.requireNonNull(mapper.apply(headKey), "mapper must not return null");
+        Map<R, V> newTail = new LinkedHashMap<>();
+        tail.forEach((k, v) -> {
+            R mapped = Objects.requireNonNull(mapper.apply(k), "mapper must not return null");
+            if (!mapped.equals(newHeadKey)) {
+                newTail.put(mapped, v);
+            }
+        });
+        return new NonEmptyMap<>(newHeadKey, headValue, Collections.unmodifiableMap(newTail));
+    }
+
+    /**
+     * Returns a new {@code NonEmptyMap} containing only entries for which {@code predicate}
+     * returns {@code true}, wrapped in {@link Option#some(Object)}.
+     * Returns {@link Option#none()} if no entries pass the predicate.
+     *
+     * @param predicate a non-null predicate to test each key-value pair
+     * @return {@code Some(filteredMap)} if at least one entry passes, {@code None} otherwise
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     */
+    public Option<NonEmptyMap<K, V>> filter(BiPredicate<? super K, ? super V> predicate) {
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        Map<K, V> result = new LinkedHashMap<>();
+        if (predicate.test(headKey, headValue)) result.put(headKey, headValue);
+        tail.forEach((k, v) -> { if (predicate.test(k, v)) result.put(k, v); });
+        return NonEmptyMap.fromMap(result);
+    }
+
+    /**
+     * Returns a new {@code NonEmptyMap} that is the union of this map and {@code other}.
+     * When both maps contain the same key, {@code mergeFunction} is applied to the two values.
+     *
+     * @param other         the other map; must not be {@code null}
+     * @param mergeFunction function to resolve value conflicts; must not be {@code null}
+     * @return a new {@code NonEmptyMap} containing all entries from both maps
+     * @throws NullPointerException if {@code other} or {@code mergeFunction} is {@code null}
+     */
+    public NonEmptyMap<K, V> merge(NonEmptyMap<K, V> other, BinaryOperator<V> mergeFunction) {
+        Objects.requireNonNull(other,         "other must not be null");
+        Objects.requireNonNull(mergeFunction, "mergeFunction must not be null");
+        Map<K, V> combined = new LinkedHashMap<>(this.toMap());
+        other.toMap().forEach((k, v) -> combined.merge(k, v, mergeFunction));
+        return fromMapUnsafe(combined);
+    }
+
+    /**
+     * Converts this map to a {@link NonEmptyList} of its entries in insertion order.
+     *
+     * @return a {@code NonEmptyList<Map.Entry<K, V>>}
+     */
+    public NonEmptyList<Map.Entry<K, V>> toNonEmptyList() {
+        List<Map.Entry<K, V>> entries = new ArrayList<>(toMap().entrySet());
+        Map.Entry<K, V> head = entries.get(0);
+        List<Map.Entry<K, V>> tailList = entries.subList(1, entries.size());
+        return NonEmptyList.of(head, List.copyOf(tailList));
+    }
+
+    // -------------------------------------------------------------------------
+    // Object
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof NonEmptyMap<?, ?> other)) return false;
+        return toMap().equals(other.toMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return toMap().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return toMap().toString();
+    }
+}

--- a/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -301,15 +301,20 @@ public final class NonEmptyMap<K, V> {
      * When both maps contain the same key, {@code mergeFunction} is applied to the two values.
      *
      * @param other         the other map; must not be {@code null}
-     * @param mergeFunction function to resolve value conflicts; must not be {@code null}
+     * @param mergeFunction function to resolve value conflicts; must not be {@code null};
+     *                      must not return {@code null} (a null return would violate the
+     *                      non-null value contract and is rejected immediately)
      * @return a new {@code NonEmptyMap} containing all entries from both maps
-     * @throws NullPointerException if {@code other} or {@code mergeFunction} is {@code null}
+     * @throws NullPointerException if {@code other}, {@code mergeFunction}, or the result
+     *                              of {@code mergeFunction} is {@code null}
      */
     public NonEmptyMap<K, V> merge(NonEmptyMap<K, V> other, BinaryOperator<V> mergeFunction) {
         Objects.requireNonNull(other,         "other must not be null");
         Objects.requireNonNull(mergeFunction, "mergeFunction must not be null");
         Map<K, V> combined = new LinkedHashMap<>(this.toMap());
-        other.toMap().forEach((k, v) -> combined.merge(k, v, mergeFunction));
+        other.toMap().forEach((k, v) -> combined.merge(k, v,
+            (oldVal, newVal) -> Objects.requireNonNull(
+                mergeFunction.apply(oldVal, newVal), "mergeFunction must not return null")));
         return fromMapUnsafe(combined);
     }
 

--- a/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -186,6 +186,27 @@ public final class NonEmptyMap<K, V> {
     }
 
     /**
+     * Returns a {@link NonEmptySet} containing all keys of this map in insertion order.
+     * The head key of this map is the head of the returned set.
+     *
+     * @return a {@code NonEmptySet<K>} of all keys (never {@code null})
+     */
+    public NonEmptySet<K> keySet() {
+        return NonEmptySet.of(headKey, tail.keySet());
+    }
+
+    /**
+     * Returns a {@link NonEmptyList} containing all values of this map in insertion order.
+     * The head value of this map is the head of the returned list.
+     * Duplicate values are preserved (unlike keys, values need not be unique).
+     *
+     * @return a {@code NonEmptyList<V>} of all values (never {@code null})
+     */
+    public NonEmptyList<V> values() {
+        return NonEmptyList.of(headValue, new ArrayList<>(tail.values()));
+    }
+
+    /**
      * Returns an unmodifiable {@link Map} containing all entries (head entry first,
      * then tail entries in insertion order).
      *

--- a/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -37,6 +37,8 @@ public final class NonEmptyMap<K, V> {
     private final V headValue;
     private final Map<K, V> tail; // unmodifiable, does NOT include headKey
 
+    private transient volatile Map<K, V> cachedMap;
+
     private NonEmptyMap(K headKey, V headValue, Map<K, V> tail) {
         this.headKey   = headKey;
         this.headValue = headValue;
@@ -208,15 +210,25 @@ public final class NonEmptyMap<K, V> {
 
     /**
      * Returns an unmodifiable {@link Map} containing all entries (head entry first,
-     * then tail entries in insertion order).
+     * then tail entries in insertion order). The same instance is returned on repeated
+     * calls (lazily initialized, thread-safe).
      *
-     * @return a new unmodifiable map with all entries
+     * @return an unmodifiable map with all entries
      */
     public Map<K, V> toMap() {
-        Map<K, V> result = new LinkedHashMap<>();
-        result.put(headKey, headValue);
-        result.putAll(tail);
-        return Collections.unmodifiableMap(result);
+        Map<K, V> m = cachedMap;
+        if (m == null) {
+            synchronized (this) {
+                m = cachedMap;
+                if (m == null) {
+                    Map<K, V> result = new LinkedHashMap<>();
+                    result.put(headKey, headValue);
+                    result.putAll(tail);
+                    cachedMap = m = Collections.unmodifiableMap(result);
+                }
+            }
+        }
+        return m;
     }
 
     // -------------------------------------------------------------------------
@@ -245,9 +257,9 @@ public final class NonEmptyMap<K, V> {
      * Applies {@code mapper} to every key and returns a new {@code NonEmptyMap}
      * with the mapped keys and the original values.
      *
-     * <p>If multiple keys map to the same new key, last-write-wins semantics apply
-     * (same as building a {@link LinkedHashMap} in encounter order). The head key is
-     * always processed first.
+     * <p>If multiple keys map to the same new key, <strong>head-wins</strong> semantics apply:
+     * the head entry is always preserved, and any tail entry whose mapped key collides with
+     * the mapped head key is silently dropped.
      *
      * @param mapper a non-null function to apply to each key; must not return {@code null}
      * @param <R>    the result key type

--- a/lib/src/main/java/dmx/fun/NonEmptySet.java
+++ b/lib/src/main/java/dmx/fun/NonEmptySet.java
@@ -34,6 +34,8 @@ public final class NonEmptySet<T> implements Iterable<T> {
     private final T head;
     private final Set<T> tail; // unmodifiable, does NOT include head
 
+    private transient volatile Set<T> cachedSet;
+
     private NonEmptySet(T head, Set<T> tail) {
         this.head = head;
         this.tail = tail;
@@ -146,15 +148,25 @@ public final class NonEmptySet<T> implements Iterable<T> {
 
     /**
      * Returns an unmodifiable {@link Set} containing all elements (head first, then
-     * tail in insertion order).
+     * tail in insertion order). The same instance is returned on repeated calls
+     * (lazily initialized, thread-safe).
      *
-     * @return a new unmodifiable set with all elements
+     * @return an unmodifiable set with all elements
      */
     public Set<T> toSet() {
-        Set<T> result = new LinkedHashSet<>();
-        result.add(head);
-        result.addAll(tail);
-        return Collections.unmodifiableSet(result);
+        Set<T> s = cachedSet;
+        if (s == null) {
+            synchronized (this) {
+                s = cachedSet;
+                if (s == null) {
+                    Set<T> result = new LinkedHashSet<>();
+                    result.add(head);
+                    result.addAll(tail);
+                    cachedSet = s = Collections.unmodifiableSet(result);
+                }
+            }
+        }
+        return s;
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/main/java/dmx/fun/NonEmptySet.java
+++ b/lib/src/main/java/dmx/fun/NonEmptySet.java
@@ -3,8 +3,10 @@ package dmx.fun;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -246,6 +248,28 @@ public final class NonEmptySet<T> implements Iterable<T> {
     public NonEmptyList<T> toNonEmptyList() {
         List<T> tailList = new ArrayList<>(tail);
         return NonEmptyList.of(head, tailList);
+    }
+
+    /**
+     * Returns a {@link NonEmptyMap} by applying {@code valueMapper} to each element of
+     * this set. Elements become keys; mapped results become values.
+     * The head of this set is the head key of the returned map.
+     *
+     * @param valueMapper a non-null function to derive a value from each element;
+     *                    must not return {@code null}
+     * @param <V>         the value type
+     * @return a new {@code NonEmptyMap<T, V>}
+     * @throws NullPointerException if {@code valueMapper} is {@code null} or returns {@code null}
+     */
+    public <V> NonEmptyMap<T, V> toNonEmptyMap(Function<? super T, ? extends V> valueMapper) {
+        Objects.requireNonNull(valueMapper, "valueMapper must not be null");
+        V headVal = Objects.requireNonNull(valueMapper.apply(head), "valueMapper must not return null");
+        Map<T, V> tailMap = new LinkedHashMap<>();
+        for (T element : tail) {
+            V val = Objects.requireNonNull(valueMapper.apply(element), "valueMapper must not return null");
+            tailMap.put(element, val);
+        }
+        return NonEmptyMap.of(head, headVal, tailMap);
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/main/java/dmx/fun/NonEmptySet.java
+++ b/lib/src/main/java/dmx/fun/NonEmptySet.java
@@ -1,0 +1,302 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An immutable, non-empty set: a set guaranteed at construction time to contain
+ * at least one element.
+ *
+ * <p>This type makes the non-emptiness constraint part of the static type system.
+ * APIs that require at least one item can declare {@code NonEmptySet<T>} instead of
+ * {@code Set<T>} and eliminate runtime emptiness checks entirely.
+ *
+ * <p>Insertion order is preserved (backed by {@link LinkedHashSet}). The first element
+ * inserted is the {@link #head()}.
+ *
+ * <p>This class is {@code @NullMarked}: all elements and parameters are non-null by default.
+ *
+ * @param <T> the type of elements in this set
+ */
+@NullMarked
+public final class NonEmptySet<T> implements Iterable<T> {
+
+    private final T head;
+    private final Set<T> tail; // unmodifiable, does NOT include head
+
+    private NonEmptySet(T head, Set<T> tail) {
+        this.head = head;
+        this.tail = tail;
+    }
+
+    // -------------------------------------------------------------------------
+    // Smart constructors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@code NonEmptySet} with the given head element and additional elements.
+     *
+     * <p>If {@code rest} contains {@code head}, the duplicate is silently ignored.
+     *
+     * @param head the first (mandatory) element; must not be {@code null}
+     * @param rest additional elements; must not be {@code null}; elements must not be {@code null}
+     * @param <T>  the element type
+     * @return a new {@code NonEmptySet}
+     * @throws NullPointerException if {@code head}, {@code rest}, or any element in
+     *                              {@code rest} is {@code null}
+     */
+    public static <T> NonEmptySet<T> of(T head, Set<? extends T> rest) {
+        Objects.requireNonNull(head, "head must not be null");
+        Objects.requireNonNull(rest, "rest must not be null");
+        Set<T> tail = new LinkedHashSet<>();
+        for (T element : rest) {
+            Objects.requireNonNull(element, "rest elements must not be null");
+            if (!element.equals(head)) {
+                tail.add(element);
+            }
+        }
+        return new NonEmptySet<>(head, Collections.unmodifiableSet(tail));
+    }
+
+    /**
+     * Creates a {@code NonEmptySet} containing exactly one element.
+     *
+     * @param head the sole element; must not be {@code null}
+     * @param <T>  the element type
+     * @return a singleton {@code NonEmptySet}
+     * @throws NullPointerException if {@code head} is {@code null}
+     */
+    public static <T> NonEmptySet<T> singleton(T head) {
+        Objects.requireNonNull(head, "head must not be null");
+        return new NonEmptySet<>(head, Set.of());
+    }
+
+    /**
+     * Attempts to construct a {@code NonEmptySet} from a plain {@link Set}.
+     *
+     * @param set  the source set; must not be {@code null}; elements must not be {@code null}
+     * @param <T>  the element type
+     * @return {@link Option#some(Object)} wrapping the {@code NonEmptySet} if the set is
+     *         non-empty, or {@link Option#none()} if the set is empty
+     * @throws NullPointerException if {@code set} or any element is {@code null}
+     */
+    public static <T> Option<NonEmptySet<T>> fromSet(Set<? extends T> set) {
+        Objects.requireNonNull(set, "set must not be null");
+        if (set.isEmpty()) {
+            return Option.none();
+        }
+        set.forEach(e -> Objects.requireNonNull(e, "set elements must not be null"));
+        return Option.some(fromSetUnsafe(set));
+    }
+
+    /** Internal: builds from a known-non-empty set without Option wrapping. */
+    private static <T> NonEmptySet<T> fromSetUnsafe(Set<? extends T> set) {
+        Iterator<? extends T> it = set.iterator();
+        T head = it.next();
+        Set<T> tail = new LinkedHashSet<>();
+        while (it.hasNext()) {
+            tail.add(it.next());
+        }
+        return new NonEmptySet<>(head, Collections.unmodifiableSet(tail));
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the guaranteed head element of this set (the first inserted element).
+     *
+     * @return the head element (never {@code null})
+     */
+    public T head() {
+        return head;
+    }
+
+    /**
+     * Returns the number of elements in this set. Always &ge; 1.
+     *
+     * @return the size
+     */
+    public int size() {
+        return 1 + tail.size();
+    }
+
+    /**
+     * Returns {@code true} if this set contains {@code element}.
+     *
+     * @param element the element to test; must not be {@code null}
+     * @return {@code true} if the element is present
+     * @throws NullPointerException if {@code element} is {@code null}
+     */
+    public boolean contains(T element) {
+        Objects.requireNonNull(element, "element must not be null");
+        return head.equals(element) || tail.contains(element);
+    }
+
+    /**
+     * Returns an unmodifiable {@link Set} containing all elements (head first, then
+     * tail in insertion order).
+     *
+     * @return a new unmodifiable set with all elements
+     */
+    public Set<T> toSet() {
+        Set<T> result = new LinkedHashSet<>();
+        result.add(head);
+        result.addAll(tail);
+        return Collections.unmodifiableSet(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies {@code mapper} to every element and returns a new {@code NonEmptySet}
+     * of the results. Duplicate mapped values are deduplicated; the head is always
+     * the mapped value of the original head.
+     *
+     * @param mapper a non-null function to apply to each element; must not return {@code null}
+     * @param <R>    the result element type
+     * @return a new {@code NonEmptySet} of mapped values
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    public <R> NonEmptySet<R> map(Function<? super T, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        R newHead = Objects.requireNonNull(mapper.apply(head), "mapper must not return null");
+        Set<R> newTail = new LinkedHashSet<>();
+        for (T element : tail) {
+            R mapped = Objects.requireNonNull(mapper.apply(element), "mapper must not return null");
+            if (!mapped.equals(newHead)) {
+                newTail.add(mapped);
+            }
+        }
+        return new NonEmptySet<>(newHead, Collections.unmodifiableSet(newTail));
+    }
+
+    /**
+     * Returns a new {@code NonEmptySet} containing elements that satisfy {@code predicate},
+     * wrapped in {@link Option#some(Object)}.
+     * Returns {@link Option#none()} if no elements pass the predicate.
+     *
+     * @param predicate a non-null predicate to test each element
+     * @return {@code Some(filteredSet)} if at least one element passes, {@code None} otherwise
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     */
+    public Option<NonEmptySet<T>> filter(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        if (predicate.test(head)) result.add(head);
+        for (T element : tail) {
+            if (predicate.test(element)) result.add(element);
+        }
+        if (result.isEmpty()) return Option.none();
+        return Option.some(fromSetUnsafe(result));
+    }
+
+    /**
+     * Returns a new {@code NonEmptySet} that is the union of this set and {@code other}.
+     * The result is always non-empty since both inputs are non-empty.
+     *
+     * @param other the other set; must not be {@code null}
+     * @return a new {@code NonEmptySet} containing all elements from both sets
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    public NonEmptySet<T> union(NonEmptySet<T> other) {
+        Objects.requireNonNull(other, "other must not be null");
+        Set<T> combined = new LinkedHashSet<>(this.toSet());
+        combined.addAll(other.toSet());
+        return fromSetUnsafe(combined);
+    }
+
+    /**
+     * Returns a new {@code NonEmptySet} containing only elements present in both this
+     * set and {@code other}, wrapped in {@link Option#some(Object)}.
+     * Returns {@link Option#none()} if the intersection is empty.
+     *
+     * @param other the set to intersect with; must not be {@code null}
+     * @return {@code Some(intersection)} if at least one common element exists,
+     *         {@code None} otherwise
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    public Option<NonEmptySet<T>> intersection(Set<? extends T> other) {
+        Objects.requireNonNull(other, "other must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        if (other.contains(head)) result.add(head);
+        for (T element : tail) {
+            if (other.contains(element)) result.add(element);
+        }
+        if (result.isEmpty()) return Option.none();
+        return Option.some(fromSetUnsafe(result));
+    }
+
+    /**
+     * Converts this set to a {@link NonEmptyList} of its elements in insertion order.
+     *
+     * @return a {@code NonEmptyList<T>} with the same elements
+     */
+    public NonEmptyList<T> toNonEmptyList() {
+        List<T> tailList = new ArrayList<>(tail);
+        return NonEmptyList.of(head, tailList);
+    }
+
+    // -------------------------------------------------------------------------
+    // Iterable
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns an iterator over all elements (head first, then tail in insertion order).
+     *
+     * @return an iterator
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<T>() {
+            private boolean headConsumed = false;
+            private final Iterator<T> tailIt = tail.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return !headConsumed || tailIt.hasNext();
+            }
+
+            @Override
+            public T next() {
+                if (!headConsumed) {
+                    headConsumed = true;
+                    return head;
+                }
+                return tailIt.next();
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Object
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof NonEmptySet<?> other)) return false;
+        return toSet().equals(other.toSet());
+    }
+
+    @Override
+    public int hashCode() {
+        return toSet().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return toSet().toString();
+    }
+}

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -5,20 +5,22 @@
  * <ul>
  *   <li>{@link dmx.fun.Option} — represents an optional value</li>
  *   <li>{@link dmx.fun.Result} — represents a value or an error</li>
+ *   <li>{@link dmx.fun.Either} — neutral disjoint union of two value types</li>
  *   <li>{@link dmx.fun.Try}    — represents a computation that may throw</li>
- *   <li>{@link dmx.fun.Tuple2}     — an immutable pair of two values</li>
+ *   <li>{@link dmx.fun.Tuple2}    — an immutable pair of two values</li>
  *   <li>{@link dmx.fun.Validated} — error-accumulating validation type</li>
  *   <li>{@link dmx.fun.CheckedSupplier} — supplier that may throw checked exceptions</li>
- *   <li>{@link dmx.fun.CheckedRunnable}  — runnable that may throw checked exceptions</li>
- *   <li>{@link dmx.fun.CheckedFunction}  — function that may throw checked exceptions</li>
- *   <li>{@link dmx.fun.CheckedConsumer}  — consumer that may throw checked exceptions</li>
+ *   <li>{@link dmx.fun.CheckedRunnable} — runnable that may throw checked exceptions</li>
+ *   <li>{@link dmx.fun.CheckedFunction} — function that may throw checked exceptions</li>
+ *   <li>{@link dmx.fun.CheckedConsumer} — consumer that may throw checked exceptions</li>
  *   <li>{@link dmx.fun.Tuple3}       — immutable triple of three values</li>
  *   <li>{@link dmx.fun.Tuple4}       — immutable quadruple of four values</li>
  *   <li>{@link dmx.fun.TriFunction}  — function accepting three arguments</li>
  *   <li>{@link dmx.fun.QuadFunction} — function accepting four arguments</li>
  *   <li>{@link dmx.fun.Lazy}         — lazily evaluated, memoized value</li>
  *   <li>{@link dmx.fun.NonEmptyList} — list guaranteed to contain at least one element</li>
- *   <li>{@link dmx.fun.Either}       — neutral disjoint union of two value types</li>
+ *   <li>{@link dmx.fun.NonEmptyMap}  — map guaranteed to contain at least one entry</li>
+ *   <li>{@link dmx.fun.NonEmptySet}  — set guaranteed to contain at least one element</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -273,6 +273,36 @@ class NonEmptyListTest {
     }
 
     // -------------------------------------------------------------------------
+    // toNonEmptySet()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toNonEmptySet_shouldContainAllDistinctElements() {
+        NonEmptyList<String> nel = NonEmptyList.of("a", List.of("b", "c"));
+        NonEmptySet<String> nes = nel.toNonEmptySet();
+        assertThat(nes.size()).isEqualTo(3);
+        assertThat(nes.head()).isEqualTo("a");
+        assertThat(nes.contains("b")).isTrue();
+        assertThat(nes.contains("c")).isTrue();
+    }
+
+    @Test
+    void toNonEmptySet_shouldDeduplicateTailElements() {
+        NonEmptyList<String> nel = NonEmptyList.of("a", List.of("b", "a", "b"));
+        NonEmptySet<String> nes = nel.toNonEmptySet();
+        assertThat(nes.size()).isEqualTo(2);
+        assertThat(nes.head()).isEqualTo("a");
+        assertThat(nes.contains("b")).isTrue();
+    }
+
+    @Test
+    void toNonEmptySet_singletonShouldYieldSingletonSet() {
+        NonEmptySet<String> nes = NonEmptyList.singleton("x").toNonEmptySet();
+        assertThat(nes.size()).isEqualTo(1);
+        assertThat(nes.head()).isEqualTo("x");
+    }
+
+    // -------------------------------------------------------------------------
     // Iterable
     // -------------------------------------------------------------------------
 

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -284,6 +284,7 @@ class NonEmptyListTest {
         assertThat(nes.head()).isEqualTo("a");
         assertThat(nes.contains("b")).isTrue();
         assertThat(nes.contains("c")).isTrue();
+        assertThat(nes).containsExactly("a", "b", "c"); // insertion order preserved
     }
 
     @Test
@@ -293,6 +294,7 @@ class NonEmptyListTest {
         assertThat(nes.size()).isEqualTo(2);
         assertThat(nes.head()).isEqualTo("a");
         assertThat(nes.contains("b")).isTrue();
+        assertThat(nes).containsExactly("a", "b"); // insertion order preserved
     }
 
     @Test
@@ -300,6 +302,7 @@ class NonEmptyListTest {
         NonEmptySet<String> nes = NonEmptyList.singleton("x").toNonEmptySet();
         assertThat(nes.size()).isEqualTo(1);
         assertThat(nes.head()).isEqualTo("x");
+        assertThat(nes).containsExactly("x");
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -242,6 +242,56 @@ class NonEmptyMapTest {
     }
 
     // -------------------------------------------------------------------------
+    // keySet()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void keySet_shouldReturnAllKeys() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        NonEmptySet<String> keys = nem.keySet();
+        assertThat(keys.size()).isEqualTo(2);
+        assertThat(keys.contains("alice")).isTrue();
+        assertThat(keys.contains("bob")).isTrue();
+    }
+
+    @Test
+    void keySet_headShouldMatchMapHeadKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        assertThat(nem.keySet().head()).isEqualTo("alice");
+    }
+
+    @Test
+    void keySet_singletonMapShouldYieldSingletonSet() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.keySet().size()).isEqualTo(1);
+        assertThat(nem.keySet().head()).isEqualTo("alice");
+    }
+
+    // -------------------------------------------------------------------------
+    // values()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void values_shouldReturnAllValues() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        NonEmptyList<Integer> vals = nem.values();
+        assertThat(vals.size()).isEqualTo(2);
+        assertThat(vals.toList()).containsExactlyInAnyOrder(10, 20);
+    }
+
+    @Test
+    void values_headShouldMatchMapHeadValue() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 42);
+        assertThat(nem.values().head()).isEqualTo(42);
+    }
+
+    @Test
+    void values_shouldPreserveDuplicateValues() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 10));
+        assertThat(nem.values().size()).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
     // toNonEmptyList()
     // -------------------------------------------------------------------------
 

--- a/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -1,0 +1,279 @@
+package dmx.fun;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NonEmptyMapTest {
+
+    // -------------------------------------------------------------------------
+    // of()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_shouldCreateMapWithHeadAndRest() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        assertThat(nem.headKey()).isEqualTo("alice");
+        assertThat(nem.headValue()).isEqualTo(10);
+        assertThat(nem.size()).isEqualTo(2);
+    }
+
+    @Test
+    void of_shouldCreateMapWithEmptyRest() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of());
+        assertThat(nem.size()).isEqualTo(1);
+    }
+
+    @Test
+    void of_shouldIgnoreDuplicateKeyInRest() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("alice", 99));
+        assertThat(nem.size()).isEqualTo(1);
+        assertThat(nem.headValue()).isEqualTo(10);
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenKeyIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.of(null, 1, Map.of()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("key");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenValueIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.of("k", null, Map.of()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("value");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenRestIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.of("k", 1, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("rest");
+    }
+
+    // -------------------------------------------------------------------------
+    // singleton()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void singleton_shouldCreateSingleEntryMap() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.headKey()).isEqualTo("alice");
+        assertThat(nem.headValue()).isEqualTo(10);
+        assertThat(nem.size()).isEqualTo(1);
+    }
+
+    @Test
+    void singleton_shouldThrowNPE_whenKeyIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.singleton(null, 1))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromMap()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromMap_shouldReturnSome_whenMapIsNonEmpty() {
+        Option<NonEmptyMap<String, Integer>> result = NonEmptyMap.fromMap(Map.of("a", 1));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+    }
+
+    @Test
+    void fromMap_shouldReturnNone_whenMapIsEmpty() {
+        Option<NonEmptyMap<String, Integer>> result = NonEmptyMap.fromMap(Map.of());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromMap_shouldThrowNPE_whenMapIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.fromMap(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // get() / containsKey()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void get_shouldReturnSome_forHeadKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.get("alice").isDefined()).isTrue();
+        assertThat(nem.get("alice").get()).isEqualTo(10);
+    }
+
+    @Test
+    void get_shouldReturnSome_forTailKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        assertThat(nem.get("bob").isDefined()).isTrue();
+        assertThat(nem.get("bob").get()).isEqualTo(20);
+    }
+
+    @Test
+    void get_shouldReturnNone_forAbsentKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.get("unknown").isEmpty()).isTrue();
+    }
+
+    @Test
+    void containsKey_shouldReturnTrue_forHeadKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.containsKey("alice")).isTrue();
+    }
+
+    @Test
+    void containsKey_shouldReturnFalse_forAbsentKey() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.containsKey("bob")).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // toMap()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toMap_shouldReturnAllEntries() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        Map<String, Integer> map = nem.toMap();
+        assertThat(map).containsEntry("alice", 10).containsEntry("bob", 20);
+    }
+
+    @Test
+    void toMap_shouldBeUnmodifiable() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThatThrownBy(() -> nem.toMap().put("x", 1))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // mapValues()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapValues_shouldTransformAllValues() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        NonEmptyMap<String, String> mapped = nem.mapValues(v -> v + " pts");
+        assertThat(mapped.get("alice").get()).isEqualTo("10 pts");
+        assertThat(mapped.get("bob").get()).isEqualTo("20 pts");
+    }
+
+    @Test
+    void mapValues_shouldThrowNPE_whenMapperIsNull() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("a", 1);
+        assertThatThrownBy(() -> nem.mapValues(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // mapKeys()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapKeys_shouldTransformAllKeys() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        NonEmptyMap<String, Integer> mapped = nem.mapKeys(String::toUpperCase);
+        assertThat(mapped.containsKey("ALICE")).isTrue();
+        assertThat(mapped.containsKey("BOB")).isTrue();
+    }
+
+    @Test
+    void mapKeys_shouldDropDuplicateKeysKeepingHead() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("a", 1, Map.of("A", 2));
+        NonEmptyMap<String, Integer> mapped = nem.mapKeys(String::toUpperCase);
+        assertThat(mapped.size()).isEqualTo(1);
+        assertThat(mapped.headKey()).isEqualTo("A");
+        assertThat(mapped.headValue()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // filter()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void filter_shouldReturnSome_whenSomeEntriesPass() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        Option<NonEmptyMap<String, Integer>> result = nem.filter((k, v) -> v > 15);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+        assertThat(result.get().containsKey("bob")).isTrue();
+    }
+
+    @Test
+    void filter_shouldReturnNone_whenNoEntriesPass() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        Option<NonEmptyMap<String, Integer>> result = nem.filter((k, v) -> v > 100);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void filter_shouldReturnAll_whenAllEntriesPass() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("a", 1, Map.of("b", 2));
+        Option<NonEmptyMap<String, Integer>> result = nem.filter((k, v) -> v > 0);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // merge()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void merge_shouldCombineDistinctEntries() {
+        NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("alice", 10);
+        NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("bob", 20);
+        NonEmptyMap<String, Integer> merged = a.merge(b, Integer::sum);
+        assertThat(merged.size()).isEqualTo(2);
+        assertThat(merged.containsKey("alice")).isTrue();
+        assertThat(merged.containsKey("bob")).isTrue();
+    }
+
+    @Test
+    void merge_shouldApplyMergeFunctionOnConflict() {
+        NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("alice", 10);
+        NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("alice", 5);
+        NonEmptyMap<String, Integer> merged = a.merge(b, Integer::sum);
+        assertThat(merged.size()).isEqualTo(1);
+        assertThat(merged.get("alice").get()).isEqualTo(15);
+    }
+
+    // -------------------------------------------------------------------------
+    // toNonEmptyList()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toNonEmptyList_shouldContainAllEntries() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        NonEmptyList<Map.Entry<String, Integer>> nel = nem.toNonEmptyList();
+        assertThat(nel.size()).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // equals / hashCode / toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void equals_shouldBeTrue_forEqualMaps() {
+        NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("x", 1);
+        NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("x", 1);
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void equals_shouldBeFalse_forDifferentMaps() {
+        NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("x", 1);
+        NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("y", 2);
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void toString_shouldIncludeEntries() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
+        assertThat(nem.toString()).contains("alice").contains("10");
+    }
+}

--- a/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -241,6 +241,15 @@ class NonEmptyMapTest {
         assertThat(merged.get("alice").get()).isEqualTo(15);
     }
 
+    @Test
+    void merge_shouldThrowNPE_whenMergeFunctionReturnsNull() {
+        NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("alice", 10);
+        NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("alice", 5);
+        assertThatThrownBy(() -> a.merge(b, (v1, v2) -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mergeFunction must not return null");
+    }
+
     // -------------------------------------------------------------------------
     // keySet()
     // -------------------------------------------------------------------------

--- a/lib/src/test/java/dmx/fun/NonEmptySetTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptySetTest.java
@@ -1,0 +1,292 @@
+package dmx.fun;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NonEmptySetTest {
+
+    // -------------------------------------------------------------------------
+    // of()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_shouldCreateSetWithHeadAndRest() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+        assertThat(nes.head()).isEqualTo("admin");
+        assertThat(nes.size()).isEqualTo(3);
+    }
+
+    @Test
+    void of_shouldCreateSetWithEmptyRest() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of());
+        assertThat(nes.size()).isEqualTo(1);
+    }
+
+    @Test
+    void of_shouldIgnoreDuplicateHeadInRest() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("admin", "user"));
+        assertThat(nes.size()).isEqualTo(2);
+        assertThat(nes.contains("admin")).isTrue();
+        assertThat(nes.contains("user")).isTrue();
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenHeadIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.of(null, Set.of()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("head");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenRestIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.of("x", null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("rest");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenRestContainsNull() {
+        Set<String> restWithNull = new java.util.HashSet<>();
+        restWithNull.add("user");
+        restWithNull.add(null);
+        assertThatThrownBy(() -> NonEmptySet.of("admin", restWithNull))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // singleton()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void singleton_shouldCreateSingleElementSet() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThat(nes.head()).isEqualTo("admin");
+        assertThat(nes.size()).isEqualTo(1);
+    }
+
+    @Test
+    void singleton_shouldThrowNPE_whenHeadIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.singleton(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromSet()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromSet_shouldReturnSome_whenSetIsNonEmpty() {
+        Option<NonEmptySet<String>> result = NonEmptySet.fromSet(Set.of("a", "b"));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(2);
+    }
+
+    @Test
+    void fromSet_shouldReturnNone_whenSetIsEmpty() {
+        Option<NonEmptySet<String>> result = NonEmptySet.fromSet(Set.of());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromSet_shouldThrowNPE_whenSetIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.fromSet(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // contains() / toSet()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void contains_shouldReturnTrue_forHead() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThat(nes.contains("admin")).isTrue();
+    }
+
+    @Test
+    void contains_shouldReturnTrue_forTailElement() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user"));
+        assertThat(nes.contains("user")).isTrue();
+    }
+
+    @Test
+    void contains_shouldReturnFalse_forAbsentElement() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThat(nes.contains("unknown")).isFalse();
+    }
+
+    @Test
+    void toSet_shouldReturnAllElements() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user"));
+        assertThat(nes.toSet()).containsExactlyInAnyOrder("admin", "user");
+    }
+
+    @Test
+    void toSet_shouldBeUnmodifiable() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThatThrownBy(() -> nes.toSet().add("x"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // map()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void map_shouldTransformAllElements() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user"));
+        NonEmptySet<String> upper = nes.map(String::toUpperCase);
+        assertThat(upper.contains("ADMIN")).isTrue();
+        assertThat(upper.contains("USER")).isTrue();
+    }
+
+    @Test
+    void map_shouldDeduplicateMappedElements() {
+        NonEmptySet<String> nes = NonEmptySet.of("a", Set.of("A"));
+        NonEmptySet<String> mapped = nes.map(String::toUpperCase);
+        assertThat(mapped.size()).isEqualTo(1);
+        assertThat(mapped.head()).isEqualTo("A");
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("x");
+        assertThatThrownBy(() -> nes.map(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // filter()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void filter_shouldReturnSome_whenSomeElementsPass() {
+        NonEmptySet<Integer> nes = NonEmptySet.of(1, Set.of(2, 3));
+        Option<NonEmptySet<Integer>> result = nes.filter(n -> n > 1);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(2);
+    }
+
+    @Test
+    void filter_shouldReturnNone_whenNoElementsPass() {
+        NonEmptySet<Integer> nes = NonEmptySet.singleton(1);
+        Option<NonEmptySet<Integer>> result = nes.filter(n -> n > 100);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void filter_shouldReturnAll_whenAllElementsPass() {
+        NonEmptySet<Integer> nes = NonEmptySet.of(1, Set.of(2, 3));
+        Option<NonEmptySet<Integer>> result = nes.filter(n -> n > 0);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(3);
+    }
+
+    // -------------------------------------------------------------------------
+    // union()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void union_shouldCombineDisjointSets() {
+        NonEmptySet<String> a = NonEmptySet.singleton("admin");
+        NonEmptySet<String> b = NonEmptySet.singleton("user");
+        NonEmptySet<String> union = a.union(b);
+        assertThat(union.size()).isEqualTo(2);
+        assertThat(union.contains("admin")).isTrue();
+        assertThat(union.contains("user")).isTrue();
+    }
+
+    @Test
+    void union_shouldDeduplicateOverlappingElements() {
+        NonEmptySet<String> a = NonEmptySet.of("admin", Set.of("user"));
+        NonEmptySet<String> b = NonEmptySet.singleton("user");
+        NonEmptySet<String> union = a.union(b);
+        assertThat(union.size()).isEqualTo(2);
+    }
+
+    @Test
+    void union_shouldThrowNPE_whenOtherIsNull() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("x");
+        assertThatThrownBy(() -> nes.union(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // intersection()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void intersection_shouldReturnSome_whenCommonElementsExist() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user"));
+        Option<NonEmptySet<String>> result = nes.intersection(Set.of("admin", "moderator"));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+        assertThat(result.get().contains("admin")).isTrue();
+    }
+
+    @Test
+    void intersection_shouldReturnNone_whenNoCommonElements() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        Option<NonEmptySet<String>> result = nes.intersection(Set.of("user"));
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void intersection_shouldThrowNPE_whenOtherIsNull() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("x");
+        assertThatThrownBy(() -> nes.intersection(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // toNonEmptyList()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toNonEmptyList_shouldContainAllElements() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+        NonEmptyList<String> nel = nes.toNonEmptyList();
+        assertThat(nel.size()).isEqualTo(3);
+        assertThat(nel.toList()).containsExactlyInAnyOrder("admin", "user", "moderator");
+    }
+
+    // -------------------------------------------------------------------------
+    // Iterable
+    // -------------------------------------------------------------------------
+
+    @Test
+    void iterable_shouldIterateAllElements() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user"));
+        int count = 0;
+        for (String s : nes) count++;
+        assertThat(count).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // equals / hashCode / toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void equals_shouldBeTrue_forEqualSets() {
+        NonEmptySet<String> a = NonEmptySet.singleton("x");
+        NonEmptySet<String> b = NonEmptySet.singleton("x");
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void equals_shouldBeFalse_forDifferentSets() {
+        NonEmptySet<String> a = NonEmptySet.singleton("x");
+        NonEmptySet<String> b = NonEmptySet.singleton("y");
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void toString_shouldIncludeElements() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThat(nes.toString()).contains("admin");
+    }
+}

--- a/lib/src/test/java/dmx/fun/NonEmptySetTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptySetTest.java
@@ -254,6 +254,36 @@ class NonEmptySetTest {
     }
 
     // -------------------------------------------------------------------------
+    // toNonEmptyMap()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toNonEmptyMap_shouldCreateMapWithMappedValues() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("editor"));
+        NonEmptyMap<String, Integer> nem = nes.toNonEmptyMap(String::length);
+        assertThat(nem.headKey()).isEqualTo("admin");
+        assertThat(nem.headValue()).isEqualTo(5);
+        assertThat(nem.get("editor").get()).isEqualTo(6);
+        assertThat(nem.size()).isEqualTo(2);
+    }
+
+    @Test
+    void toNonEmptyMap_singletonShouldYieldSingletonMap() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        NonEmptyMap<String, Integer> nem = nes.toNonEmptyMap(String::length);
+        assertThat(nem.size()).isEqualTo(1);
+        assertThat(nem.headKey()).isEqualTo("admin");
+        assertThat(nem.headValue()).isEqualTo(5);
+    }
+
+    @Test
+    void toNonEmptyMap_shouldThrowNPE_whenMapperIsNull() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("x");
+        assertThatThrownBy(() -> nes.toNonEmptyMap(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
     // Iterable
     // -------------------------------------------------------------------------
 

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
@@ -1,6 +1,7 @@
 package dmx.fun.samples;
 
 import dmx.fun.NonEmptyList;
+import dmx.fun.NonEmptySet;
 import dmx.fun.Option;
 import dmx.fun.Validated;
 import java.util.List;
@@ -47,6 +48,12 @@ public class NonEmptyListSample {
 
         Option<NonEmptyList<String>> fromFull = NonEmptyList.fromList(List.of("a", "b"));
         System.out.println("From full: " + fromFull.isDefined()); // true
+
+        // toNonEmptySet — deduplicates while preserving head and insertion order
+        NonEmptyList<String> withDups = NonEmptyList.of("java", List.of("fp", "java", "fp", "dmx-fun"));
+        NonEmptySet<String> dedupSet  = withDups.toNonEmptySet();
+        System.out.println("Set head: " + dedupSet.head());  // java
+        System.out.println("Set size: " + dedupSet.size());  // 3 (not 5)
 
         // Concat — instance method
         NonEmptyList<String> more = NonEmptyList.of("quarkus", List.of("spring"));

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java
@@ -2,6 +2,7 @@ package dmx.fun.samples;
 
 import dmx.fun.NonEmptyList;
 import dmx.fun.NonEmptyMap;
+import dmx.fun.NonEmptySet;
 import dmx.fun.Option;
 import java.util.HashSet;
 import java.util.Map;
@@ -104,6 +105,17 @@ public class NonEmptyMapSample {
         System.out.println("Merged bob: " + total.get("bob").getOrElse(0)); // 20
 
         // ---- Interop ----
+
+        // keySet() — all keys as a NonEmptySet; head key becomes set head
+        NonEmptySet<String> keys = scores.keySet();
+        System.out.println("Keys size: " + keys.size());       // 3
+        System.out.println("Keys head: " + keys.head());       // alice
+        System.out.println("Keys has bob: " + keys.contains("bob")); // true
+
+        // values() — all values as a NonEmptyList in insertion order
+        NonEmptyList<Integer> vals = scores.values();
+        System.out.println("Values size: " + vals.size());     // 3
+        System.out.println("Values head: " + vals.head());     // 10
 
         // toMap — standard java.util.Map
         Map<String, Integer> javaMap = scores.toMap();

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java
@@ -1,0 +1,134 @@
+package dmx.fun.samples;
+
+import dmx.fun.NonEmptyList;
+import dmx.fun.NonEmptyMap;
+import dmx.fun.Option;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Demonstrates NonEmptyMap<K, V>: a map guaranteed to have at least one entry at compile time.
+ * Use NonEmptyMap when a registry, configuration, or lookup table must always have at least one entry.
+ */
+public class NonEmptyMapSample {
+
+    // -------------------------------------------------------------------------
+    // A role-to-permissions registry backed by NonEmptyMap.
+    // The compiler prevents creating the registry with an empty map.
+    // -------------------------------------------------------------------------
+
+    static Option<NonEmptyMap<String, Set<String>>> rolesWithPermission(
+            NonEmptyMap<String, Set<String>> registry, String permission) {
+        return registry.filter((role, perms) -> perms.contains(permission));
+    }
+
+    static NonEmptyMap<String, Set<String>> addRole(
+            NonEmptyMap<String, Set<String>> registry, String role, Set<String> perms) {
+        return registry.merge(NonEmptyMap.singleton(role, perms), (existing, incoming) -> {
+            Set<String> merged = new HashSet<>(existing);
+            merged.addAll(incoming);
+            return Set.copyOf(merged);
+        });
+    }
+
+    static void main(String[] args) {
+        // ---- Construction ----
+
+        // of(key, value, rest) — head entry + additional entries
+        NonEmptyMap<String, Integer> scores =
+            NonEmptyMap.of("alice", 10, Map.of("bob", 20, "carol", 30));
+        System.out.println("Head key:   " + scores.headKey());   // alice
+        System.out.println("Head value: " + scores.headValue()); // 10
+        System.out.println("Size:       " + scores.size());      // 3
+
+        // Duplicate head key in rest — head value wins
+        NonEmptyMap<String, Integer> dedup =
+            NonEmptyMap.of("alice", 10, Map.of("alice", 99, "bob", 20));
+        System.out.println("Dedup size: " + dedup.size());           // 2
+        System.out.println("Alice:      " + dedup.headValue());      // 10 (not 99)
+
+        // singleton
+        NonEmptyMap<String, Integer> single = NonEmptyMap.singleton("alice", 10);
+        System.out.println("Single size: " + single.size());         // 1
+
+        // fromMap — safe bridge from plain Map
+        Option<NonEmptyMap<String, Integer>> fromEmpty = NonEmptyMap.fromMap(Map.of());
+        System.out.println("From empty: " + fromEmpty.isEmpty());    // true
+
+        Option<NonEmptyMap<String, Integer>> fromFull = NonEmptyMap.fromMap(Map.of("x", 1));
+        System.out.println("From full:  " + fromFull.isDefined());   // true
+
+        // ---- Accessing elements ----
+
+        Option<Integer> found   = scores.get("bob");     // Some(20)
+        Option<Integer> missing = scores.get("unknown"); // None
+        System.out.println("bob:     " + found.getOrElse(-1));   // 20
+        System.out.println("unknown: " + missing.getOrElse(-1)); // -1
+
+        System.out.println("containsKey alice: " + scores.containsKey("alice")); // true
+        System.out.println("containsKey dave:  " + scores.containsKey("dave"));  // false
+
+        // ---- Transformations ----
+
+        // mapValues
+        NonEmptyMap<String, String> labeled = scores.mapValues(v -> v + " pts");
+        System.out.println("alice labeled: " + labeled.get("alice").getOrElse("?")); // 10 pts
+
+        // mapKeys
+        NonEmptyMap<String, Integer> upper = scores.mapKeys(String::toUpperCase);
+        System.out.println("ALICE: " + upper.containsKey("ALICE")); // true
+        System.out.println("BOB:   " + upper.containsKey("BOB"));   // true
+
+        // mapKeys — collision: head key takes priority
+        NonEmptyMap<String, Integer> collision = NonEmptyMap.of("a", 1, Map.of("A", 2));
+        NonEmptyMap<String, Integer> mapped = collision.mapKeys(String::toUpperCase);
+        System.out.println("Collision size: " + mapped.size());      // 1
+        System.out.println("A value:        " + mapped.headValue()); // 1 (not 2)
+
+        // ---- Filter ----
+
+        Option<NonEmptyMap<String, Integer>> highScorers = scores.filter((k, v) -> v >= 20);
+        highScorers.peek(m -> System.out.println("High scorers: " + m.toMap()));
+        // {bob=20, carol=30}
+
+        Option<NonEmptyMap<String, Integer>> noMatch = scores.filter((k, v) -> v > 100);
+        System.out.println("No match: " + noMatch.isEmpty()); // true
+
+        // ---- Merge ----
+
+        NonEmptyMap<String, Integer> round1 = NonEmptyMap.of("alice", 10, Map.of("bob", 5));
+        NonEmptyMap<String, Integer> round2 = NonEmptyMap.of("carol", 20, Map.of("bob", 15));
+
+        NonEmptyMap<String, Integer> total = round1.merge(round2, Integer::sum);
+        System.out.println("Merged bob: " + total.get("bob").getOrElse(0)); // 20
+
+        // ---- Interop ----
+
+        // toMap — standard java.util.Map
+        Map<String, Integer> javaMap = scores.toMap();
+        System.out.println("Java map size: " + javaMap.size()); // 3
+
+        // toNonEmptyList
+        NonEmptyList<Map.Entry<String, Integer>> entries = scores.toNonEmptyList();
+        System.out.println("Entries size: " + entries.size()); // 3
+
+        // ---- Real-world: role permissions registry ----
+
+        NonEmptyMap<String, Set<String>> registry = NonEmptyMap.of(
+            "admin",  Set.of("read", "write", "delete"),
+            Map.of(
+                "editor", Set.of("read", "write"),
+                "viewer", Set.of("read")
+            )
+        );
+
+        Option<NonEmptyMap<String, Set<String>>> canWrite = rolesWithPermission(registry, "write");
+        canWrite.peek(m -> System.out.println("Can write: " + m.toMap().keySet()));
+        // [admin, editor]
+
+        NonEmptyMap<String, Set<String>> withModerator =
+            addRole(registry, "moderator", Set.of("read", "flag"));
+        System.out.println("Roles after add: " + withModerator.size()); // 4
+    }
+}

--- a/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java
@@ -1,6 +1,7 @@
 package dmx.fun.samples;
 
 import dmx.fun.NonEmptyList;
+import dmx.fun.NonEmptyMap;
 import dmx.fun.NonEmptySet;
 import dmx.fun.Option;
 import java.util.Set;
@@ -109,6 +110,13 @@ public class NonEmptySetSample {
         System.out.println("No common: " + noCommon.isEmpty()); // true
 
         // ---- Interop ----
+
+        // toNonEmptyMap(valueMapper) — elements become keys; mapper produces values
+        NonEmptySet<String> roleSet = NonEmptySet.of("admin", Set.of("editor", "viewer"));
+        NonEmptyMap<String, Integer> permCount = roleSet.toNonEmptyMap(String::length);
+        System.out.println("admin perms key:   " + permCount.headKey());              // admin
+        System.out.println("admin perms value: " + permCount.headValue());            // 5
+        System.out.println("editor length:     " + permCount.get("editor").getOrElse(0)); // 6
 
         // toNonEmptyList — ordered snapshot
         NonEmptyList<String> nel = roles.toNonEmptyList();

--- a/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java
@@ -1,0 +1,136 @@
+package dmx.fun.samples;
+
+import dmx.fun.NonEmptyList;
+import dmx.fun.NonEmptySet;
+import dmx.fun.Option;
+import java.util.Set;
+
+/**
+ * Demonstrates NonEmptySet<T>: a set guaranteed to have at least one element at compile time.
+ * Use NonEmptySet when set semantics (no duplicates) are needed with a non-emptiness guarantee,
+ * e.g. user roles, product tags, or required permission sets.
+ */
+public class NonEmptySetSample {
+
+    // -------------------------------------------------------------------------
+    // Access-control helpers backed by NonEmptySet.
+    // A user's roles are always non-empty — the type system enforces this.
+    // -------------------------------------------------------------------------
+
+    record UserAccess(String username, NonEmptySet<String> roles) {}
+
+    static boolean hasAnyRole(UserAccess user, NonEmptySet<String> required) {
+        return user.roles().intersection(required.toSet()).isDefined();
+    }
+
+    static boolean hasAllRoles(UserAccess user, Set<String> required) {
+        return user.roles().intersection(required)
+            .map(common -> common.size() == required.size())
+            .getOrElse(false);
+    }
+
+    static UserAccess addRole(UserAccess user, String newRole) {
+        return new UserAccess(user.username(), user.roles().union(NonEmptySet.singleton(newRole)));
+    }
+
+    static void main(String[] args) {
+        // ---- Construction ----
+
+        // of(head, rest) — head element + additional elements
+        NonEmptySet<String> roles = NonEmptySet.of("admin", Set.of("editor", "viewer"));
+        System.out.println("Head: " + roles.head());  // admin
+        System.out.println("Size: " + roles.size());  // 3
+
+        // Duplicate head in rest is silently ignored
+        NonEmptySet<String> dedup = NonEmptySet.of("admin", Set.of("admin", "editor"));
+        System.out.println("Dedup size: " + dedup.size()); // 2
+
+        // singleton
+        NonEmptySet<String> single = NonEmptySet.singleton("admin");
+        System.out.println("Single size: " + single.size()); // 1
+
+        // fromSet — safe bridge from plain Set
+        Option<NonEmptySet<String>> fromEmpty = NonEmptySet.fromSet(Set.of());
+        System.out.println("From empty: " + fromEmpty.isEmpty());  // true
+
+        Option<NonEmptySet<String>> fromFull = NonEmptySet.fromSet(Set.of("a", "b"));
+        System.out.println("From full:  " + fromFull.isDefined()); // true
+
+        // ---- Accessing elements ----
+
+        System.out.println("contains admin:   " + roles.contains("admin"));   // true
+        System.out.println("contains unknown: " + roles.contains("unknown")); // false
+
+        // toSet — unmodifiable java.util.Set
+        Set<String> javaSet = roles.toSet();
+        System.out.println("Java set size: " + javaSet.size()); // 3
+
+        // Iterable — direct for-each
+        System.out.print("Roles: ");
+        for (String role : roles) System.out.print(role + " ");
+        System.out.println();
+
+        // ---- Transformations ----
+
+        NonEmptySet<String> upper = roles.map(String::toUpperCase);
+        System.out.println("Upper contains ADMIN: " + upper.contains("ADMIN")); // true
+
+        // map with deduplication
+        NonEmptySet<String> collision = NonEmptySet.of("a", Set.of("A"));
+        NonEmptySet<String> mapped = collision.map(String::toUpperCase);
+        System.out.println("Collision size: " + mapped.size());  // 1
+        System.out.println("Mapped head:    " + mapped.head()); // A
+
+        // ---- Filter ----
+
+        NonEmptySet<Integer> nums = NonEmptySet.of(1, Set.of(2, 3, 4, 5));
+
+        Option<NonEmptySet<Integer>> evens = nums.filter(n -> n % 2 == 0);
+        evens.peek(s -> System.out.println("Evens: " + s.toSet())); // [2, 4]
+
+        Option<NonEmptySet<Integer>> none = nums.filter(n -> n > 100);
+        System.out.println("No match: " + none.isEmpty()); // true
+
+        // ---- Set operations ----
+
+        NonEmptySet<String> a = NonEmptySet.of("admin", Set.of("editor"));
+        NonEmptySet<String> b = NonEmptySet.of("editor", Set.of("viewer"));
+
+        // union — always non-empty
+        NonEmptySet<String> union = a.union(b);
+        System.out.println("Union size: " + union.size());             // 3
+        System.out.println("Union has viewer: " + union.contains("viewer")); // true
+
+        // intersection — may be empty, returns Option
+        Option<NonEmptySet<String>> common = a.intersection(b.toSet());
+        common.peek(s -> System.out.println("Common: " + s.toSet())); // [editor]
+
+        Option<NonEmptySet<String>> noCommon = a.intersection(Set.of("unknown"));
+        System.out.println("No common: " + noCommon.isEmpty()); // true
+
+        // ---- Interop ----
+
+        // toNonEmptyList — ordered snapshot
+        NonEmptyList<String> nel = roles.toNonEmptyList();
+        System.out.println("NEL size: " + nel.size()); // 3
+
+        // ---- Real-world: access control ----
+
+        UserAccess alice = new UserAccess("alice", NonEmptySet.of("admin", Set.of("editor")));
+        UserAccess bob   = new UserAccess("bob",   NonEmptySet.singleton("viewer"));
+
+        System.out.println("alice can edit: " +
+            hasAnyRole(alice, NonEmptySet.singleton("editor")));       // true
+        System.out.println("bob can write:  " +
+            hasAllRoles(bob, Set.of("viewer", "editor")));             // false
+        System.out.println("bob has viewer: " +
+            hasAnyRole(bob, NonEmptySet.singleton("viewer")));         // true
+
+        UserAccess bobPromoted = addRole(bob, "editor");
+        System.out.println("Bob promoted size: " + bobPromoted.roles().size()); // 2
+
+        // Combined roles (e.g. for delegation)
+        NonEmptySet<String> allRoles = alice.roles().union(bob.roles());
+        System.out.println("Combined roles: " + allRoles.toSet()); // [admin, editor, viewer]
+    }
+}

--- a/site/src/data/code/guide/non-empty-list/interop-non-empty-types.mdx
+++ b/site/src/data/code/guide/non-empty-list/interop-non-empty-types.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyList<String> nel = NonEmptyList.of("admin", List.of("editor", "admin", "viewer"));
+
+// toNonEmptySet() — deduplicate while preserving head; insertion order retained
+NonEmptySet<String> nes = nel.toNonEmptySet();
+// NonEmptySet["admin", "editor", "viewer"]  (duplicate "admin" dropped)
+nes.head();   // "admin"
+nes.size();   // 3  (not 4)
+
+// Singleton list — yields singleton set
+NonEmptySet<String> single = NonEmptyList.singleton("admin").toNonEmptySet();
+single.size();   // 1
+
+// Round-trip: NonEmptySet → NonEmptyList → NonEmptySet (idempotent)
+NonEmptySet<String> roles = NonEmptySet.of("admin", Set.of("editor"));
+NonEmptySet<String> roundTrip = roles.toNonEmptyList().toNonEmptySet();
+assertThat(roundTrip).isEqualTo(roles);
+```

--- a/site/src/data/code/guide/non-empty-map/accessing-elements.mdx
+++ b/site/src/data/code/guide/non-empty-map/accessing-elements.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+
+String  headKey   = nem.headKey();    // "alice" — always present, never null
+Integer headValue = nem.headValue();  // 10      — always present, never null
+int     size      = nem.size();       // 2       — always >= 1
+
+// get — Option-based safe lookup
+Option<Integer> found   = nem.get("bob");     // Some(20)
+Option<Integer> missing = nem.get("unknown"); // None
+
+// containsKey
+boolean hasAlice = nem.containsKey("alice"); // true
+boolean hasDave  = nem.containsKey("dave");  // false
+
+// toMap — unmodifiable view of all entries
+Map<String, Integer> all = nem.toMap(); // {alice=10, bob=20}
+```

--- a/site/src/data/code/guide/non-empty-map/accessing-elements.mdx
+++ b/site/src/data/code/guide/non-empty-map/accessing-elements.mdx
@@ -17,6 +17,6 @@ Option<Integer> missing = nem.get("unknown"); // None
 boolean hasAlice = nem.containsKey("alice"); // true
 boolean hasDave  = nem.containsKey("dave");  // false
 
-// toMap — unmodifiable view of all entries
+// toMap — unmodifiable copy of all entries (not backed by internal storage)
 Map<String, Integer> all = nem.toMap(); // {alice=10, bob=20}
 ```

--- a/site/src/data/code/guide/non-empty-map/creating-instances.mdx
+++ b/site/src/data/code/guide/non-empty-map/creating-instances.mdx
@@ -1,0 +1,21 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// of(key, value, rest) — explicit head entry + additional entries
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20, "carol", 30));
+// {alice=10, bob=20, carol=30}
+
+// Duplicate head key in rest is silently ignored — head value wins
+NonEmptyMap<String, Integer> dedup = NonEmptyMap.of("alice", 10, Map.of("alice", 99, "bob", 20));
+// {alice=10, bob=20}  (alice=99 dropped)
+
+// singleton — exactly one entry
+NonEmptyMap<String, Integer> single = NonEmptyMap.singleton("alice", 10);
+// {alice=10}
+
+// fromMap — safe conversion from a plain Map; empty map returns None
+Option<NonEmptyMap<String, Integer>> fromMap = NonEmptyMap.fromMap(someMap);
+// Some({...})  or  None
+```

--- a/site/src/data/code/guide/non-empty-map/filter.mdx
+++ b/site/src/data/code/guide/non-empty-map/filter.mdx
@@ -1,0 +1,18 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 5, "carol", 30));
+
+// filter — predicate receives (key, value); returns Option because result may be empty
+Option<NonEmptyMap<String, Integer>> highScorers = nem.filter((k, v) -> v >= 10);
+// Some({alice=10, carol=30})
+
+Option<NonEmptyMap<String, Integer>> none = nem.filter((k, v) -> v > 100);
+// None
+
+// filter on key
+Option<NonEmptyMap<String, Integer>> startWithC = nem.filter((k, v) -> k.startsWith("c"));
+// Some({carol=30})
+```

--- a/site/src/data/code/guide/non-empty-map/interop.mdx
+++ b/site/src/data/code/guide/non-empty-map/interop.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+
+// toMap — unmodifiable java.util.Map for interop with standard APIs
+Map<String, Integer> javaMap = nem.toMap();
+
+// toNonEmptyList — convert entries to a NonEmptyList in insertion order
+NonEmptyList<Map.Entry<String, Integer>> entries = nem.toNonEmptyList();
+// [alice=10, bob=20]
+
+// fromMap — bridge from plain Map (e.g. from external source)
+Map<String, Integer> external = fetchScoresFromDatabase();
+Option<NonEmptyMap<String, Integer>> safe = NonEmptyMap.fromMap(external);
+safe.forEach(scores -> processScores(scores));
+```

--- a/site/src/data/code/guide/non-empty-map/interop.mdx
+++ b/site/src/data/code/guide/non-empty-map/interop.mdx
@@ -3,17 +3,29 @@ fileName: 'Demo.java'
 ---
 
 ```java
-NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20, "carol", 30));
 
-// toMap — unmodifiable java.util.Map for interop with standard APIs
+// keySet() — all keys as a NonEmptySet; head key becomes set head
+NonEmptySet<String> keys = nem.keySet();
+// NonEmptySet["alice", "bob", "carol"]
+keys.head();          // "alice"
+keys.size();          // 3
+
+// values() — all values as a NonEmptyList in insertion order; head value becomes list head
+NonEmptyList<Integer> vals = nem.values();
+// NonEmptyList[10, 20, 30]
+vals.head();          // 10
+vals.size();          // 3
+
+// toMap() — unmodifiable java.util.Map for interop with standard APIs
 Map<String, Integer> javaMap = nem.toMap();
 
-// toNonEmptyList — convert entries to a NonEmptyList in insertion order
+// toNonEmptyList() — all entries as Map.Entry objects in insertion order
 NonEmptyList<Map.Entry<String, Integer>> entries = nem.toNonEmptyList();
-// [alice=10, bob=20]
+// [alice=10, bob=20, carol=30]
 
-// fromMap — bridge from plain Map (e.g. from external source)
+// fromMap() — bridge from plain Map (e.g. from external source)
 Map<String, Integer> external = fetchScoresFromDatabase();
 Option<NonEmptyMap<String, Integer>> safe = NonEmptyMap.fromMap(external);
-safe.forEach(scores -> processScores(scores));
+safe.peek(scores -> processScores(scores));
 ```

--- a/site/src/data/code/guide/non-empty-map/merge.mdx
+++ b/site/src/data/code/guide/non-empty-map/merge.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyMap<String, Integer> scores1 = NonEmptyMap.of("alice", 10, Map.of("bob", 5));
+NonEmptyMap<String, Integer> scores2 = NonEmptyMap.of("carol", 20, Map.of("bob", 15));
+
+// merge — combine two maps; mergeFunction resolves conflicts
+NonEmptyMap<String, Integer> combined = scores1.merge(scores2, Integer::sum);
+// {alice=10, bob=20, carol=20}  (bob: 5+15=20)
+
+// merge with last-write-wins for conflicts
+NonEmptyMap<String, Integer> lastWins = scores1.merge(scores2, (v1, v2) -> v2);
+// {alice=10, bob=15, carol=20}  (bob=15 from scores2)
+
+// Disjoint maps — no conflict, all entries preserved
+NonEmptyMap<String, Integer> a = NonEmptyMap.singleton("x", 1);
+NonEmptyMap<String, Integer> b = NonEmptyMap.singleton("y", 2);
+NonEmptyMap<String, Integer> merged = a.merge(b, Integer::sum);
+// {x=1, y=2}
+```

--- a/site/src/data/code/guide/non-empty-map/real-world-example.mdx
+++ b/site/src/data/code/guide/non-empty-map/real-world-example.mdx
@@ -1,0 +1,55 @@
+---
+fileName: 'RolePermissionsService.java'
+---
+
+```java
+// A role-to-permissions registry that is always initialized with at least one entry.
+// The compiler prevents calling this service with an empty map.
+
+public class RolePermissionsService {
+
+    private final NonEmptyMap<String, Set<String>> permissions;
+
+    public RolePermissionsService(NonEmptyMap<String, Set<String>> permissions) {
+        this.permissions = permissions;
+    }
+
+    /** Returns the permissions for a role, or an empty set if the role is unknown. */
+    public Set<String> permissionsFor(String role) {
+        return permissions.get(role)
+            .getOrElse(Set.of());
+    }
+
+    /** Returns a new service with an additional role merged in. */
+    public RolePermissionsService withRole(String role, Set<String> perms) {
+        NonEmptyMap<String, Set<String>> updated =
+            permissions.merge(NonEmptyMap.singleton(role, perms), (existing, incoming) -> {
+                Set<String> merged = new HashSet<>(existing);
+                merged.addAll(incoming);
+                return Set.copyOf(merged);
+            });
+        return new RolePermissionsService(updated);
+    }
+
+    /** Returns only roles that have the given permission. */
+    public Option<NonEmptyMap<String, Set<String>>> rolesWithPermission(String permission) {
+        return permissions.filter((role, perms) -> perms.contains(permission));
+    }
+}
+
+// Usage
+NonEmptyMap<String, Set<String>> initial = NonEmptyMap.of(
+    "admin",  Set.of("read", "write", "delete"),
+    Map.of(
+        "editor", Set.of("read", "write"),
+        "viewer", Set.of("read")
+    )
+);
+
+RolePermissionsService svc = new RolePermissionsService(initial);
+
+Set<String> editorPerms = svc.permissionsFor("editor"); // [read, write]
+
+Option<NonEmptyMap<String, Set<String>>> canWrite = svc.rolesWithPermission("write");
+// Some({admin=[read,write,delete], editor=[read,write]})
+```

--- a/site/src/data/code/guide/non-empty-map/transformations.mdx
+++ b/site/src/data/code/guide/non-empty-map/transformations.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+
+// mapValues — transform every value; keys are unchanged
+NonEmptyMap<String, String> labeled = nem.mapValues(v -> v + " pts");
+// {alice="10 pts", bob="20 pts"}
+
+// mapKeys — transform every key; values follow their original key
+NonEmptyMap<String, Integer> upper = nem.mapKeys(String::toUpperCase);
+// {ALICE=10, BOB=20}
+
+// Colliding mapped keys: head key takes priority; conflicting tail entries are dropped
+NonEmptyMap<String, Integer> collision = NonEmptyMap.of("a", 1, Map.of("A", 2));
+NonEmptyMap<String, Integer> mapped = collision.mapKeys(String::toUpperCase);
+// {A=1}  (tail entry A=2 dropped because mapped key equals the new head key)
+```

--- a/site/src/data/code/guide/non-empty-set/accessing-elements.mdx
+++ b/site/src/data/code/guide/non-empty-set/accessing-elements.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+
+String head = nes.head();  // "admin" — always present, never null
+int    size = nes.size();  // 3       — always >= 1
+
+// contains
+boolean hasAdmin   = nes.contains("admin");   // true
+boolean hasUnknown = nes.contains("unknown"); // false
+
+// toSet — unmodifiable view of all elements in insertion order
+Set<String> all = nes.toSet(); // [admin, user, moderator]
+
+// Iterable — use directly in for-each loops
+for (String role : nes) {
+    System.out.println(role);
+}
+```

--- a/site/src/data/code/guide/non-empty-set/accessing-elements.mdx
+++ b/site/src/data/code/guide/non-empty-set/accessing-elements.mdx
@@ -3,7 +3,9 @@ fileName: 'Demo.java'
 ---
 
 ```java
-NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+// Use a LinkedHashSet to guarantee insertion order in the rest argument
+Set<String> rest = new LinkedHashSet<>(List.of("user", "moderator"));
+NonEmptySet<String> nes = NonEmptySet.of("admin", rest);
 
 String head = nes.head();  // "admin" — always present, never null
 int    size = nes.size();  // 3       — always >= 1
@@ -12,7 +14,7 @@ int    size = nes.size();  // 3       — always >= 1
 boolean hasAdmin   = nes.contains("admin");   // true
 boolean hasUnknown = nes.contains("unknown"); // false
 
-// toSet — unmodifiable view of all elements in insertion order
+// toSet — unmodifiable copy of all elements in insertion order
 Set<String> all = nes.toSet(); // [admin, user, moderator]
 
 // Iterable — use directly in for-each loops

--- a/site/src/data/code/guide/non-empty-set/creating-instances.mdx
+++ b/site/src/data/code/guide/non-empty-set/creating-instances.mdx
@@ -1,0 +1,21 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// of(head, rest) — explicit head element + additional elements
+NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+// [admin, user, moderator]
+
+// Duplicate head in rest is silently ignored
+NonEmptySet<String> dedup = NonEmptySet.of("admin", Set.of("admin", "user"));
+// [admin, user]
+
+// singleton — exactly one element
+NonEmptySet<String> single = NonEmptySet.singleton("admin");
+// [admin]
+
+// fromSet — safe conversion from a plain Set; empty set returns None
+Option<NonEmptySet<String>> fromSet = NonEmptySet.fromSet(someSet);
+// Some([...])  or  None
+```

--- a/site/src/data/code/guide/non-empty-set/filter.mdx
+++ b/site/src/data/code/guide/non-empty-set/filter.mdx
@@ -1,0 +1,18 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptySet<Integer> nes = NonEmptySet.of(1, Set.of(2, 3, 4, 5));
+
+// filter — returns Option because no element may pass
+Option<NonEmptySet<Integer>> evens = nes.filter(n -> n % 2 == 0);
+// Some([2, 4])
+
+Option<NonEmptySet<Integer>> none = nes.filter(n -> n > 100);
+// None
+
+// All elements pass — same size as original
+Option<NonEmptySet<Integer>> all = nes.filter(n -> n > 0);
+// Some([1, 2, 3, 4, 5])
+```

--- a/site/src/data/code/guide/non-empty-set/filter.mdx
+++ b/site/src/data/code/guide/non-empty-set/filter.mdx
@@ -3,7 +3,9 @@ fileName: 'Demo.java'
 ---
 
 ```java
-NonEmptySet<Integer> nes = NonEmptySet.of(1, Set.of(2, 3, 4, 5));
+// Use a LinkedHashSet to guarantee insertion order in the rest argument
+Set<Integer> rest = new LinkedHashSet<>(List.of(2, 3, 4, 5));
+NonEmptySet<Integer> nes = NonEmptySet.of(1, rest);
 
 // filter — returns Option because no element may pass
 Option<NonEmptySet<Integer>> evens = nes.filter(n -> n % 2 == 0);

--- a/site/src/data/code/guide/non-empty-set/interop.mdx
+++ b/site/src/data/code/guide/non-empty-set/interop.mdx
@@ -1,0 +1,24 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+
+// toSet — unmodifiable java.util.Set for interop with standard APIs
+Set<String> javaSet = nes.toSet();
+
+// toNonEmptyList — ordered snapshot of elements as a NonEmptyList
+NonEmptyList<String> nel = nes.toNonEmptyList();
+// NonEmptyList["admin", "user", "moderator"]
+
+// fromSet — bridge from plain Set (e.g. from external source)
+Set<String> external = fetchRolesFromDatabase();
+Option<NonEmptySet<String>> safe = NonEmptySet.fromSet(external);
+safe.forEach(roles -> processRoles(roles));
+
+// Iterable — stream-friendly via StreamSupport or direct for-each
+StreamSupport.stream(nes.spliterator(), false)
+    .filter(r -> r.startsWith("a"))
+    .forEach(System.out::println);
+```

--- a/site/src/data/code/guide/non-empty-set/interop.mdx
+++ b/site/src/data/code/guide/non-empty-set/interop.mdx
@@ -3,22 +3,27 @@ fileName: 'Demo.java'
 ---
 
 ```java
-NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("editor", "viewer"));
 
-// toSet — unmodifiable java.util.Set for interop with standard APIs
+// toNonEmptyMap(valueMapper) — each element becomes a key; mapper produces values
+NonEmptyMap<String, Integer> permCount = nes.toNonEmptyMap(role -> loadPermissions(role).size());
+// NonEmptyMap{admin=3, editor=2, viewer=1}
+permCount.headKey();          // "admin"
+permCount.headValue();        // 3
+
+// Identity map (element → itself)
+NonEmptyMap<String, String> identity = nes.toNonEmptyMap(r -> r);
+// {admin=admin, editor=editor, viewer=viewer}
+
+// toSet() — unmodifiable java.util.Set for interop with standard APIs
 Set<String> javaSet = nes.toSet();
 
-// toNonEmptyList — ordered snapshot of elements as a NonEmptyList
+// toNonEmptyList() — ordered snapshot of elements as a NonEmptyList
 NonEmptyList<String> nel = nes.toNonEmptyList();
-// NonEmptyList["admin", "user", "moderator"]
+// NonEmptyList["admin", "editor", "viewer"]
 
-// fromSet — bridge from plain Set (e.g. from external source)
+// fromSet() — bridge from plain Set (e.g. from external source)
 Set<String> external = fetchRolesFromDatabase();
 Option<NonEmptySet<String>> safe = NonEmptySet.fromSet(external);
-safe.forEach(roles -> processRoles(roles));
-
-// Iterable — stream-friendly via StreamSupport or direct for-each
-StreamSupport.stream(nes.spliterator(), false)
-    .filter(r -> r.startsWith("a"))
-    .forEach(System.out::println);
+safe.peek(roles -> processRoles(roles));
 ```

--- a/site/src/data/code/guide/non-empty-set/real-world-example.mdx
+++ b/site/src/data/code/guide/non-empty-set/real-world-example.mdx
@@ -1,0 +1,47 @@
+---
+fileName: 'AccessControlService.java'
+---
+
+```java
+// An access-control service where every user must have at least one role.
+// The compiler prevents creating a user with no roles.
+
+public record UserAccess(String username, NonEmptySet<String> roles) {}
+
+public class AccessControlService {
+
+    /** Checks whether the user has ALL of the required roles. */
+    public boolean hasAllRoles(UserAccess user, Set<String> required) {
+        return user.roles().intersection(required)
+            .map(common -> common.size() == required.size())
+            .getOrElse(false);
+    }
+
+    /** Checks whether the user has ANY of the required roles. */
+    public boolean hasAnyRole(UserAccess user, NonEmptySet<String> required) {
+        return user.roles().intersection(required.toSet())
+            .isDefined();
+    }
+
+    /** Combines two users' roles (e.g. for a temporary delegation). */
+    public NonEmptySet<String> combinedRoles(UserAccess a, UserAccess b) {
+        return a.roles().union(b.roles());
+    }
+
+    /** Promotes a user by adding a new role. */
+    public UserAccess addRole(UserAccess user, String newRole) {
+        NonEmptySet<String> updatedRoles = user.roles().union(NonEmptySet.singleton(newRole));
+        return new UserAccess(user.username(), updatedRoles);
+    }
+}
+
+// Usage
+UserAccess alice = new UserAccess("alice", NonEmptySet.of("admin", Set.of("editor")));
+UserAccess bob   = new UserAccess("bob",   NonEmptySet.singleton("viewer"));
+
+AccessControlService acl = new AccessControlService();
+
+boolean aliceCanEdit = acl.hasAnyRole(alice, NonEmptySet.singleton("editor")); // true
+NonEmptySet<String> allRoles = acl.combinedRoles(alice, bob);
+// [admin, editor, viewer]
+```

--- a/site/src/data/code/guide/non-empty-set/set-operations.mdx
+++ b/site/src/data/code/guide/non-empty-set/set-operations.mdx
@@ -1,0 +1,27 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptySet<String> a = NonEmptySet.of("admin", Set.of("user"));
+NonEmptySet<String> b = NonEmptySet.of("user",  Set.of("moderator"));
+
+// union — always non-empty (both inputs are non-empty)
+NonEmptySet<String> union = a.union(b);
+// [admin, user, moderator]
+
+// union with fully overlapping sets — deduplication applies
+NonEmptySet<String> same = a.union(a);
+// [admin, user]
+
+// intersection — may be empty, so returns Option
+Option<NonEmptySet<String>> common = a.intersection(Set.of("user", "moderator"));
+// Some([user])
+
+Option<NonEmptySet<String>> empty = a.intersection(Set.of("unknown"));
+// None
+
+// intersection accepts any java.util.Set, not just NonEmptySet
+Set<String> external = fetchAllowedRoles();
+Option<NonEmptySet<String>> allowed = a.intersection(external);
+```

--- a/site/src/data/code/guide/non-empty-set/transformations.mdx
+++ b/site/src/data/code/guide/non-empty-set/transformations.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptySet<String> nes = NonEmptySet.of("admin", Set.of("user", "moderator"));
+
+// map — transform every element; result is deduplicated, head always comes from mapping head
+NonEmptySet<String> upper = nes.map(String::toUpperCase);
+// [ADMIN, USER, MODERATOR]
+
+// map with deduplication: "a" and "A" both map to "A" — only one "A" survives
+NonEmptySet<String> collision = NonEmptySet.of("a", Set.of("A"));
+NonEmptySet<String> mapped = collision.map(String::toUpperCase);
+// [A]  (size 1 — head "a" maps to "A", tail "A" is a duplicate and dropped)
+```

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AssertJ Integration — Developer Guide"
 description: "How to use the optional fun-assertj module: fluent assertions for Option, Result, Try, Validated, and Tuple types via DmxFunAssertions.assertThat."
-order: 13
+order: 15
 h1: "AssertJ Integration"
 ---
 

--- a/site/src/data/guide/checked-interfaces.mdx
+++ b/site/src/data/guide/checked-interfaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Checked Interfaces — Developer Guide"
 description: "Comprehensive guide to CheckedFunction, CheckedSupplier, CheckedConsumer, CheckedRunnable, TriFunction, and QuadFunction: eliminating checked-exception boilerplate in functional code."
-order: 9
+order: 11
 h1: "Checked Interfaces"
 ---
 

--- a/site/src/data/guide/combining-types.mdx
+++ b/site/src/data/guide/combining-types.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Combining Types — Developer Guide"
 description: "Recipes for composing Option, Result, Try, Validated, and Either together: conversion cheat sheet, pipeline patterns, traverse, and anti-patterns."
-order: 10
+order: 12
 h1: "Combining Types"
 ---
 

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Contributing — Developer Guide"
 description: "How to set up the dmx-fun development environment, run tests, run the site locally, follow code conventions, and open a pull request."
-order: 14
+order: 16
 h1: "Contributing"
 ---
 

--- a/site/src/data/guide/jackson.mdx
+++ b/site/src/data/guide/jackson.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jackson Integration — Developer Guide"
 description: "How to serialize and deserialize all dmx-fun types with Jackson: module registration, JSON shapes, TypeReference round-trips, Spring Boot / JAX-RS integration, and known limitations."
-order: 12
+order: 14
 h1: "Jackson Integration"
 ---
 

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a New Module — Developer Guide"
 description: "Conventions and checklist for adding a new optional integration module to dmx-fun (e.g. fun-spring, fun-micronaut)."
-order: 17
+order: 19
 h1: "Adding a New Module"
 ---
 

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -11,8 +11,9 @@ import {Content as Transformations}    from '../code/guide/non-empty-list/transf
 import {Content as InteropOption}      from '../code/guide/non-empty-list/interop-option.mdx';
 import {Content as InteropValidated}   from '../code/guide/non-empty-list/interop-validated.mdx';
 import {Content as StreamInterop}      from '../code/guide/non-empty-list/stream-interop.mdx';
-import {Content as EqualityToString}   from '../code/guide/non-empty-list/equality-tostring.mdx';
-import {Content as RealWorldExample}   from '../code/guide/non-empty-list/real-world-example.mdx';
+import {Content as EqualityToString}       from '../code/guide/non-empty-list/equality-tostring.mdx';
+import {Content as InteropNonEmptyTypes}   from '../code/guide/non-empty-list/interop-non-empty-types.mdx';
+import {Content as RealWorldExample}       from '../code/guide/non-empty-list/real-world-example.mdx';
 
 > **Runnable example:** [`NonEmptyListSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java)
 
@@ -90,6 +91,13 @@ provides three dedicated helpers:
 integration with the standard Java stream API.
 
 <StreamInterop/>
+
+## Interoperability — `NonEmptySet` and `NonEmptyMap`
+
+`toNonEmptySet()` converts a list to a set, deduplicating elements while preserving the
+head. It is the inverse of `NonEmptySet.toNonEmptyList()`.
+
+<InteropNonEmptyTypes/>
 
 ## `equals`, `hashCode`, and `toString`
 

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -94,8 +94,10 @@ integration with the standard Java stream API.
 
 ## Interoperability — `NonEmptySet` and `NonEmptyMap`
 
-`toNonEmptySet()` converts a list to a set, deduplicating elements while preserving the
-head. It is the inverse of `NonEmptySet.toNonEmptyList()`.
+`toNonEmptySet()` is the complementary conversion to `NonEmptySet.toNonEmptyList()`.
+Note that it is **not a strict inverse**: converting a list to a set deduplicates
+elements, so a round-trip through `toNonEmptySet().toNonEmptyList()` may produce a
+shorter list than the original.
 
 <InteropNonEmptyTypes/>
 

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -1,6 +1,6 @@
 ---
 title: "NonEmptyMap<K, V> — Developer Guide"
-description: "Comprehensive guide to NonEmptyMap<K, V>: construction, entry access, transformations, filter, merge, and interoperability."
+description: "Comprehensive guide to NonEmptyMap<K, V>: construction, entry access, transformations, filter, merge, interoperability, and cross-type conversions (keySet, values)."
 order: 9
 h1: "NonEmptyMap<K, V>"
 ---
@@ -79,6 +79,17 @@ conflicts. Because both inputs are non-empty, the result is guaranteed non-empty
 no `Option` wrapping needed.
 
 ## Interoperability
+
+Cross-type conversions bridge `NonEmptyMap` with `NonEmptySet`, `NonEmptyList`, and the
+standard Java collections.
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `keySet()` | `NonEmptySet<K>` | All keys as a non-empty set; head key becomes set head |
+| `values()` | `NonEmptyList<V>` | All values in insertion order; duplicates preserved |
+| `toMap()` | `Map<K, V>` | Unmodifiable `java.util.Map` for standard API interop |
+| `toNonEmptyList()` | `NonEmptyList<Map.Entry<K,V>>` | All entries in insertion order |
+| `fromMap(map)` | `Option<NonEmptyMap<K,V>>` | Safe bridge from a plain `Map`; `None` if empty |
 
 <Interop/>
 

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -13,6 +13,8 @@ import {Content as Merge}              from '../code/guide/non-empty-map/merge.m
 import {Content as Interop}            from '../code/guide/non-empty-map/interop.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-map/real-world-example.mdx';
 
+> **Runnable example:** [`NonEmptyMapSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java)
+
 ## What is NonEmptyMap&lt;K, V&gt;?
 
 `NonEmptyMap<K, V>` is an **immutable map guaranteed at construction time to contain

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -1,0 +1,105 @@
+---
+title: "NonEmptyMap<K, V> — Developer Guide"
+description: "Comprehensive guide to NonEmptyMap<K, V>: construction, entry access, transformations, filter, merge, and interoperability."
+order: 9
+h1: "NonEmptyMap<K, V>"
+---
+
+import {Content as CreatingInstances}  from '../code/guide/non-empty-map/creating-instances.mdx';
+import {Content as AccessingElements}  from '../code/guide/non-empty-map/accessing-elements.mdx';
+import {Content as Transformations}    from '../code/guide/non-empty-map/transformations.mdx';
+import {Content as Filter}             from '../code/guide/non-empty-map/filter.mdx';
+import {Content as Merge}              from '../code/guide/non-empty-map/merge.mdx';
+import {Content as Interop}            from '../code/guide/non-empty-map/interop.mdx';
+import {Content as RealWorldExample}   from '../code/guide/non-empty-map/real-world-example.mdx';
+
+## What is NonEmptyMap&lt;K, V&gt;?
+
+`NonEmptyMap<K, V>` is an **immutable map guaranteed at construction time to contain
+at least one entry**. The non-emptiness constraint is encoded in the static type —
+callers that receive a `NonEmptyMap<K, V>` never need to check whether it is empty.
+
+**Internal structure**: a `headKey` + `headValue` (the first entry) and a `tail`
+(an unmodifiable `Map<K, V>` for the remaining entries, which may be empty).
+`headKey()` and `headValue()` are always present.
+
+**Null policy**: `NonEmptyMap` is `@NullMarked` — null keys, values, or rest entries
+throw `NullPointerException` at construction time.
+
+**Insertion order preserved**: backed by `LinkedHashMap`, so iteration follows
+insertion order with the head entry always first.
+
+Use it when:
+
+- An API contract requires at least one map entry and you want the compiler to enforce it.
+- You are building a registry, configuration, or lookup table that must always have at least one entry.
+- You want to eliminate runtime `isEmpty()` guards on maps that are semantically never empty.
+
+## Creating instances
+
+| Factory                                       | When input is empty?          |
+|-----------------------------------------------|-------------------------------|
+| `NonEmptyMap.of(key, value, rest)`            | N/A — head entry is always required |
+| `NonEmptyMap.singleton(key, value)`           | N/A — always one entry        |
+| `NonEmptyMap.fromMap(map)`                    | Returns `None`                |
+
+<CreatingInstances/>
+
+## Accessing elements
+
+<AccessingElements/>
+
+`size()` always returns a value `>= 1`. `headKey()` and `headValue()` give direct,
+null-safe access to the first entry. `get(key)` returns `Option<V>` — no nulls, no
+`NoSuchElementException`.
+
+## Transformations
+
+<Transformations/>
+
+`mapValues` and `mapKeys` always return a **new `NonEmptyMap`** — the original is
+unchanged. When `mapKeys` produces collisions, the head key takes priority and
+conflicting tail entries are dropped.
+
+## Filter
+
+<Filter/>
+
+`filter` returns `Option<NonEmptyMap<K, V>>` because filtering can produce an empty
+result. The predicate receives both the key and the value via `BiPredicate<K, V>`.
+
+## Merge
+
+<Merge/>
+
+`merge` takes a second `NonEmptyMap` and a `BinaryOperator<V>` to resolve key
+conflicts. Because both inputs are non-empty, the result is guaranteed non-empty —
+no `Option` wrapping needed.
+
+## Interoperability
+
+<Interop/>
+
+## `equals`, `hashCode`, and `toString`
+
+Equality is **structural and consistent with `Map`**: two `NonEmptyMap` instances are
+equal if and only if their entry sets are equal (key equality + value equality, order
+ignored). `hashCode` delegates to `toMap().hashCode()`. `toString` prints in
+`{key=value, ...}` format.
+
+## When to use `NonEmptyMap` vs plain `Map`
+
+| Scenario                                               | Recommendation                               |
+|--------------------------------------------------------|----------------------------------------------|
+| At least one entry required by contract                | `NonEmptyMap<K, V>`                          |
+| Map may legitimately be empty                          | `Map<K, V>`                                  |
+| Reading from an external source that may be empty      | `NonEmptyMap.fromMap(map)` → handle `None`   |
+| Merging two registries — result is always non-empty    | `nem1.merge(nem2, mergeFunction)`            |
+| Filtering entries — result may be empty                | `nem.filter(predicate)` → handle `None`      |
+
+## Real-world example
+
+A role-to-permissions registry initialized with at least one role. The type system
+prevents constructing the service with an empty permissions map.
+
+<RealWorldExample/>

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -13,6 +13,8 @@ import {Content as SetOperations}      from '../code/guide/non-empty-set/set-ope
 import {Content as Interop}            from '../code/guide/non-empty-set/interop.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-set/real-world-example.mdx';
 
+> **Runnable example:** [`NonEmptySetSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java)
+
 ## What is NonEmptySet&lt;T&gt;?
 
 `NonEmptySet<T>` is an **immutable set guaranteed at construction time to contain

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -1,0 +1,109 @@
+---
+title: "NonEmptySet<T> — Developer Guide"
+description: "Comprehensive guide to NonEmptySet<T>: construction, element access, transformations, filter, set operations (union, intersection), and interoperability."
+order: 10
+h1: "NonEmptySet<T>"
+---
+
+import {Content as CreatingInstances}  from '../code/guide/non-empty-set/creating-instances.mdx';
+import {Content as AccessingElements}  from '../code/guide/non-empty-set/accessing-elements.mdx';
+import {Content as Transformations}    from '../code/guide/non-empty-set/transformations.mdx';
+import {Content as Filter}             from '../code/guide/non-empty-set/filter.mdx';
+import {Content as SetOperations}      from '../code/guide/non-empty-set/set-operations.mdx';
+import {Content as Interop}            from '../code/guide/non-empty-set/interop.mdx';
+import {Content as RealWorldExample}   from '../code/guide/non-empty-set/real-world-example.mdx';
+
+## What is NonEmptySet&lt;T&gt;?
+
+`NonEmptySet<T>` is an **immutable set guaranteed at construction time to contain
+at least one element**. The non-emptiness constraint is encoded in the static type —
+callers that receive a `NonEmptySet<T>` never need to check whether it is empty.
+
+**Internal structure**: a `head` (the first element) and a `tail`
+(an unmodifiable `Set<T>` for the remaining elements, which may be empty).
+`head()` is always present.
+
+**Null policy**: `NonEmptySet` is `@NullMarked` — null elements throw
+`NullPointerException` at construction time.
+
+**Insertion order preserved**: backed by `LinkedHashSet`, so iteration follows
+insertion order with the head element always first.
+
+**Implements `Iterable<T>`**: use directly in for-each loops, or adapt to streams
+via `StreamSupport.stream(nes.spliterator(), false)`.
+
+Use it when:
+
+- An API contract requires at least one element and you want the compiler to enforce it.
+- You need set semantics (no duplicates) with the additional guarantee of non-emptiness.
+- You want to eliminate `isEmpty()` guards on sets that are semantically never empty
+  (e.g. a user's assigned roles, a product's tags).
+
+## Creating instances
+
+| Factory                                       | When input is empty?          |
+|-----------------------------------------------|-------------------------------|
+| `NonEmptySet.of(head, rest)`                  | N/A — head is always required |
+| `NonEmptySet.singleton(head)`                 | N/A — always one element      |
+| `NonEmptySet.fromSet(set)`                    | Returns `None`                |
+
+<CreatingInstances/>
+
+## Accessing elements
+
+<AccessingElements/>
+
+`size()` always returns a value `>= 1`. `head()` gives direct, null-safe access to
+the first element. `toSet()` returns an unmodifiable `java.util.Set` for standard API
+interop.
+
+## Transformations
+
+<Transformations/>
+
+`map` always returns a **new `NonEmptySet`** — the original is unchanged. Because
+mapping can produce duplicates, the result is automatically deduplicated; the head
+element always takes priority.
+
+## Filter
+
+<Filter/>
+
+`filter` returns `Option<NonEmptySet<T>>` because filtering can produce an empty
+result. If no element passes the predicate, `None` is returned.
+
+## Set operations
+
+<SetOperations/>
+
+`union` always returns a non-empty set (both inputs are non-empty), so no `Option`
+wrapping is needed. `intersection` may yield an empty result, so it returns
+`Option<NonEmptySet<T>>`. `intersection` accepts any `java.util.Set<? extends T>`,
+not just `NonEmptySet`.
+
+## Interoperability
+
+<Interop/>
+
+## `equals`, `hashCode`, and `toString`
+
+Equality is **structural and consistent with `Set`**: two `NonEmptySet` instances are
+equal if and only if their element sets are equal (order ignored). `hashCode`
+delegates to `toSet().hashCode()`. `toString` prints in `[element, ...]` format.
+
+## When to use `NonEmptySet` vs plain `Set`
+
+| Scenario                                               | Recommendation                               |
+|--------------------------------------------------------|----------------------------------------------|
+| At least one element required by contract              | `NonEmptySet<T>`                             |
+| Set may legitimately be empty                          | `Set<T>`                                     |
+| Reading from an external source that may be empty      | `NonEmptySet.fromSet(set)` → handle `None`   |
+| Combining two non-empty sets — result always non-empty | `nes1.union(nes2)`                           |
+| Finding common elements — result may be empty          | `nes.intersection(other)` → handle `None`    |
+
+## Real-world example
+
+An access-control service where every user must have at least one role. The type
+system prevents creating a user with no roles.
+
+<RealWorldExample/>

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: "NonEmptySet<T> — Developer Guide"
-description: "Comprehensive guide to NonEmptySet<T>: construction, element access, transformations, filter, set operations (union, intersection), and interoperability."
+description: "Comprehensive guide to NonEmptySet<T>: construction, element access, transformations, filter, set operations (union, intersection), and cross-type conversions (toNonEmptyMap, toNonEmptyList)."
 order: 10
 h1: "NonEmptySet<T>"
 ---
@@ -84,6 +84,16 @@ wrapping is needed. `intersection` may yield an empty result, so it returns
 not just `NonEmptySet`.
 
 ## Interoperability
+
+Cross-type conversions bridge `NonEmptySet` with `NonEmptyMap`, `NonEmptyList`, and the
+standard Java collections.
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `toNonEmptyMap(valueMapper)` | `NonEmptyMap<T, V>` | Elements become keys; mapper produces values |
+| `toNonEmptyList()` | `NonEmptyList<T>` | Ordered snapshot; head element preserved |
+| `toSet()` | `Set<T>` | Unmodifiable `java.util.Set` for standard API interop |
+| `fromSet(set)` | `Option<NonEmptySet<T>>` | Safe bridge from a plain `Set`; `None` if empty |
 
 <Interop/>
 

--- a/site/src/data/guide/performance.mdx
+++ b/site/src/data/guide/performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance — Developer Guide"
 description: "Performance characteristics of dmx-fun types: why allocation cost is negligible for most code, the two cases where overhead could be observable, and how to report a real performance concern."
-order: 11
+order: 13
 h1: "Performance"
 ---
 

--- a/site/src/data/guide/pipelines.mdx
+++ b/site/src/data/guide/pipelines.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CI/CD Pipelines — Developer Guide"
 description: "Reference for every GitHub Actions workflow in dmx-fun: triggers, purpose, required secrets, local equivalents, and known gotchas."
-order: 15
+order: 17
 h1: "CI/CD Pipelines"
 ---
 

--- a/site/src/data/guide/release-process.mdx
+++ b/site/src/data/guide/release-process.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Release Process — Developer Guide"
 description: "Step-by-step process for cutting a stable dmx-fun release: version bump, CI publish, tag creation, post-release SNAPSHOT bump, and verification."
-order: 16
+order: 18
 h1: "Release Process"
 ---
 

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -68,6 +68,22 @@ const types = [
         tag: 'Collections',
     },
     {
+        name: 'NonEmptyMap<K, V>',
+        href: `${base}guide/non-empty-map`,
+        summary: 'A map guaranteed to have at least one entry at compile time. Insertion order preserved.',
+        whenToUse: 'A registry, configuration, or lookup table that must always contain at least one entry.',
+        avoidWhen: 'Emptiness is a valid state — use a regular Map.',
+        tag: 'Collections',
+    },
+    {
+        name: 'NonEmptySet<T>',
+        href: `${base}guide/non-empty-set`,
+        summary: 'A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved.',
+        whenToUse: 'Set semantics (no duplicates) with the additional guarantee of non-emptiness, e.g. user roles or product tags.',
+        avoidWhen: 'Emptiness is a valid state — use a regular Set.',
+        tag: 'Collections',
+    },
+    {
         name: 'Checked interfaces',
         href: `${base}guide/checked-interfaces`,
         summary: 'Checked variants of Function, Supplier, Consumer, Runnable, plus TriFunction/QuadFunction.',


### PR DESCRIPTION
- **feat(lib): add NonEmptyMap<K,V> and NonEmptySet<T> types (close #225)**
- **docs(guide): add NonEmptyMap and NonEmptySet developer guide pages**
- **feat(samples): add NonEmptyMapSample and NonEmptySetSample runnable examples**
- **feat(non-empty-types): add cross-type interoperability methods**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #225

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NonEmptyMap<K,V> — immutable, non-empty map with guaranteed head entry, construction, transform, filter, merge, and view APIs.
  * Added NonEmptySet<T> — immutable, non-empty insertion-ordered set with map/filter/union/intersection.
  * NonEmptyList gained toNonEmptySet() — converts to a NonEmptySet, preserving the list head and insertion order while deduplicating tail elements.

* **Documentation**
  * New developer guides, examples, and updated README showcasing usage and interoperability.

* **Tests**
  * Added and extended test suites for the new types and conversions.

* **Samples**
  * New sample programs demonstrating real-world usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->