### PR TITLE
feat(Option): add zipWith(Function) and flatZip for dependent pairing (closes #229)

### DIFF
--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -614,6 +614,58 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     }
 
     /**
+     * Applies {@code mapper} to the value inside this {@code Option} and pairs the original value
+     * with the result. Returns {@link Option#none()} if this is empty <em>or</em> if the mapper
+     * returns {@link Option#none()}.
+     *
+     * <p>This is the monadic "dependent zip": the second {@code Option} is computed <em>from</em>
+     * the first value, unlike {@link #zip(Option)} which takes an already-evaluated option.
+     *
+     * <pre>{@code
+     * Option<String> name = Option.some("alice");
+     * Option<Tuple2<String, Integer>> result =
+     *     name.zipWith(n -> lookupAge(n));
+     * // Some(Tuple2("alice", 30)) if lookupAge returns Some(30)
+     * // None                      if lookupAge returns None
+     * }</pre>
+     *
+     * @param <B>    type of the value produced by {@code mapper}
+     * @param mapper function that receives this option's value and returns an {@code Option<B>};
+     *               must not be {@code null}, and must not return {@code null}
+     * @return {@code Some(Tuple2(thisValue, b))} if both are present, otherwise {@code None}
+     * @throws NullPointerException if {@code mapper} is {@code null} or if {@code mapper} returns
+     *                              {@code null}
+     */
+    default <B> Option<Tuple2<Value, B>> zipWith(
+            Function<? super Value, ? extends Option<? extends B>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return flatMap(v -> {
+            Option<? extends B> opt =
+                Objects.requireNonNull(mapper.apply(v), "mapper must not return null");
+            return opt.map(b -> new Tuple2<>(v, b));
+        });
+    }
+
+    /**
+     * Alias for {@link #zipWith(Function)}.
+     *
+     * <p>Applies {@code mapper} to the value inside this {@code Option} and pairs the original
+     * value with the result. Useful when the name {@code flatZip} better communicates intent
+     * at the call site.
+     *
+     * @param <B>    type of the value produced by {@code mapper}
+     * @param mapper function that receives this option's value and returns an {@code Option<B>};
+     *               must not be {@code null}, and must not return {@code null}
+     * @return {@code Some(Tuple2(thisValue, b))} if both are present, otherwise {@code None}
+     * @throws NullPointerException if {@code mapper} is {@code null} or if {@code mapper} returns
+     *                              {@code null}
+     */
+    default <B> Option<Tuple2<Value, B>> flatZip(
+            Function<? super Value, ? extends Option<? extends B>> mapper) {
+        return zipWith(mapper);
+    }
+
+    /**
      * Combines this {@code Option} with two others into an {@code Option<Tuple3>}.
      * Returns {@link Option#none()} if any of the three is empty.
      *

--- a/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/lib/src/test/java/dmx/fun/OptionTest.java
@@ -597,4 +597,55 @@ class OptionTest {
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("leftIfNone");
     }
+
+    // -------------------------------------------------------------------------
+    // zipWith(Function) / flatZip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void zipWith_function_shouldReturnTuple_whenBothPresent() {
+        Option<Tuple2<String, Integer>> result =
+            Option.some("alice").zipWith(name -> Option.some(name.length()));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get()).isEqualTo(new Tuple2<>("alice", 5));
+    }
+
+    @Test
+    void zipWith_function_shouldReturnNone_whenMapperReturnsNone() {
+        Option<Tuple2<String, Integer>> result =
+            Option.<String>some("alice").zipWith(name -> Option.none());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void zipWith_function_shouldReturnNone_whenThisIsNone() {
+        boolean[] called = {false};
+        Option<Tuple2<String, Integer>> result =
+            Option.<String>none().zipWith(name -> { called[0] = true; return Option.some(1); });
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(called[0]).isFalse();
+    }
+
+    @Test
+    void zipWith_function_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Option.some("x").zipWith(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void zipWith_function_shouldThrowNPE_whenMapperReturnsNull() {
+        assertThatThrownBy(() -> Option.some("x").zipWith(v -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper must not return null");
+    }
+
+    @Test
+    void flatZip_shouldBehaveIdenticallyToZipWith() {
+        Option<Tuple2<String, Integer>> viaZipWith =
+            Option.some("hello").zipWith(s -> Option.some(s.length()));
+        Option<Tuple2<String, Integer>> viaFlatZip =
+            Option.some("hello").flatZip(s -> Option.some(s.length()));
+        assertThat(viaFlatZip).isEqualTo(viaZipWith);
+    }
 }

--- a/site/src/data/code/guide/option/composing-zip-with.mdx
+++ b/site/src/data/code/guide/option/composing-zip-with.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// zipWith(Function) — pair the current value with a derived Option
+Option<String> name = Option.some("alice");
+
+Option<Tuple2<String, Integer>> result =
+    name.zipWith(n -> lookupAge(n));
+// Some(Tuple2("alice", 30))  — if lookupAge returns Some(30)
+// None                       — if lookupAge returns None or name is None
+
+// flatZip is an alias with the same semantics
+Option<Tuple2<String, Integer>> same =
+    name.flatZip(n -> lookupAge(n));
+
+// Contrast with zip(Option) — the second Option is pre-evaluated
+Option<Integer> age = Option.some(30);
+Option<Tuple2<String, Integer>> fromZip = name.zip(age);
+// Both are None when name is None, but zip always evaluates age regardless
+```

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -20,6 +20,7 @@ import {Content as TransformingPeek}       from '../code/guide/option/transformi
 import {Content as TransformingMatch}      from '../code/guide/option/transforming-match.mdx';
 import {Content as ComposingOrElse}        from '../code/guide/option/composing-or-else.mdx';
 import {Content as ComposingZip}           from '../code/guide/option/composing-zip.mdx';
+import {Content as ComposingZipWith}       from '../code/guide/option/composing-zip-with.mdx';
 import {Content as ComposingSequence}      from '../code/guide/option/composing-sequence.mdx';
 import {Content as ComposingStream}        from '../code/guide/option/composing-stream.mdx';
 import {Content as InteropConversions}     from '../code/guide/option/interop-conversions.mdx';
@@ -150,6 +151,17 @@ Combine multiple independent `Option` values.
 Returns `None` if any input is `None`.
 
 <ComposingZip/>
+
+### Pairing a value with a derived Option — `zipWith` / `flatZip`
+
+`zipWith(mapper)` applies a function to the current value and pairs the original
+value with whatever the function returns. If the mapper returns `None`, the whole
+result is `None`. Unlike `zip(Option)`, the second `Option` is computed lazily
+_from_ the first value.
+
+`flatZip` is an alias that may read more naturally at the call site.
+
+<ComposingZipWith/>
 
 ### Collecting a list with `sequence`
 


### PR DESCRIPTION
  Add two new instance methods to Option<T>:
  - zipWith(Function): applies the mapper lazily to the present value and returns
    Some(Tuple2(thisValue, b)) if both steps are non-empty, None otherwise
  - flatZip(Function): alias for zipWith, provided for readability at call sites

  Add 6 unit tests covering: both present, mapper returns None, this is None
  (mapper not called), null mapper NPE, mapper returning null NPE, and
  flatZip/zipWith equivalence.

  Add composing-zip-with.mdx code snippet and update the Option developer guide
  with a dedicated "Pairing a value with a derived Option" subsection.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #229

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `zipWith()` and `flatZip()` methods to Option for composing dependent Options, pairing values with lazily-computed derived Options.

* **Tests**
  * Added comprehensive test coverage for the new methods.

* **Documentation**
  * Added guide documentation for the new Option composition pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->