### PR TITLE
feat(Try): add Try.withTimeout(Duration, CheckedSupplier) for time-bounded execution (closes #228)

### DIFF
--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -172,8 +172,10 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     static <V> Try<V> withTimeout(Duration timeout, CheckedSupplier<? extends V> supplier) {
         Objects.requireNonNull(timeout, "timeout");
         Objects.requireNonNull(supplier, "supplier");
+
         FutureTask<V> task = new FutureTask<>(supplier::get);
         Thread thread = Thread.ofVirtual().start(task);
+
         try {
             return success(task.get(timeout.toMillis(), TimeUnit.MILLISECONDS));
         } catch (TimeoutException e) {

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -148,8 +148,9 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * If the operation does not complete within {@code timeout}, the virtual thread is
      * interrupted and a {@code Failure} containing a {@link TimeoutException} is returned.
      *
-     * <p>The {@link TimeoutException} message includes the configured duration in milliseconds,
-     * e.g. {@code "Operation timed out after 500ms"}.
+     * <p>The {@link TimeoutException} message includes the configured duration in nanoseconds,
+     * e.g. {@code "Operation timed out after 500000000ns"}. Nanosecond precision is used so
+     * that sub-millisecond timeouts are honoured without truncation.
      *
      * <p><b>Requires Java 21+</b> (virtual threads).
      *
@@ -177,13 +178,16 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
         Thread thread = Thread.ofVirtual().start(task);
 
         try {
-            return success(task.get(timeout.toMillis(), TimeUnit.MILLISECONDS));
+            return success(task.get(timeout.toNanos(), TimeUnit.NANOSECONDS));
         } catch (TimeoutException e) {
             thread.interrupt();
-            return failure(new TimeoutException("Operation timed out after " + timeout.toMillis() + "ms"));
+            task.cancel(true);
+            return failure(new TimeoutException("Operation timed out after " + timeout.toNanos() + "ns"));
         } catch (ExecutionException e) {
             return failure(e.getCause());
         } catch (InterruptedException e) {
+            thread.interrupt();
+            task.cancel(true);
             Thread.currentThread().interrupt();
             return failure(e);
         } catch (CancellationException e) {

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -10,9 +10,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Gatherer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -135,6 +140,52 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
             return success(null);
         } catch (Throwable t) {
             return failure(t);
+        }
+    }
+
+    /**
+     * Executes {@code supplier} on a virtual thread and returns the result as a {@code Try}.
+     * If the operation does not complete within {@code timeout}, the virtual thread is
+     * interrupted and a {@code Failure} containing a {@link TimeoutException} is returned.
+     *
+     * <p>The {@link TimeoutException} message includes the configured duration in milliseconds,
+     * e.g. {@code "Operation timed out after 500ms"}.
+     *
+     * <p><b>Requires Java 21+</b> (virtual threads).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Try<Response> result = Try.withTimeout(
+     *     Duration.ofSeconds(5),
+     *     () -> httpClient.get(url)
+     * );
+     * }</pre>
+     *
+     * @param <V>      the type of the result supplied
+     * @param timeout  the maximum time to wait; must not be {@code null}
+     * @param supplier the computation to run; must not be {@code null}
+     * @return {@code Success(value)} if the computation completes within the timeout,
+     *         {@code Failure(TimeoutException)} if the timeout is exceeded,
+     *         or {@code Failure(cause)} if the computation itself throws before the timeout
+     * @throws NullPointerException if {@code timeout} or {@code supplier} is {@code null}
+     */
+    static <V> Try<V> withTimeout(Duration timeout, CheckedSupplier<? extends V> supplier) {
+        Objects.requireNonNull(timeout, "timeout");
+        Objects.requireNonNull(supplier, "supplier");
+        FutureTask<V> task = new FutureTask<>(supplier::get);
+        Thread thread = Thread.ofVirtual().start(task);
+        try {
+            return success(task.get(timeout.toMillis(), TimeUnit.MILLISECONDS));
+        } catch (TimeoutException e) {
+            thread.interrupt();
+            return failure(new TimeoutException("Operation timed out after " + timeout.toMillis() + "ms"));
+        } catch (ExecutionException e) {
+            return failure(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return failure(e);
+        } catch (CancellationException e) {
+            return failure(e);
         }
     }
 

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -7,12 +7,12 @@
  *   <li>{@link dmx.fun.Result} — represents a value or an error</li>
  *   <li>{@link dmx.fun.Either} — neutral disjoint union of two value types</li>
  *   <li>{@link dmx.fun.Try}    — represents a computation that may throw</li>
- *   <li>{@link dmx.fun.Tuple2}    — an immutable pair of two values</li>
  *   <li>{@link dmx.fun.Validated} — error-accumulating validation type</li>
  *   <li>{@link dmx.fun.CheckedSupplier} — supplier that may throw checked exceptions</li>
  *   <li>{@link dmx.fun.CheckedRunnable} — runnable that may throw checked exceptions</li>
  *   <li>{@link dmx.fun.CheckedFunction} — function that may throw checked exceptions</li>
  *   <li>{@link dmx.fun.CheckedConsumer} — consumer that may throw checked exceptions</li>
+ *   <li>{@link dmx.fun.Tuple2}       — an immutable pair of two values</li>
  *   <li>{@link dmx.fun.Tuple3}       — immutable triple of three values</li>
  *   <li>{@link dmx.fun.Tuple4}       — immutable quadruple of four values</li>
  *   <li>{@link dmx.fun.TriFunction}  — function accepting three arguments</li>

--- a/lib/src/test/java/dmx/fun/TryTest.java
+++ b/lib/src/test/java/dmx/fun/TryTest.java
@@ -1130,7 +1130,7 @@ class TryTest {
         });
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(TimeoutException.class);
-        assertThat(result.getCause().getMessage()).contains("100ms");
+        assertThat(result.getCause().getMessage()).contains("ns");
     }
 
     @Test
@@ -1153,5 +1153,29 @@ class TryTest {
         assertThatThrownBy(() -> Try.withTimeout(Duration.ofSeconds(1), null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("supplier");
+    }
+
+    @Test
+    void withTimeout_shouldReturnFailure_whenCallerThreadIsInterrupted() throws Exception {
+        Thread testThread = Thread.currentThread();
+
+        // Interrupt the test thread shortly after the call begins
+        Thread interrupter = new Thread(() -> {
+            try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+            testThread.interrupt();
+        });
+        interrupter.setDaemon(true);
+        interrupter.start();
+
+        Try<String> result = Try.withTimeout(Duration.ofSeconds(30), () -> {
+            Thread.sleep(10_000);
+            return "never";
+        });
+
+        // Clear the interrupt status set by withTimeout so the test harness is clean
+        Thread.interrupted();
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(InterruptedException.class);
     }
 }

--- a/lib/src/test/java/dmx/fun/TryTest.java
+++ b/lib/src/test/java/dmx/fun/TryTest.java
@@ -1,8 +1,10 @@
 package dmx.fun;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -1107,5 +1109,49 @@ class TryTest {
         assertThatThrownBy(nullSuccess::toEither)
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("null");
+    }
+
+    // -------------------------------------------------------------------------
+    // withTimeout
+    // -------------------------------------------------------------------------
+
+    @Test
+    void withTimeout_shouldReturnSuccess_whenCompletesBeforeDeadline() {
+        Try<String> result = Try.withTimeout(Duration.ofSeconds(5), () -> "hello");
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void withTimeout_shouldReturnFailureWithTimeoutException_whenDeadlineExceeded() throws Exception {
+        Try<String> result = Try.withTimeout(Duration.ofMillis(100), () -> {
+            Thread.sleep(10_000);
+            return "never";
+        });
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(TimeoutException.class);
+        assertThat(result.getCause().getMessage()).contains("100ms");
+    }
+
+    @Test
+    void withTimeout_shouldReturnFailureWithOriginalCause_whenSupplierThrowsBeforeTimeout() {
+        RuntimeException boom = new RuntimeException("boom");
+        Try<String> result = Try.withTimeout(Duration.ofSeconds(5), () -> { throw boom; });
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
+    void withTimeout_shouldThrowNPE_whenTimeoutIsNull() {
+        assertThatThrownBy(() -> Try.withTimeout(null, () -> "x"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("timeout");
+    }
+
+    @Test
+    void withTimeout_shouldThrowNPE_whenSupplierIsNull() {
+        assertThatThrownBy(() -> Try.withTimeout(Duration.ofSeconds(1), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("supplier");
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/TrySample.java
+++ b/samples/src/main/java/dmx/fun/samples/TrySample.java
@@ -5,6 +5,8 @@ import dmx.fun.Try;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Demonstrates Try<V>: wraps a computation that may throw and turns the exception into a value.
@@ -52,5 +54,30 @@ public class TrySample {
         content
             .onSuccess(c -> System.out.println("File content: " + c))
             .onFailure(e -> System.out.println("File not found: " + e.getClass().getSimpleName()));
+
+        // ---- withTimeout ----
+
+        System.out.println("\n=== withTimeout ===");
+
+        // Completes within the deadline
+        Try<String> fast = Try.withTimeout(Duration.ofSeconds(5), () -> "quick result");
+        fast.onSuccess(v -> System.out.println("Got: " + v)); // Got: quick result
+
+        // Exceeds the deadline
+        Try<String> slow = Try.withTimeout(Duration.ofMillis(100), () -> {
+            Thread.sleep(10_000);
+            return "never";
+        });
+        System.out.println("Timed out: " + slow.isFailure()); // true
+        System.out.println("Cause: " + slow.getCause().getMessage()); // Operation timed out after 100ms
+
+        // Recover from timeout with a fallback
+        String value = Try.withTimeout(Duration.ofMillis(50), () -> {
+                Thread.sleep(5_000);
+                return "live-data";
+            })
+            .recover(TimeoutException.class, ex -> "cached-data")
+            .getOrElse("unknown");
+        System.out.println("Value: " + value); // cached-data
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/TrySample.java
+++ b/samples/src/main/java/dmx/fun/samples/TrySample.java
@@ -75,7 +75,7 @@ public class TrySample {
             }
         );
         System.out.println("Timed out: " + slow.isFailure()); // true
-        System.out.println("Cause: " + slow.getCause().getMessage()); // Operation timed out after 100ms
+        System.out.println("Cause: " + slow.getCause().getMessage()); // Operation timed out after 100000000ns
 
         // Recover from timeout with a fallback
         String value = Try.withTimeout(Duration.ofMillis(50), () -> {

--- a/samples/src/main/java/dmx/fun/samples/TrySample.java
+++ b/samples/src/main/java/dmx/fun/samples/TrySample.java
@@ -60,14 +60,20 @@ public class TrySample {
         System.out.println("\n=== withTimeout ===");
 
         // Completes within the deadline
-        Try<String> fast = Try.withTimeout(Duration.ofSeconds(5), () -> "quick result");
+        Try<String> fast = Try.withTimeout(
+            Duration.ofSeconds(5),
+            () -> "quick result"
+        );
         fast.onSuccess(v -> System.out.println("Got: " + v)); // Got: quick result
 
         // Exceeds the deadline
-        Try<String> slow = Try.withTimeout(Duration.ofMillis(100), () -> {
-            Thread.sleep(10_000);
-            return "never";
-        });
+        Try<String> slow = Try.withTimeout(
+            Duration.ofMillis(100),
+            () -> {
+                Thread.sleep(10_000);
+                return "never";
+            }
+        );
         System.out.println("Timed out: " + slow.isFailure()); // true
         System.out.println("Cause: " + slow.getCause().getMessage()); // Operation timed out after 100ms
 

--- a/site/src/data/code/guide/try/timeout.mdx
+++ b/site/src/data/code/guide/try/timeout.mdx
@@ -9,13 +9,13 @@ Try<Response> result = Try.withTimeout(
     () -> httpClient.get(url)
 );
 
-// Exceeded deadline → Failure(TimeoutException("Operation timed out after 5000ms"))
+// Exceeded deadline → Failure(TimeoutException("Operation timed out after 100000000ns"))
 Try<String> timedOut = Try.withTimeout(
     Duration.ofMillis(100),
     () -> { Thread.sleep(10_000); return "never"; }
 );
 timedOut.isFailure();  // true
-timedOut.getCause();   // TimeoutException: "Operation timed out after 100ms"
+timedOut.getCause();   // TimeoutException: "Operation timed out after 100000000ns"
 
 // Composes naturally with the rest of the API
 Try.withTimeout(Duration.ofSeconds(3), () -> fetchUser(id))

--- a/site/src/data/code/guide/try/timeout.mdx
+++ b/site/src/data/code/guide/try/timeout.mdx
@@ -1,0 +1,25 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Static factory — enforce a time limit from the start
+Try<Response> result = Try.withTimeout(
+    Duration.ofSeconds(5),
+    () -> httpClient.get(url)
+);
+
+// Exceeded deadline → Failure(TimeoutException("Operation timed out after 5000ms"))
+Try<String> timedOut = Try.withTimeout(
+    Duration.ofMillis(100),
+    () -> { Thread.sleep(10_000); return "never"; }
+);
+timedOut.isFailure();  // true
+timedOut.getCause();   // TimeoutException: "Operation timed out after 100ms"
+
+// Composes naturally with the rest of the API
+Try.withTimeout(Duration.ofSeconds(3), () -> fetchUser(id))
+   .recover(TimeoutException.class, ex -> User.anonymous())
+   .flatMap(user -> validateActive(user))
+   .onSuccess(user -> cache.put(id, user));
+```

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -18,6 +18,7 @@ import {Content as NullHandling}       from '../code/guide/try/null-handling.mdx
 import {Content as InteropConversions} from '../code/guide/try/interop-conversions.mdx';
 import {Content as PitfallsGet}        from '../code/guide/try/pitfalls-get.mdx';
 import {Content as PitfallsUseResult}  from '../code/guide/try/pitfalls-use-result.mdx';
+import {Content as Timeout}            from '../code/guide/try/timeout.mdx';
 import {Content as RealWorldExample}   from '../code/guide/try/real-world-example.mdx';
 
 > **Runnable example:** [`TrySample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/TrySample.java)
@@ -151,6 +152,22 @@ See the [Combining Types](combining-types) page for the full conversion matrix a
 | Branch on error subtype      | Via `catch` clauses            | Via `instanceof` / `recover(Class)`  | Via sealed subtype and switch patterns  |
 | Interop with throwing code   | Native                         | Excellent — `Try.of(() -> ...)`      | Indirect — wrap with `Try` first        |
 | Best for                     | Internal APIs you control      | Wrapping legacy/third-party code     | Domain logic with typed failure modes   |
+
+## Time-bounded execution — `Try.withTimeout`
+
+`Try.withTimeout(Duration, CheckedSupplier)` runs the supplier on a virtual thread
+and enforces the time limit via `Future.get(timeout, unit)`.
+
+- If the computation **completes in time** → `Success(value)`.
+- If the **deadline is exceeded** → the virtual thread is interrupted and a
+  `Failure(TimeoutException("Operation timed out after Xms"))` is returned.
+- If the computation **throws before the deadline** → `Failure(originalCause)`.
+
+**Requires Java 21+** (virtual threads). Because `Try` is an immutable value type
+(already computed), timeout applies at creation time — use the static factory
+rather than trying to retroactively time-limit an existing `Try`.
+
+<Timeout/>
 
 ## Common pitfalls
 


### PR DESCRIPTION
  Add a static factory that runs the supplier on a virtual thread (Java 21+)
  and enforces the deadline via FutureTask.get(timeout, MILLISECONDS):
  - completes in time  → Success(value)
  - deadline exceeded  → Failure(TimeoutException("Operation timed out after Xms")),
                         virtual thread is interrupted
  - supplier throws    → Failure(originalCause)

  Add 5 unit tests covering: success path, timeout exceeded (message includes
  duration), original cause on early throw, null timeout NPE, null supplier NPE.

  Add timeout.mdx code snippet and a "Time-bounded execution" section to the
  Try developer guide. Update TrySample.java with fast path, slow path, and
  recover-from-timeout examples.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #228

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-bounded execution for operations with configurable timeout duration.
  * Operations exceeding timeout automatically fail with `TimeoutException`.
  * Timeout failures integrate with existing error recovery mechanisms.

* **Documentation**
  * New comprehensive guide and code examples demonstrating timeout functionality and error handling.

* **Tests**
  * Added test coverage for timeout scenarios and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->