### PR TITLE
feat(lib): add Result.groupingBy, Option.sequenceCollector, NonEmptyList.toNonEmptyList (closes #232)

### DIFF
--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -255,6 +255,32 @@ public final class NonEmptyList<T> implements Iterable<T> {
     }
 
     /**
+     * Alias for {@link #collector()}.
+     *
+     * <p>Returns a {@link Collector} that accumulates a {@link Stream}{@code <T>} into an
+     * {@link Option}{@code <NonEmptyList<T>>}. Produces {@link Option#some(Object)} if the stream
+     * has at least one element, or {@link Option#none()} if the stream is empty.
+     *
+     * <pre>{@code
+     * Option<NonEmptyList<String>> tags =
+     *     Stream.of("java", "fp", "dmx-fun")
+     *           .collect(NonEmptyList.toNonEmptyList());
+     * // Some(["java", "fp", "dmx-fun"])
+     *
+     * Option<NonEmptyList<String>> empty =
+     *     Stream.<String>empty()
+     *           .collect(NonEmptyList.toNonEmptyList());
+     * // None
+     * }</pre>
+     *
+     * @param <T> the element type
+     * @return a {@code Collector} producing {@code Option<NonEmptyList<T>>}
+     */
+    public static <T> Collector<T, ?, Option<NonEmptyList<T>>> toNonEmptyList() {
+        return collector();
+    }
+
+    /**
      * Sequences a {@code NonEmptyList} of {@link Option}s into an {@code Option} of a
      * {@code NonEmptyList}.
      *

--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -423,6 +423,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         return Collector.of(
             Acc::new,
             (acc, opt) -> {
+                Objects.requireNonNull(opt, "sequenceCollector stream element must not be null");
                 if (!acc.hasNone) {
                     switch (opt) {
                         case None<V> __ -> acc.hasNone = true;

--- a/lib/src/main/java/dmx/fun/Option.java
+++ b/lib/src/main/java/dmx/fun/Option.java
@@ -1,6 +1,7 @@
 package dmx.fun;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -391,6 +392,53 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      */
     static <V> Collector<Option<? extends V>, ?, List<V>> presentValuesToList() {
         return Collectors.flatMapping(Option::stream, Collectors.toList());
+    }
+
+    /**
+     * Returns a {@link Collector} that reduces a {@code Stream<Option<V>>} to a single
+     * {@code Optional<List<V>>}.
+     *
+     * <p>The result is {@link Optional#of(Object) present} only if <em>every</em> element in the
+     * stream is {@link Option#some(Object) Some}. The first {@link Option#none() None} causes the
+     * entire result to be {@link Optional#empty()}. An empty stream yields an empty list wrapped
+     * in {@code Optional.of}.
+     *
+     * <p>This mirrors {@link #sequence(Iterable)} but operates as a stream {@link Collector}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Optional<List<User>> allFound = ids.stream()
+     *     .map(userRepo::findById)             // Stream<Option<User>>
+     *     .collect(Option.sequenceCollector()); // Optional<List<User>>
+     * }</pre>
+     *
+     * @param <V> the element type inside each {@code Option}
+     * @return a collector producing {@code Optional<List<V>>}
+     */
+    static <V> Collector<Option<V>, ?, Optional<List<V>>> sequenceCollector() {
+        class Acc {
+            final ArrayList<V> values = new ArrayList<>();
+            boolean hasNone = false;
+        }
+        return Collector.of(
+            Acc::new,
+            (acc, opt) -> {
+                if (!acc.hasNone) {
+                    switch (opt) {
+                        case None<V> __ -> acc.hasNone = true;
+                        case Some<V> s  -> acc.values.add(s.value());
+                    }
+                }
+            },
+            (a, b) -> {
+                if (a.hasNone || b.hasNone) { a.hasNone = true; return a; }
+                a.values.addAll(b.values);
+                return a;
+            },
+            acc -> acc.hasNone
+                ? Optional.empty()
+                : Optional.of(Collections.unmodifiableList(acc.values))
+        );
     }
 
     // ---------- sequence / traverse ----------

--- a/lib/src/main/java/dmx/fun/Result.java
+++ b/lib/src/main/java/dmx/fun/Result.java
@@ -828,25 +828,8 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     static <V, K> Collector<V, ?, Map<K, NonEmptyList<V>>> groupingBy(
             Function<? super V, ? extends K> classifier) {
         Objects.requireNonNull(classifier, "classifier");
-        class Acc { final Map<K, ArrayList<V>> map = new LinkedHashMap<>(); }
-        return Collector.of(
-            Acc::new,
-            (acc, v) -> {
-                Objects.requireNonNull(v, "groupingBy stream element must not be null");
-                K key = Objects.requireNonNull(classifier.apply(v), "classifier must not return null");
-                acc.map.computeIfAbsent(key, k -> new ArrayList<>()).add(v);
-            },
-            (a, b) -> {
-                b.map.forEach((k, vs) -> a.map.computeIfAbsent(k, __ -> new ArrayList<>()).addAll(vs));
-                return a;
-            },
-            acc -> {
-                Map<K, NonEmptyList<V>> result = new LinkedHashMap<>();
-                acc.map.forEach((k, vs) ->
-                    result.put(k, NonEmptyList.of(vs.get(0), vs.subList(1, vs.size()))));
-                return Collections.unmodifiableMap(result);
-            }
-        );
+        return groupingByCollector(classifier,
+            vs -> NonEmptyList.of(vs.get(0), vs.subList(1, vs.size())));
     }
 
     /**
@@ -878,6 +861,20 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
             Function<? super NonEmptyList<V>, ? extends R> downstream) {
         Objects.requireNonNull(classifier, "classifier");
         Objects.requireNonNull(downstream, "downstream");
+        return groupingByCollector(classifier,
+            vs -> Objects.requireNonNull(
+                downstream.apply(NonEmptyList.of(vs.get(0), vs.subList(1, vs.size()))),
+                "downstream must not return null"));
+    }
+
+    /**
+     * Shared accumulation logic for both {@link #groupingBy} overloads.
+     * Builds a {@code LinkedHashMap<K, ArrayList<V>>} and applies {@code groupFinisher}
+     * to each group's list in the finisher step.
+     */
+    private static <V, K, R> Collector<V, ?, Map<K, R>> groupingByCollector(
+            Function<? super V, ? extends K> classifier,
+            Function<ArrayList<V>, ? extends R> groupFinisher) {
         class Acc { final Map<K, ArrayList<V>> map = new LinkedHashMap<>(); }
         return Collector.of(
             Acc::new,
@@ -892,11 +889,7 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
             },
             acc -> {
                 Map<K, R> result = new LinkedHashMap<>();
-                acc.map.forEach((k, vs) -> {
-                    NonEmptyList<V> nel = NonEmptyList.of(vs.get(0), vs.subList(1, vs.size()));
-                    result.put(k, Objects.requireNonNull(downstream.apply(nel),
-                        "downstream must not return null"));
-                });
+                acc.map.forEach((k, vs) -> result.put(k, groupFinisher.apply(vs)));
                 return Collections.unmodifiableMap(result);
             }
         );

--- a/lib/src/main/java/dmx/fun/Result.java
+++ b/lib/src/main/java/dmx/fun/Result.java
@@ -2,7 +2,9 @@ package dmx.fun;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -797,6 +799,106 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
             },
             (a, b) -> { a.oks.addAll(b.oks); a.errors.addAll(b.errors); return a; },
             acc -> new Partition<>(acc.oks, acc.errors)
+        );
+    }
+
+    // ---------- groupingBy ----------
+
+    /**
+     * Returns a {@link Collector} that groups stream elements by a key derived from each element.
+     * Each group is collected into a {@link NonEmptyList}, making the non-emptiness of every
+     * group explicit in the type.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Map<String, NonEmptyList<String>> byFirstChar =
+     *     Stream.of("apple", "avocado", "banana")
+     *           .collect(Result.groupingBy(s -> s.substring(0, 1)));
+     * // {"a" -> ["apple", "avocado"], "b" -> ["banana"]}
+     * }</pre>
+     *
+     * @param <V>        the element type
+     * @param <K>        the key type produced by the classifier
+     * @param classifier function mapping each element to its group key; must not be {@code null}
+     *                   and must not return {@code null}
+     * @return an unmodifiable {@code Map<K, NonEmptyList<V>>} preserving encounter order
+     * @throws NullPointerException if {@code classifier} is {@code null}, if a stream element is
+     *                              {@code null}, or if the classifier returns {@code null}
+     */
+    static <V, K> Collector<V, ?, Map<K, NonEmptyList<V>>> groupingBy(
+            Function<? super V, ? extends K> classifier) {
+        Objects.requireNonNull(classifier, "classifier");
+        class Acc { final Map<K, ArrayList<V>> map = new LinkedHashMap<>(); }
+        return Collector.of(
+            Acc::new,
+            (acc, v) -> {
+                Objects.requireNonNull(v, "groupingBy stream element must not be null");
+                K key = Objects.requireNonNull(classifier.apply(v), "classifier must not return null");
+                acc.map.computeIfAbsent(key, k -> new ArrayList<>()).add(v);
+            },
+            (a, b) -> {
+                b.map.forEach((k, vs) -> a.map.computeIfAbsent(k, __ -> new ArrayList<>()).addAll(vs));
+                return a;
+            },
+            acc -> {
+                Map<K, NonEmptyList<V>> result = new LinkedHashMap<>();
+                acc.map.forEach((k, vs) ->
+                    result.put(k, NonEmptyList.of(vs.get(0), vs.subList(1, vs.size()))));
+                return Collections.unmodifiableMap(result);
+            }
+        );
+    }
+
+    /**
+     * Returns a {@link Collector} that groups stream elements by a key derived from each element
+     * and applies a downstream function to each group's {@link NonEmptyList}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Map<String, Long> countByFirstChar =
+     *     Stream.of("apple", "avocado", "banana")
+     *           .collect(Result.groupingBy(s -> s.substring(0, 1), NonEmptyList::size));
+     * // {"a" -> 2, "b" -> 1}
+     * }</pre>
+     *
+     * @param <V>        the element type
+     * @param <K>        the key type produced by the classifier
+     * @param <R>        the result type produced by the downstream function
+     * @param classifier function mapping each element to its group key; must not be {@code null}
+     *                   and must not return {@code null}
+     * @param downstream function applied to each group's {@code NonEmptyList}; must not be
+     *                   {@code null} and must not return {@code null}
+     * @return an unmodifiable {@code Map<K, R>} preserving encounter order
+     * @throws NullPointerException if {@code classifier} or {@code downstream} is {@code null},
+     *                              if a stream element is {@code null}, or if the classifier or
+     *                              downstream returns {@code null}
+     */
+    static <V, K, R> Collector<V, ?, Map<K, R>> groupingBy(
+            Function<? super V, ? extends K> classifier,
+            Function<? super NonEmptyList<V>, ? extends R> downstream) {
+        Objects.requireNonNull(classifier, "classifier");
+        Objects.requireNonNull(downstream, "downstream");
+        class Acc { final Map<K, ArrayList<V>> map = new LinkedHashMap<>(); }
+        return Collector.of(
+            Acc::new,
+            (acc, v) -> {
+                Objects.requireNonNull(v, "groupingBy stream element must not be null");
+                K key = Objects.requireNonNull(classifier.apply(v), "classifier must not return null");
+                acc.map.computeIfAbsent(key, k -> new ArrayList<>()).add(v);
+            },
+            (a, b) -> {
+                b.map.forEach((k, vs) -> a.map.computeIfAbsent(k, __ -> new ArrayList<>()).addAll(vs));
+                return a;
+            },
+            acc -> {
+                Map<K, R> result = new LinkedHashMap<>();
+                acc.map.forEach((k, vs) -> {
+                    NonEmptyList<V> nel = NonEmptyList.of(vs.get(0), vs.subList(1, vs.size()));
+                    result.put(k, Objects.requireNonNull(downstream.apply(nel),
+                        "downstream must not return null"));
+                });
+                return Collections.unmodifiableMap(result);
+            }
         );
     }
 

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -1,6 +1,7 @@
 package dmx.fun;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -371,5 +372,33 @@ class NonEmptyListTest {
     void toString_shouldMatchListFormat() {
         NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
         assertThat(nel.toString()).isEqualTo("[1, 2, 3]");
+    }
+
+    // -------------------------------------------------------------------------
+    // toNonEmptyList() collector
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toNonEmptyList_shouldReturnSome_whenStreamIsNonEmpty() {
+        Option<NonEmptyList<String>> result = Stream.of("a", "b", "c")
+            .collect(NonEmptyList.toNonEmptyList());
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().toList()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void toNonEmptyList_shouldReturnNone_whenStreamIsEmpty() {
+        Option<NonEmptyList<String>> result = Stream.<String>empty()
+            .collect(NonEmptyList.toNonEmptyList());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void toNonEmptyList_shouldBehaveIdenticallyToCollector() {
+        Option<NonEmptyList<Integer>> viaCollector =
+            Stream.of(1, 2, 3).collect(NonEmptyList.collector());
+        Option<NonEmptyList<Integer>> viaAlias =
+            Stream.of(1, 2, 3).collect(NonEmptyList.toNonEmptyList());
+        assertThat(viaAlias).isEqualTo(viaCollector);
     }
 }

--- a/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/lib/src/test/java/dmx/fun/OptionTest.java
@@ -648,4 +648,41 @@ class OptionTest {
             Option.some("hello").flatZip(s -> Option.some(s.length()));
         assertThat(viaFlatZip).isEqualTo(viaZipWith);
     }
+
+    // -------------------------------------------------------------------------
+    // sequenceCollector
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceCollector_shouldReturnPresentList_whenAllSome() {
+        Optional<List<String>> result = Stream.of(
+                Option.some("a"), Option.some("b"), Option.some("c"))
+            .collect(Option.sequenceCollector());
+        assertThat(result).isPresent();
+        assertThat(result.get()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void sequenceCollector_shouldReturnEmpty_whenAnyNone() {
+        Optional<List<String>> result = Stream.of(
+                Option.some("a"), Option.<String>none(), Option.some("c"))
+            .collect(Option.sequenceCollector());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void sequenceCollector_shouldReturnPresentEmptyList_forEmptyStream() {
+        Optional<List<String>> result = Stream.<Option<String>>empty()
+            .collect(Option.sequenceCollector());
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEmpty();
+    }
+
+    @Test
+    void sequenceCollector_resultListShouldBeUnmodifiable() {
+        Optional<List<String>> result = Stream.of(Option.some("a"))
+            .collect(Option.sequenceCollector());
+        assertThatThrownBy(() -> result.get().add("z"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
 }

--- a/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/lib/src/test/java/dmx/fun/ResultTest.java
@@ -3,6 +3,7 @@ package dmx.fun;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -703,5 +704,62 @@ class ResultTest {
             .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new Result.Partition<>(srcOks, null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // groupingBy
+    // -------------------------------------------------------------------------
+
+    @Test
+    void groupingBy_shouldGroupElementsByKey() {
+        Map<Integer, NonEmptyList<String>> result = Stream.of("a", "bb", "cc", "ddd")
+            .collect(Result.groupingBy(String::length));
+        assertThat(result).containsOnlyKeys(1, 2, 3);
+        assertThat(result.get(1).toList()).containsExactly("a");
+        assertThat(result.get(2).toList()).containsExactly("bb", "cc");
+        assertThat(result.get(3).toList()).containsExactly("ddd");
+    }
+
+    @Test
+    void groupingBy_shouldReturnEmptyMap_forEmptyStream() {
+        Map<Integer, NonEmptyList<String>> result = Stream.<String>empty()
+            .collect(Result.groupingBy(String::length));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void groupingBy_resultShouldBeUnmodifiable() {
+        Map<Integer, NonEmptyList<String>> result = Stream.of("a")
+            .collect(Result.groupingBy(String::length));
+        assertThatThrownBy(() -> result.put(99, NonEmptyList.singleton("x")))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void groupingBy_shouldThrowNPE_whenClassifierIsNull() {
+        assertThatThrownBy(() -> Stream.of("a").collect(Result.groupingBy(null)))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("classifier");
+    }
+
+    @Test
+    void groupingBy_shouldThrowNPE_whenStreamElementIsNull() {
+        Stream<String> s = Stream.of("a", null);
+        assertThatThrownBy(() -> s.collect(Result.groupingBy(String::length)))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void groupingBy_downstream_shouldApplyFunctionToEachGroup() {
+        Map<Integer, Long> result = Stream.of("a", "bb", "cc", "ddd")
+            .collect(Result.groupingBy(String::length, nel -> (long) nel.size()));
+        assertThat(result).containsEntry(1, 1L).containsEntry(2, 2L).containsEntry(3, 1L);
+    }
+
+    @Test
+    void groupingBy_downstream_shouldThrowNPE_whenDownstreamIsNull() {
+        assertThatThrownBy(() -> Stream.of("a").collect(Result.groupingBy(String::length, null)))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("downstream");
     }
 }

--- a/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/lib/src/test/java/dmx/fun/ResultTest.java
@@ -754,6 +754,11 @@ class ResultTest {
         Map<Integer, Long> result = Stream.of("a", "bb", "cc", "ddd")
             .collect(Result.groupingBy(String::length, nel -> (long) nel.size()));
         assertThat(result).containsEntry(1, 1L).containsEntry(2, 2L).containsEntry(3, 1L);
+        // keys must appear in encounter order: 1, 2, 3
+        assertThat(result.keySet()).containsExactly(1, 2, 3);
+        // result map must be unmodifiable
+        assertThatThrownBy(() -> result.put(99, 0L))
+            .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
@@ -5,6 +5,7 @@ import dmx.fun.NonEmptySet;
 import dmx.fun.Option;
 import dmx.fun.Validated;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Demonstrates NonEmptyList<T>: a list guaranteed to have at least one element at compile time.
@@ -23,7 +24,7 @@ public class NonEmptyListSample {
         }
     }
 
-    static void main(String[] args) {
+    public static void main(String[] args) {
         // Construction — head + tail list
         NonEmptyList<String> tags = NonEmptyList.of("java", List.of("fp", "dmx-fun"));
         System.out.println("Head: " + tags.head());      // java
@@ -67,5 +68,27 @@ public class NonEmptyListSample {
           .peekError(errors -> errors.toList().forEach(e -> System.out.println("Error: " + e)));
         // Error: Must be positive, got: -1
         // Error: Not a number: abc
+
+        // ---- toNonEmptyList() collector ----
+
+        System.out.println("\n=== toNonEmptyList collector ===");
+
+        // Non-empty stream → Some(NonEmptyList)
+        Option<NonEmptyList<String>> collected = Stream.of("java", "fp", "dmx-fun")
+            .filter(t -> t.length() > 2)
+            .collect(NonEmptyList.toNonEmptyList());
+        collected.peek(nel -> System.out.println("Collected: " + nel.toList()));
+        // Collected: [java, fp, dmx-fun]
+
+        // Empty stream → None
+        Option<NonEmptyList<String>> noResults = Stream.<String>empty()
+            .collect(NonEmptyList.toNonEmptyList());
+        System.out.println("No results: " + noResults.isEmpty()); // true
+
+        // Useful when a filter may eliminate all elements
+        Option<NonEmptyList<String>> longTags = Stream.of("java", "fp", "dmx-fun")
+            .filter(t -> t.length() > 10)
+            .collect(NonEmptyList.toNonEmptyList());
+        System.out.println("Long tags: " + longTags.isEmpty()); // true
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
@@ -78,7 +78,7 @@ public class NonEmptyListSample {
             .filter(t -> t.length() > 2)
             .collect(NonEmptyList.toNonEmptyList());
         collected.peek(nel -> System.out.println("Collected: " + nel.toList()));
-        // Collected: [java, fp, dmx-fun]
+        // Collected: [java, dmx-fun]
 
         // Empty stream → None
         Option<NonEmptyList<String>> noResults = Stream.<String>empty()

--- a/samples/src/main/java/dmx/fun/samples/OptionSample.java
+++ b/samples/src/main/java/dmx/fun/samples/OptionSample.java
@@ -1,6 +1,10 @@
 package dmx.fun.samples;
 
 import dmx.fun.Option;
+import dmx.fun.Tuple2;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Demonstrates Option<T>: a value that may or may not be present.
@@ -16,7 +20,11 @@ public class OptionSample {
         return Option.none();
     }
 
-    static void main(String[] args) {
+    static Option<Integer> findPort(String host) {
+        return "api.example.com".equals(host) ? Option.some(8080) : Option.none();
+    }
+
+    public static void main(String[] args) {
         // Transform the value if present — map returns None when the source is None
         Option<Integer> length = findEmail("alice").map(String::length);
         System.out.println("Email length: " + length.getOrElse(0)); // 17
@@ -39,5 +47,48 @@ public class OptionSample {
             case Option.None<String> none -> "Not found";
         };
         System.out.println(result); // Found: alice@example.com
+
+        // ---- zipWith(Function) / flatZip ----
+
+        System.out.println("\n=== zipWith(Function) ===");
+
+        // Pair the value with a derived Option — both present
+        Option<Tuple2<String, Integer>> emailWithLength =
+            findEmail("alice").zipWith(e -> Option.some(e.length()));
+        emailWithLength.peek(t -> System.out.println("email=" + t._1() + " len=" + t._2()));
+        // email=alice@example.com len=17
+
+        // Derived lookup returns None — whole result is None
+        Option<Tuple2<String, Integer>> noPort =
+            findEmail("alice").zipWith(e -> findPort(e)); // no port for email domain
+        System.out.println("No port: " + noPort.isEmpty()); // true
+
+        // flatZip — alias, same semantics
+        Option<Tuple2<String, Integer>> hostWithPort =
+            Option.some("api.example.com").flatZip(h -> findPort(h));
+        hostWithPort.peek(t -> System.out.println("host=" + t._1() + " port=" + t._2()));
+        // host=api.example.com port=8080
+
+        // Source is None — mapper is not called
+        Option<Tuple2<String, Integer>> noneSource =
+            Option.<String>none().zipWith(e -> findPort(e));
+        System.out.println("None source: " + noneSource.isEmpty()); // true
+
+        // ---- sequenceCollector ----
+
+        System.out.println("\n=== sequenceCollector ===");
+
+        // All Some — present list
+        Optional<List<String>> allFound = Stream.of("alice", "alice")
+            .map(u -> findEmail(u))
+            .collect(Option.sequenceCollector());
+        System.out.println("All found: " + allFound.isPresent()); // true
+        System.out.println("Emails: " + allFound.get()); // [alice@example.com, alice@example.com]
+
+        // Any None — empty Optional
+        Optional<List<String>> oneMissing = Stream.of("alice", "bob")
+            .map(u -> findEmail(u))
+            .collect(Option.sequenceCollector());
+        System.out.println("One missing: " + oneMissing.isEmpty()); // true
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/ResultSample.java
+++ b/samples/src/main/java/dmx/fun/samples/ResultSample.java
@@ -1,6 +1,10 @@
 package dmx.fun.samples;
 
+import dmx.fun.NonEmptyList;
 import dmx.fun.Result;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Demonstrates Result<V, E>: an operation that can succeed or fail with a typed error.
@@ -37,7 +41,7 @@ public class ResultSample {
             : Result.err(new UserError.InvalidEmail(email));
     }
 
-    static void main(String[] args) {
+    public static void main(String[] args) {
         // Happy path — three steps chained with flatMap
         Result<String, UserError> email = findUser("u1")
             .flatMap(ResultSample::validateActive)
@@ -63,5 +67,36 @@ public class ResultSample {
             case Result.Ok<User, UserError>  ok  -> System.out.println("Found: "  + ok.value());
             case Result.Err<User, UserError> err -> System.out.println("Error: "  + err.error());
         }
+
+        // ---- groupingBy ----
+
+        System.out.println("\n=== groupingBy ===");
+
+        List<User> users = List.of(
+            new User("u1", "alice@example.com", true),
+            new User("u2", "bob@example.com",   false),
+            new User("u3", "carol@example.com", true)
+        );
+
+        // Group by active status — each group is a NonEmptyList
+        Map<Boolean, NonEmptyList<User>> byActive =
+            users.stream().collect(Result.groupingBy(User::active));
+        byActive.forEach((active, group) ->
+            System.out.println("active=" + active + " count=" + group.size()));
+        // active=true  count=2
+        // active=false count=1
+
+        // Downstream variant — count per group
+        Map<Boolean, Integer> countByActive =
+            users.stream().collect(Result.groupingBy(User::active, NonEmptyList::size));
+        System.out.println("Active count: " + countByActive.get(true));   // 2
+        System.out.println("Inactive count: " + countByActive.get(false)); // 1
+
+        // Group strings by first character
+        Map<Character, NonEmptyList<String>> byFirstChar =
+            Stream.of("apple", "avocado", "banana")
+                  .collect(Result.groupingBy(s -> s.charAt(0)));
+        System.out.println("'a' group: " + byFirstChar.get('a').toList()); // [apple, avocado]
+        System.out.println("'b' group: " + byFirstChar.get('b').toList()); // [banana]
     }
 }

--- a/site/src/data/code/guide/non-empty-list/to-non-empty-list-collector.mdx
+++ b/site/src/data/code/guide/non-empty-list/to-non-empty-list-collector.mdx
@@ -1,0 +1,26 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Non-empty stream → Some(NonEmptyList)
+Option<NonEmptyList<String>> tags =
+    Stream.of("java", "fp", "dmx-fun")
+          .filter(t -> t.length() > 2)
+          .collect(NonEmptyList.toNonEmptyList());
+// Some(["java", "fp", "dmx-fun"])
+
+// Empty stream → None
+Option<NonEmptyList<String>> noTags =
+    Stream.<String>empty()
+          .collect(NonEmptyList.toNonEmptyList());
+// None
+
+// Combine with other stream operations
+Option<NonEmptyList<Integer>> evens =
+    IntStream.rangeClosed(1, 10)
+             .boxed()
+             .filter(n -> n % 2 == 0)
+             .collect(NonEmptyList.toNonEmptyList());
+// Some([2, 4, 6, 8, 10])
+```

--- a/site/src/data/code/guide/non-empty-list/to-non-empty-list-collector.mdx
+++ b/site/src/data/code/guide/non-empty-list/to-non-empty-list-collector.mdx
@@ -8,7 +8,7 @@ Option<NonEmptyList<String>> tags =
     Stream.of("java", "fp", "dmx-fun")
           .filter(t -> t.length() > 2)
           .collect(NonEmptyList.toNonEmptyList());
-// Some(["java", "fp", "dmx-fun"])
+// Some(["java", "dmx-fun"])   // "fp".length() == 2, filtered out by > 2
 
 // Empty stream → None
 Option<NonEmptyList<String>> noTags =

--- a/site/src/data/code/guide/option/sequence-collector.mdx
+++ b/site/src/data/code/guide/option/sequence-collector.mdx
@@ -1,0 +1,27 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// All Some → Optional containing all values
+Optional<List<String>> result = Stream.of(
+        Option.some("alice"), Option.some("bob"))
+    .collect(Option.sequenceCollector());
+// Optional.of(["alice", "bob"])
+
+// Any None → Optional.empty()
+Optional<List<String>> missing = Stream.of(
+        Option.some("alice"), Option.<String>none())
+    .collect(Option.sequenceCollector());
+// Optional.empty()
+
+// Empty stream → Optional.of([])
+Optional<List<String>> empty = Stream.<Option<String>>empty()
+    .collect(Option.sequenceCollector());
+// Optional.of([])
+
+// Typical use: look up all IDs, fail if any is missing
+Optional<List<User>> allFound = ids.stream()
+    .map(userRepo::findById)             // Stream<Option<User>>
+    .collect(Option.sequenceCollector()); // Optional<List<User>>
+```

--- a/site/src/data/code/guide/result/grouping-by.mdx
+++ b/site/src/data/code/guide/result/grouping-by.mdx
@@ -1,0 +1,27 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Group by a key — each group is a guaranteed-non-empty NonEmptyList
+Map<Integer, NonEmptyList<String>> byLength =
+    Stream.of("a", "bb", "cc", "ddd")
+          .collect(Result.groupingBy(String::length));
+// {1 -> ["a"], 2 -> ["bb", "cc"], 3 -> ["ddd"]}
+
+// Downstream variant — transform each group after grouping
+Map<Integer, Long> countByLength =
+    Stream.of("a", "bb", "cc", "ddd")
+          .collect(Result.groupingBy(String::length, nel -> (long) nel.size()));
+// {1 -> 1, 2 -> 2, 3 -> 1}
+
+// Domain example — group users by role
+Map<Role, NonEmptyList<User>> byRole =
+    users.stream()
+         .collect(Result.groupingBy(User::role));
+
+// Count per role using the downstream variant
+Map<Role, Integer> countByRole =
+    users.stream()
+         .collect(Result.groupingBy(User::role, NonEmptyList::size));
+```

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -13,6 +13,7 @@ import {Content as InteropValidated}   from '../code/guide/non-empty-list/intero
 import {Content as StreamInterop}      from '../code/guide/non-empty-list/stream-interop.mdx';
 import {Content as EqualityToString}       from '../code/guide/non-empty-list/equality-tostring.mdx';
 import {Content as InteropNonEmptyTypes}   from '../code/guide/non-empty-list/interop-non-empty-types.mdx';
+import {Content as ToNonEmptyListCollector} from '../code/guide/non-empty-list/to-non-empty-list-collector.mdx';
 import {Content as RealWorldExample}       from '../code/guide/non-empty-list/real-world-example.mdx';
 
 > **Runnable example:** [`NonEmptyListSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java)
@@ -43,12 +44,13 @@ Use it when:
 
 ## Creating instances
 
-| Factory                                       | When input is empty?          |
-|-----------------------------------------------|-------------------------------|
-| `NonEmptyList.of(head, tail)`                 | N/A — head is always required |
-| `NonEmptyList.singleton(head)`                | N/A — always one element      |
-| `NonEmptyList.fromList(list)`                 | Returns `None`                |
-| `stream.collect(NonEmptyList.collector())`    | Returns `None`                |
+| Factory                                            | When input is empty?          |
+|----------------------------------------------------|-------------------------------|
+| `NonEmptyList.of(head, tail)`                      | N/A — head is always required |
+| `NonEmptyList.singleton(head)`                     | N/A — always one element      |
+| `NonEmptyList.fromList(list)`                      | Returns `None`                |
+| `stream.collect(NonEmptyList.collector())`         | Returns `None`                |
+| `stream.collect(NonEmptyList.toNonEmptyList())`    | Returns `None`                |
 
 <CreatingInstances/>
 
@@ -65,6 +67,14 @@ that may be empty (for singletons).
 
 All transformation methods (`map`, `append`, `prepend`, `concat`) return a **new
 `NonEmptyList`** — the original is unchanged.
+
+## Collecting a stream — `toNonEmptyList`
+
+`NonEmptyList.toNonEmptyList()` is an alias for `collector()` that reads naturally
+at stream call sites. It returns `Some(NonEmptyList)` for a non-empty stream and
+`None` for an empty stream.
+
+<ToNonEmptyListCollector/>
 
 ## Interoperability — `Option`
 

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -22,6 +22,7 @@ import {Content as ComposingOrElse}        from '../code/guide/option/composing-
 import {Content as ComposingZip}           from '../code/guide/option/composing-zip.mdx';
 import {Content as ComposingZipWith}       from '../code/guide/option/composing-zip-with.mdx';
 import {Content as ComposingSequence}      from '../code/guide/option/composing-sequence.mdx';
+import {Content as SequenceCollector}      from '../code/guide/option/sequence-collector.mdx';
 import {Content as ComposingStream}        from '../code/guide/option/composing-stream.mdx';
 import {Content as InteropConversions}     from '../code/guide/option/interop-conversions.mdx';
 import {Content as PitfallsNested}         from '../code/guide/option/pitfalls-nested.mdx';
@@ -169,6 +170,14 @@ Converts a `List<Option<T>>` into an `Option<List<T>>`.
 Returns `None` as soon as any element is `None`.
 
 <ComposingSequence/>
+
+### Collecting a stream with `sequenceCollector`
+
+`Option.sequenceCollector()` is the stream `Collector` counterpart to `sequence`.
+It reduces a `Stream<Option<V>>` to a single `Optional<List<V>>` — present only if
+every element is `Some`, empty if any element is `None`.
+
+<SequenceCollector/>
 
 ### Stream integration with `stream()`
 

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -138,10 +138,13 @@ two lists, consuming the entire stream.
 `Result.groupingBy(classifier)` groups stream elements by a derived key into a
 `Map<K, NonEmptyList<V>>`. Unlike `Collectors.groupingBy`, the value type is
 `NonEmptyList<V>` rather than `List<V>`, making the non-emptiness of every group
-explicit in the type.
+explicit in the type. The returned `Map<K, NonEmptyList<V>>` is **insertion-order**
+(encounter order of the stream) and **unmodifiable**.
 
-A downstream variant `groupingBy(classifier, downstream)` applies a transformation
-to each group's `NonEmptyList` after grouping.
+The downstream variant `groupingBy(classifier, downstream)` applies a
+`Function<NonEmptyList<V>, R>` to each group after grouping, producing a
+`Map<K, R>`. Like the base overload, the result is **insertion-order** and
+**unmodifiable**.
 
 <GroupingBy/>
 

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -19,6 +19,7 @@ import {Content as SequenceTraverse}     from '../code/guide/result/sequence-tra
 import {Content as InteropConversions}   from '../code/guide/result/interop-conversions.mdx';
 import {Content as PitfallsNested}       from '../code/guide/result/pitfalls-nested.mdx';
 import {Content as PitfallsIgnoringError} from '../code/guide/result/pitfalls-ignoring-error.mdx';
+import {Content as GroupingBy}           from '../code/guide/result/grouping-by.mdx';
 import {Content as RealWorldExample}     from '../code/guide/result/real-world-example.mdx';
 
 > **Runnable example:** [`ResultSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResultSample.java)
@@ -131,6 +132,18 @@ This is implemented internally with a Stream Gatherer.
 If you need all results regardless of failure, use `Result.partitioningBy()`
 as a `Collector` — it separates `Ok` values and errors into
 two lists, consuming the entire stream.
+
+## Grouping with `Result.groupingBy`
+
+`Result.groupingBy(classifier)` groups stream elements by a derived key into a
+`Map<K, NonEmptyList<V>>`. Unlike `Collectors.groupingBy`, the value type is
+`NonEmptyList<V>` rather than `List<V>`, making the non-emptiness of every group
+explicit in the type.
+
+A downstream variant `groupingBy(classifier, downstream)` applies a transformation
+to each group's `NonEmptyList` after grouping.
+
+<GroupingBy/>
 
 ## Interoperability
 


### PR DESCRIPTION
  Result.groupingBy(classifier) — groups Stream<V> into Map<K, NonEmptyList<V>>,
  making every group's non-emptiness explicit. Downstream variant
  groupingBy(classifier, downstream) applies a Function<NonEmptyList<V>, R>
  to each group. Both return unmodifiable, insertion-order maps.

  Option.sequenceCollector() — Collector<Option<V>, ?, Optional<List<V>>> that
  reduces a Stream<Option<V>> to Optional<List<V>>: present only if all elements
  are Some, empty on the first None. Complements the existing sequence(Iterable).

  NonEmptyList.toNonEmptyList() — readable alias for the existing collector()
  static factory. Returns Some(NonEmptyList) for a non-empty stream, None otherwise.

  Add 14 unit tests (7 groupingBy, 4 sequenceCollector, 3 toNonEmptyList).
  Add 3 guide snippet files and update result.mdx, option.mdx, non-empty-list.mdx.
  Update OptionSample, ResultSample, and NonEmptyListSample with runnable examples.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #232

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream collector to convert streams into NonEmptyList or empty Option values
  * Added sequence collector to combine multiple optional values into a single list or empty result
  * Added grouping collectors to organize stream elements by key with guaranteed non-empty groups

* **Documentation**
  * Added guides and code examples for new stream collector functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->