### PR TITLE
feat(Resource): add composable managed resource type (issue #224)

### DIFF
--- a/lib/src/main/java/dmx/fun/Resource.java
+++ b/lib/src/main/java/dmx/fun/Resource.java
@@ -1,0 +1,252 @@
+package dmx.fun;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A functional managed resource: a value that must be acquired before use and released
+ * afterwards. {@code Resource<T>} is the composable alternative to {@code try-with-resources}.
+ *
+ * <p>Acquisition and release are declared together at construction time. The resource is only
+ * live during the execution of {@link #use(CheckedFunction) use(fn)} — it is acquired just
+ * before the body runs, and the release function is <em>always</em> called when the body
+ * completes, whether it succeeds or throws.
+ *
+ * <h2>Behaviour contract</h2>
+ * <ul>
+ *   <li>If the body succeeds and release succeeds → {@code Try.success(result)}.</li>
+ *   <li>If the body succeeds but release throws → {@code Try.failure(releaseException)}.</li>
+ *   <li>If the body throws and release succeeds → {@code Try.failure(bodyException)}.</li>
+ *   <li>If both the body and release throw → the release exception is <em>suppressed</em> onto
+ *       the body exception (mirroring {@code try-with-resources} semantics) and
+ *       {@code Try.failure(bodyException)} is returned.</li>
+ * </ul>
+ *
+ * <h2>Composition</h2>
+ * <ul>
+ *   <li>{@link #map(Function) map} transforms the resource value without changing
+ *       acquire/release.</li>
+ *   <li>{@link #flatMap(Function) flatMap} sequences two resources; both are released in
+ *       reverse acquisition order (inner first, then outer).</li>
+ * </ul>
+ *
+ * @param <T> the type of the managed resource value
+ */
+@NullMarked
+public final class Resource<T> {
+
+    /**
+     * Internal representation: a generic lifecycle function.
+     * Implemented as an anonymous class (not a lambda) because the method carries its own
+     * type parameter {@code <R>}, which Java lambdas cannot implement.
+     */
+    private interface Effect<T> {
+        <R> Try<R> run(CheckedFunction<? super T, ? extends R> body);
+    }
+
+    private final Effect<T> effect;
+
+    private Resource(Effect<T> effect) {
+        this.effect = effect;
+    }
+
+    // -------------------------------------------------------------------------
+    // Factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@code Resource<T>} from explicit acquire and release functions.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Resource<Connection> conn = Resource.of(
+     *     () -> dataSource.getConnection(),
+     *     Connection::close
+     * );
+     * }</pre>
+     *
+     * @param <T>     the resource type
+     * @param acquire supplier that obtains the resource; may throw
+     * @param release consumer that frees the resource; always called after the body
+     * @return a new {@code Resource<T>}
+     * @throws NullPointerException if {@code acquire} or {@code release} is {@code null}
+     */
+    public static <T> Resource<T> of(
+            CheckedSupplier<? extends T> acquire,
+            CheckedConsumer<? super T> release) {
+        Objects.requireNonNull(acquire, "acquire");
+        Objects.requireNonNull(release, "release");
+        return new Resource<>(new Effect<>() {
+            @Override
+            public <R> Try<R> run(CheckedFunction<? super T, ? extends R> body) {
+                T resource;
+                try {
+                    resource = acquire.get();
+                } catch (Throwable t) {
+                    return Try.failure(t);
+                }
+                return runBody(resource, body, release);
+            }
+        });
+    }
+
+    /**
+     * Creates a {@code Resource<T>} from an {@link AutoCloseable} supplier.
+     * The {@link AutoCloseable#close()} method is used as the release function.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Resource<BufferedReader> reader = Resource.fromAutoCloseable(
+     *     () -> new BufferedReader(new FileReader(path))
+     * );
+     * Try<String> content = reader.use(r -> r.lines().collect(joining("\n")));
+     * }</pre>
+     *
+     * @param <T>     the resource type, must extend {@link AutoCloseable}
+     * @param acquire supplier that obtains the {@code AutoCloseable} resource; may throw
+     * @return a new {@code Resource<T>}
+     * @throws NullPointerException if {@code acquire} is {@code null}
+     */
+    public static <T extends AutoCloseable> Resource<T> fromAutoCloseable(
+            CheckedSupplier<? extends T> acquire) {
+        Objects.requireNonNull(acquire, "acquire");
+        return of(acquire, AutoCloseable::close);
+    }
+
+    // -------------------------------------------------------------------------
+    // Core operation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Acquires the resource, applies {@code body} to it, releases the resource, and returns
+     * the body's result wrapped in a {@link Try}.
+     *
+     * <p>The release function is <em>always</em> called, even when {@code body} throws.
+     * See the class-level contract for the exact exception-merging rules.
+     *
+     * @param <R>  the result type
+     * @param body function applied to the live resource; may throw
+     * @return {@code Try.success(result)} on success, or {@code Try.failure(cause)} on any error
+     * @throws NullPointerException if {@code body} is {@code null}
+     */
+    public <R> Try<R> use(CheckedFunction<? super T, ? extends R> body) {
+        Objects.requireNonNull(body, "body");
+        return effect.run(body);
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a new {@code Resource<R>} whose body receives the result of applying {@code fn}
+     * to the acquired value. The acquire/release lifecycle of the underlying resource is
+     * unchanged.
+     *
+     * <p>If {@code fn} throws, the underlying resource is still released and the exception is
+     * captured as a {@code Try.failure}.
+     *
+     * @param <R> the mapped resource type
+     * @param fn  function transforming the acquired value; must not be {@code null}
+     * @return a new {@code Resource<R>}
+     * @throws NullPointerException if {@code fn} is {@code null}
+     */
+    public <R> Resource<R> map(Function<? super T, ? extends R> fn) {
+        Objects.requireNonNull(fn, "fn");
+        Effect<T> self = this.effect;
+        return new Resource<>(new Effect<>() {
+            @Override
+            public <S> Try<S> run(CheckedFunction<? super R, ? extends S> body) {
+                return self.run(
+                    t -> body.apply(fn.apply(t))
+                );
+            }
+        });
+    }
+
+    /**
+     * Sequences this resource with an inner resource derived from its value.
+     * Both resources are released in reverse acquisition order: the inner resource is
+     * released first, then this (outer) resource.
+     *
+     * <p>Example — connection then prepared statement:
+     * <pre>{@code
+     * Resource<PreparedStatement> stmt = connResource.flatMap(c ->
+     *     Resource.of(
+     *         () -> c.prepareStatement("SELECT * FROM users"),
+     *         PreparedStatement::close
+     *     )
+     * );
+     * Try<List<User>> result = stmt.use(ps -> mapRows(ps.executeQuery()));
+     * }</pre>
+     *
+     * @param <R> the inner resource type
+     * @param fn  function that produces the inner resource from this resource's value;
+     *            must not be {@code null} and must not return {@code null}
+     * @return a composed {@code Resource<R>} whose lifecycle manages both resources
+     * @throws NullPointerException if {@code fn} is {@code null} or returns {@code null}
+     */
+    public <R> Resource<R> flatMap(Function<? super T, ? extends Resource<R>> fn) {
+        Objects.requireNonNull(fn, "fn");
+        Effect<T> self = this.effect;
+        return new Resource<>(new Effect<>() {
+            @Override
+            public <S> Try<S> run(CheckedFunction<? super R, ? extends S> body) {
+                // Run the outer lifecycle with a body that:
+                //   1. Creates the inner resource from T
+                //   2. Runs the inner resource with the user's body
+                //   3. If inner failed, rethrows so the outer Effect captures it as bodyEx
+                //      (and still releases the outer resource)
+                //   4. If inner succeeded, returns the result so the outer Effect returns success
+                return self.run(t -> {
+                    var inner = Objects.requireNonNull(
+                        fn.apply(t), "flatMap fn must not return null");
+                    var innerResult = inner.use(body);
+                    if (innerResult.isFailure()) {
+                        sneakyThrow(innerResult.getCause());
+                    }
+                    return innerResult.get();
+                });
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Runs {@code body} with {@code resource}, always calls {@code release}, and merges
+     * exceptions according to the class-level contract.
+     */
+    private static <T, R> Try<R> runBody(
+            T resource,
+            CheckedFunction<? super T, ? extends R> body,
+            CheckedConsumer<? super T> release
+    ) {
+        Throwable bodyEx = null;
+        R result = null;
+        try {
+            result = body.apply(resource);
+        } catch (Throwable t) {
+            bodyEx = t;
+        }
+        try {
+            release.accept(resource);
+        } catch (Throwable releaseEx) {
+            if (bodyEx != null) {
+                bodyEx.addSuppressed(releaseEx);
+            } else {
+                bodyEx = releaseEx;
+            }
+        }
+        return bodyEx != null ? Try.failure(bodyEx) : Try.success(result);
+    }
+
+    /** Bypasses the checked-exception compiler check to rethrow any {@link Throwable}. */
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable, R> R sneakyThrow(Throwable t) throws E {
+        throw (E) t;
+    }
+}

--- a/lib/src/main/java/dmx/fun/Resource.java
+++ b/lib/src/main/java/dmx/fun/Resource.java
@@ -114,6 +114,42 @@ public final class Resource<T> {
         return of(acquire, AutoCloseable::close);
     }
 
+    /**
+     * Creates a {@code Resource<T>} from a pre-computed {@link Try Try&lt;T&gt;} and a release
+     * function.
+     *
+     * <p>If {@code acquired} is already a failure, {@code use} returns that failure immediately
+     * and the {@code release} function is <em>never called</em> — there is nothing to release.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Try<Connection> tryConn = Try.of(() -> dataSource.getConnection());
+     * Resource<Connection> conn = Resource.eval(tryConn, Connection::close);
+     * Try<List<User>> users = conn.use(c -> fetchUsers(c));
+     * }</pre>
+     *
+     * @param <T>      the resource type
+     * @param acquired the pre-computed result of an acquire attempt; if failure, release is skipped
+     * @param release  consumer that frees the resource when acquired successfully
+     * @return a new {@code Resource<T>}
+     * @throws NullPointerException if {@code acquired} or {@code release} is {@code null}
+     */
+    public static <T> Resource<T> eval(
+            Try<? extends T> acquired,
+            CheckedConsumer<? super T> release) {
+        Objects.requireNonNull(acquired, "acquired");
+        Objects.requireNonNull(release, "release");
+        return new Resource<>(new Effect<T>() {
+            @Override
+            public <R> Try<R> run(CheckedFunction<? super T, ? extends R> body) {
+                if (acquired.isFailure()) {
+                    return Try.failure(acquired.getCause());
+                }
+                return runBody(acquired.get(), body, release);
+            }
+        });
+    }
+
     // -------------------------------------------------------------------------
     // Core operation
     // -------------------------------------------------------------------------
@@ -133,6 +169,54 @@ public final class Resource<T> {
     public <R> Try<R> use(CheckedFunction<? super T, ? extends R> body) {
         Objects.requireNonNull(body, "body");
         return effect.run(body);
+    }
+
+    /**
+     * Acquires the resource, applies {@code body} to produce a {@link Result}, releases the
+     * resource, and returns a {@code Result<R, E>}.
+     *
+     * <p>This is the {@code Result}-integrated variant of {@link #use(CheckedFunction) use()}.
+     * It is useful when the domain layer models failures as typed {@code Result} values rather
+     * than {@code Throwable}.
+     *
+     * <ul>
+     *   <li>If acquire or release throws a {@code Throwable}, it is mapped to {@code E} via
+     *       {@code onError} and returned as {@code Result.err(e)}.</li>
+     *   <li>If the body returns {@code Result.err(e)}, that error is returned as-is.</li>
+     *   <li>If both body and release fail, the release exception is suppressed onto the body
+     *       exception and the combined throwable is passed to {@code onError}.</li>
+     * </ul>
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Result<List<User>, DbError> users = connResource.useAsResult(
+     *     conn -> fetchUsers(conn),
+     *     ex   -> new DbError.QueryFailed(ex.getMessage())
+     * );
+     * }</pre>
+     *
+     * @param <R>     the success type
+     * @param <E>     the error type
+     * @param body    function applied to the live resource; returns a {@code Result}
+     * @param onError maps any {@code Throwable} from acquire/release/body to {@code E}
+     * @return {@code Result.ok(value)} on success, or {@code Result.err(error)} on any failure
+     * @throws NullPointerException if {@code body} or {@code onError} is {@code null}
+     */
+    public <R, E> Result<R, E> useAsResult(
+            Function<? super T, ? extends Result<? extends R, ? extends E>> body,
+            Function<? super Throwable, ? extends E> onError) {
+        Objects.requireNonNull(body, "body");
+        Objects.requireNonNull(onError, "onError");
+        Try<Result<R, E>> tryResult = use(t -> {
+            @SuppressWarnings("unchecked")
+            Result<R, E> r = (Result<R, E>) Objects.requireNonNull(
+                body.apply(t), "useAsResult body must not return null");
+            return r;
+        });
+        if (tryResult.isSuccess()) {
+            return tryResult.get();
+        }
+        return Result.err(onError.apply(tryResult.getCause()));
     }
 
     // -------------------------------------------------------------------------
@@ -207,6 +291,48 @@ public final class Resource<T> {
                         sneakyThrow(innerResult.getCause());
                     }
                     return innerResult.get();
+                });
+            }
+        });
+    }
+
+    /**
+     * Returns a new {@code Resource<R>} whose value is obtained by applying a
+     * {@link Try}-returning function to the acquired value.
+     *
+     * <p>This is the {@link Try}-integrated counterpart of {@link #map(Function) map()}.
+     * It is useful when the transformation itself is a fallible operation already wrapped in
+     * a {@code Try} (e.g., parsing, validation, or a call to a {@code Try.of(...)}-wrapped API).
+     * If {@code fn} returns a failure, the underlying resource is still released and the
+     * failure is propagated.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Resource<Config> config = rawTextResource.mapTry(text ->
+     *     Try.of(() -> Config.parse(text))
+     * );
+     * Try<Integer> port = config.use(c -> c.port());
+     * }</pre>
+     *
+     * @param <R> the mapped resource type
+     * @param fn  function returning a {@code Try<R>}; must not be {@code null} or return
+     *            {@code null}
+     * @return a new {@code Resource<R>}
+     * @throws NullPointerException if {@code fn} is {@code null}
+     */
+    public <R> Resource<R> mapTry(Function<? super T, ? extends Try<? extends R>> fn) {
+        Objects.requireNonNull(fn, "fn");
+        Effect<T> self = this.effect;
+        return new Resource<>(new Effect<>() {
+            @Override
+            public <S> Try<S> run(CheckedFunction<? super R, ? extends S> body) {
+                return self.run(t -> {
+                    Try<? extends R> inner = Objects.requireNonNull(
+                        fn.apply(t), "mapTry fn must not return null");
+                    if (inner.isFailure()) {
+                        sneakyThrow(inner.getCause());
+                    }
+                    return body.apply(inner.get());
                 });
             }
         });

--- a/lib/src/main/java/dmx/fun/Resource.java
+++ b/lib/src/main/java/dmx/fun/Resource.java
@@ -121,17 +121,25 @@ public final class Resource<T> {
      * <p>If {@code acquired} is already a failure, {@code use} returns that failure immediately
      * and the {@code release} function is <em>never called</em> — there is nothing to release.
      *
+     * <p><b>One-shot contract:</b> because the resource value is pre-computed rather than
+     * freshly acquired on each call, invoking {@link #use(CheckedFunction) use()} more than
+     * once on the returned {@code Resource} will call {@code release} on the <em>same</em>
+     * underlying value each time. If the resource is not idempotent with respect to release
+     * (e.g., a JDBC {@code Connection} or an I/O stream), calling {@code use()} more than once
+     * produces undefined behaviour. Prefer {@link #of(CheckedSupplier, CheckedConsumer) of()}
+     * when reuse is required, as it acquires a fresh resource on every call.
+     *
      * <p>Example:
      * <pre>{@code
      * Try<Connection> tryConn = Try.of(() -> dataSource.getConnection());
      * Resource<Connection> conn = Resource.eval(tryConn, Connection::close);
-     * Try<List<User>> users = conn.use(c -> fetchUsers(c));
+     * Try<List<User>> users = conn.use(c -> fetchUsers(c)); // call use() exactly once
      * }</pre>
      *
      * @param <T>      the resource type
      * @param acquired the pre-computed result of an acquire attempt; if failure, release is skipped
      * @param release  consumer that frees the resource when acquired successfully
-     * @return a new {@code Resource<T>}
+     * @return a new {@code Resource<T>} backed by the pre-computed {@code acquired} value
      * @throws NullPointerException if {@code acquired} or {@code release} is {@code null}
      */
     public static <T> Resource<T> eval(

--- a/lib/src/main/java/dmx/fun/Resource.java
+++ b/lib/src/main/java/dmx/fun/Resource.java
@@ -6,7 +6,7 @@ import org.jspecify.annotations.NullMarked;
 
 /**
  * A functional managed resource: a value that must be acquired before use and released
- * afterwards. {@code Resource<T>} is the composable alternative to {@code try-with-resources}.
+ * afterward. {@code Resource<T>} is the composable alternative to {@code try-with-resources}.
  *
  * <p>Acquisition and release are declared together at construction time. The resource is only
  * live during the execution of {@link #use(CheckedFunction) use(fn)} — it is acquired just
@@ -370,7 +370,21 @@ public final class Resource<T> {
         return bodyEx != null ? Try.failure(bodyEx) : Try.success(result);
     }
 
-    /** Bypasses the checked-exception compiler check to rethrow any {@link Throwable}. */
+    /**
+     * Rethrows any {@link Throwable} without wrapping it, bypassing the compiler's
+     * checked-exception enforcement.
+     *
+     * <p><b>How it works:</b> the unchecked cast {@code (E) t} is a <em>no-op at runtime</em>
+     * because generic type parameters are erased — the JVM sees a plain {@code throw t}.
+     * The compiler, however, believes it must only throw the checked {@code E}, so it does not
+     * require callers inside a {@code CheckedFunction} lambda to declare the rethrown type.
+     * The {@code @SuppressWarnings("unchecked")} suppresses the unavoidable unchecked-cast
+     * warning that results from this intentional use of type erasure.
+     *
+     * <p><b>Safety:</b> the original {@code Throwable} is rethrown unchanged — no wrapping,
+     * no information loss. The return type {@code R} is declared only so the method can appear
+     * in throw position in expressions that require a value (e.g., {@code return sneakyThrow(t)}).
+     */
     @SuppressWarnings("unchecked")
     private static <E extends Throwable, R> R sneakyThrow(Throwable t) throws E {
         throw (E) t;

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -21,6 +21,7 @@
  *   <li>{@link dmx.fun.NonEmptyList} — list guaranteed to contain at least one element</li>
  *   <li>{@link dmx.fun.NonEmptyMap}  — map guaranteed to contain at least one entry</li>
  *   <li>{@link dmx.fun.NonEmptySet}  — set guaranteed to contain at least one element</li>
+ *   <li>{@link dmx.fun.Resource}     — composable managed resource with guaranteed release</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -1,0 +1,295 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResourceTest {
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Tracks open/close events for a resource in tests. */
+    static class Tracked {
+        final String name;
+        boolean open = false;
+        boolean closed = false;
+
+        Tracked(String name) { this.name = name; }
+
+        void open() { open = true; }
+        void close() { closed = true; }
+    }
+
+    static Resource<Tracked> tracked(String name) {
+        Tracked t = new Tracked(name);
+        return Resource.of(
+            () -> { t.open(); return t; },
+            r -> r.close()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // of / use — success path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void use_shouldReturnSuccess_whenBodyAndReleaseSucceed() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Try<Integer> result = r.use(String::length);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo(5);
+    }
+
+    @Test
+    void use_shouldAlwaysCallRelease_whenBodySucceeds() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        r.use(String::length);
+        assertThat(released.get()).isTrue();
+    }
+
+    @Test
+    void use_shouldAlwaysCallRelease_whenBodyThrows() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        RuntimeException bodyEx = new RuntimeException("body");
+        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        assertThat(released.get()).isTrue();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(bodyEx);
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception-merging contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    void use_shouldReturnReleaseException_whenBodySucceedsButReleaseThrows() {
+        RuntimeException releaseEx = new RuntimeException("release");
+        Resource<String> r = Resource.of(() -> "hello", s -> { throw releaseEx; });
+        Try<Integer> result = r.use(String::length);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(releaseEx);
+    }
+
+    @Test
+    void use_shouldSuppressReleaseException_whenBothBodyAndReleaseThrow() {
+        RuntimeException bodyEx    = new RuntimeException("body");
+        RuntimeException releaseEx = new RuntimeException("release");
+        Resource<String> r = Resource.of(() -> "hello", s -> { throw releaseEx; });
+        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(bodyEx);
+        assertThat(result.getCause().getSuppressed()).containsExactly(releaseEx);
+    }
+
+    @Test
+    void use_shouldReturnFailure_whenAcquireThrows() {
+        RuntimeException acquireEx = new RuntimeException("acquire");
+        Resource<String> r = Resource.of(() -> { throw acquireEx; }, s -> {});
+        Try<Integer> result = r.use(String::length);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(acquireEx);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromAutoCloseable
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromAutoCloseable_shouldCloseResource_afterUse() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        AutoCloseable ac = () -> closed.set(true);
+        Resource<AutoCloseable> r = Resource.fromAutoCloseable(() -> ac);
+        r.use(a -> "ok");
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void fromAutoCloseable_shouldCloseResource_whenBodyThrows() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        AutoCloseable ac = () -> closed.set(true);
+        Resource<AutoCloseable> r = Resource.fromAutoCloseable(() -> ac);
+        r.use(a -> { throw new RuntimeException("oops"); });
+        assertThat(closed.get()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // map
+    // -------------------------------------------------------------------------
+
+    @Test
+    void map_shouldTransformValue_andReleaseOriginalResource() {
+        Tracked t = new Tracked("db");
+        Resource<Tracked> base = Resource.of(() -> { t.open(); return t; }, Tracked::close);
+        Resource<String> mapped = base.map(tr -> tr.name.toUpperCase());
+
+        Try<Integer> result = mapped.use(String::length);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo(2); // "DB".length()
+        assertThat(t.open).isTrue();
+        assertThat(t.closed).isTrue();
+    }
+
+    @Test
+    void map_shouldReleaseResource_whenMapperThrows() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        RuntimeException mapEx = new RuntimeException("map");
+        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        Resource<String> mapped = r.map(s -> { throw mapEx; });
+        Try<Integer> result = mapped.use(String::length);
+        assertThat(released.get()).isTrue();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(mapEx);
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.map(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // flatMap
+    // -------------------------------------------------------------------------
+
+    @Test
+    void flatMap_shouldComposeResources_andReleaseInReverseOrder() {
+        List<String> events = new ArrayList<>();
+
+        Resource<String> outer = Resource.of(
+            () -> { events.add("outer-acquire"); return "conn"; },
+            s  -> events.add("outer-release")
+        );
+        Resource<String> composed = outer.flatMap(conn ->
+            Resource.of(
+                () -> { events.add("inner-acquire"); return conn + "+stmt"; },
+                s  -> events.add("inner-release")
+            )
+        );
+
+        Try<Integer> result = composed.use(s -> { events.add("body"); return s.length(); });
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("conn+stmt".length());
+        assertThat(events).containsExactly(
+            "outer-acquire", "inner-acquire", "body", "inner-release", "outer-release");
+    }
+
+    @Test
+    void flatMap_shouldReleaseOuterResource_whenInnerBodyThrows() {
+        List<String> events = new ArrayList<>();
+        RuntimeException bodyEx = new RuntimeException("body");
+
+        Resource<String> outer = Resource.of(
+            () -> { events.add("outer-acquire"); return "conn"; },
+            s  -> events.add("outer-release")
+        );
+        Resource<String> composed = outer.flatMap(conn ->
+            Resource.of(
+                () -> { events.add("inner-acquire"); return conn + "+stmt"; },
+                s  -> events.add("inner-release")
+            )
+        );
+
+        Try<Integer> result = composed.use(s -> { throw bodyEx; });
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(bodyEx);
+        assertThat(events).containsExactly(
+            "outer-acquire", "inner-acquire", "inner-release", "outer-release");
+    }
+
+    @Test
+    void flatMap_shouldSuppressOuterReleaseException_ontoBodyException() {
+        RuntimeException bodyEx       = new RuntimeException("body");
+        RuntimeException outerRelease = new RuntimeException("outer-release");
+
+        Resource<String> outer = Resource.of(() -> "outer", s -> { throw outerRelease; });
+        Resource<String> composed = outer.flatMap(s ->
+            Resource.of(() -> "inner", i -> {}));
+
+        Try<Integer> result = composed.use(s -> { throw bodyEx; });
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(bodyEx);
+        assertThat(result.getCause().getSuppressed()).containsExactly(outerRelease);
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenFnIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.flatMap(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenFnReturnsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Try<Integer> result = r.<String>flatMap(s -> null).use(String::length);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // NPE guards on use / of / fromAutoCloseable
+    // -------------------------------------------------------------------------
+
+    @Test
+    void use_shouldThrowNPE_whenBodyIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.use(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("body");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenAcquireIsNull() {
+        assertThatThrownBy(() -> Resource.of(null, s -> {}))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("acquire");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenReleaseIsNull() {
+        assertThatThrownBy(() -> Resource.of(() -> "hello", null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("release");
+    }
+
+    @Test
+    void fromAutoCloseable_shouldThrowNPE_whenAcquireIsNull() {
+        assertThatThrownBy(() -> Resource.fromAutoCloseable(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("acquire");
+    }
+
+    // -------------------------------------------------------------------------
+    // Reusability — each use() call is independent
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resource_shouldBeReusable_eachUseAcquiresAndReleases() {
+        AtomicInteger acquireCount = new AtomicInteger(0);
+        AtomicInteger releaseCount = new AtomicInteger(0);
+        Resource<String> r = Resource.of(
+            () -> { acquireCount.incrementAndGet(); return "hello"; },
+            s  -> releaseCount.incrementAndGet()
+        );
+
+        r.use(String::length);
+        r.use(String::length);
+
+        assertThat(acquireCount.get()).isEqualTo(2);
+        assertThat(releaseCount.get()).isEqualTo(2);
+    }
+}

--- a/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -292,4 +292,173 @@ class ResourceTest {
         assertThat(acquireCount.get()).isEqualTo(2);
         assertThat(releaseCount.get()).isEqualTo(2);
     }
+
+    // -------------------------------------------------------------------------
+    // eval — factory from pre-computed Try
+    // -------------------------------------------------------------------------
+
+    @Test
+    void eval_shouldRunBodyAndRelease_whenTryIsSuccess() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        Resource<String> r = Resource.eval(Try.success("hello"), s -> released.set(true));
+        Try<Integer> result = r.use(String::length);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo(5);
+        assertThat(released.get()).isTrue();
+    }
+
+    @Test
+    void eval_shouldReturnFailure_andSkipRelease_whenTryIsFailure() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        RuntimeException acquireEx = new RuntimeException("acquire failed");
+        Resource<String> r = Resource.eval(Try.failure(acquireEx), s -> released.set(true));
+        Try<Integer> result = r.use(String::length);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(acquireEx);
+        assertThat(released.get()).isFalse();
+    }
+
+    @Test
+    void eval_shouldAlwaysCallRelease_whenBodyThrows() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        RuntimeException bodyEx = new RuntimeException("body");
+        Resource<String> r = Resource.eval(Try.success("hello"), s -> released.set(true));
+        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        assertThat(released.get()).isTrue();
+        assertThat(result.getCause()).isSameAs(bodyEx);
+    }
+
+    @Test
+    void eval_shouldThrowNPE_whenAcquiredIsNull() {
+        assertThatThrownBy(() -> Resource.eval(null, s -> {}))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("acquired");
+    }
+
+    @Test
+    void eval_shouldThrowNPE_whenReleaseIsNull() {
+        assertThatThrownBy(() -> Resource.eval(Try.success("x"), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("release");
+    }
+
+    // -------------------------------------------------------------------------
+    // useAsResult — Result-integrated use
+    // -------------------------------------------------------------------------
+
+    @Test
+    void useAsResult_shouldReturnOk_whenBodyReturnsOk() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Result<Integer, String> result = r.useAsResult(
+            s -> Result.ok(s.length()),
+            Throwable::getMessage
+        );
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo(5);
+    }
+
+    @Test
+    void useAsResult_shouldReturnErr_whenBodyReturnsErr() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Result<Integer, String> result = r.useAsResult(
+            s -> Result.err("domain error"),
+            Throwable::getMessage
+        );
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("domain error");
+    }
+
+    @Test
+    void useAsResult_shouldMapToErr_whenAcquireThrows() {
+        RuntimeException acquireEx = new RuntimeException("acquire");
+        Resource<String> r = Resource.of(() -> { throw acquireEx; }, s -> {});
+        Result<Integer, String> result = r.useAsResult(
+            s -> Result.ok(s.length()),
+            Throwable::getMessage
+        );
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("acquire");
+    }
+
+    @Test
+    void useAsResult_shouldMapToErr_whenBodyThrowsUnexpectedly() {
+        RuntimeException bodyEx = new RuntimeException("unexpected");
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Result<Integer, String> result = r.useAsResult(
+            s -> { throw bodyEx; },
+            Throwable::getMessage
+        );
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("unexpected");
+    }
+
+    @Test
+    void useAsResult_shouldAlwaysRelease_whenBodyThrowsUnexpectedly() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        r.useAsResult(s -> { throw new RuntimeException("oops"); }, Throwable::getMessage);
+        assertThat(released.get()).isTrue();
+    }
+
+    @Test
+    void useAsResult_shouldThrowNPE_whenBodyIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.useAsResult(null, Throwable::getMessage))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("body");
+    }
+
+    @Test
+    void useAsResult_shouldThrowNPE_whenOnErrorIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.useAsResult(s -> Result.ok(s.length()), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onError");
+    }
+
+    // -------------------------------------------------------------------------
+    // mapTry — transform resource value with Try-returning function
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapTry_shouldApplyBody_whenFnReturnsSuccess() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Resource<Integer> mapped = r.mapTry(s -> Try.success(s.length()));
+        Try<String> result = mapped.use(n -> "len=" + n);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("len=5");
+    }
+
+    @Test
+    void mapTry_shouldReturnFailure_whenFnReturnsFailure() {
+        RuntimeException parseEx = new RuntimeException("parse failed");
+        Resource<String> r = Resource.of(() -> "bad", s -> {});
+        Resource<Integer> mapped = r.mapTry(s -> Try.failure(parseEx));
+        Try<String> result = mapped.use(n -> "len=" + n);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(parseEx);
+    }
+
+    @Test
+    void mapTry_shouldReleaseResource_whenFnReturnsFailure() {
+        AtomicBoolean released = new AtomicBoolean(false);
+        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        r.mapTry(s -> Try.failure(new RuntimeException("fail"))).use(n -> n);
+        assertThat(released.get()).isTrue();
+    }
+
+    @Test
+    void mapTry_shouldThrowNPE_whenFnIsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        assertThatThrownBy(() -> r.mapTry(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapTry_shouldThrowNPE_whenFnReturnsNull() {
+        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        Try<Integer> result = r.<Integer>mapTry(s -> null).use(n -> n);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(NullPointerException.class);
+    }
 }

--- a/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -28,9 +28,8 @@ class ResourceTest {
     }
 
     static Resource<Tracked> tracked(String name) {
-        Tracked t = new Tracked(name);
         return Resource.of(
-            () -> { t.open(); return t; },
+            () -> { Tracked t = new Tracked(name); t.open(); return t; },
             r -> r.close()
         );
     }

--- a/samples/src/main/java/dmx/fun/samples/ResourceSample.java
+++ b/samples/src/main/java/dmx/fun/samples/ResourceSample.java
@@ -1,0 +1,164 @@
+package dmx.fun.samples;
+
+import dmx.fun.Resource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Demonstrates Resource<T>: a composable managed resource that guarantees acquisition
+ * and release are always paired, even in the presence of exceptions.
+ * Use Resource when you need to bracket an operation around a resource (file, connection, lock)
+ * and want to compose or chain multiple resources without nested try-with-resources blocks.
+ */
+public class ResourceSample {
+
+    // Simulated DB connection
+    static class Connection {
+        final String url;
+        boolean closed = false;
+
+        Connection(String url) {
+            this.url = url;
+            System.out.println("Connection opened: " + url);
+        }
+
+        void close() {
+            closed = true;
+            System.out.println("Connection closed: " + url);
+        }
+
+        String query(String sql) {
+            return "result[" + sql + "@" + url + "]";
+        }
+    }
+
+    // Simulated prepared statement
+    static class Statement {
+        final String sql;
+        boolean closed = false;
+
+        Statement(Connection c, String sql) {
+            this.sql = sql;
+            System.out.println("Statement prepared: " + sql);
+        }
+
+        void close() {
+            closed = true;
+            System.out.println("Statement closed: " + sql);
+        }
+
+        List<String> execute() {
+            return List.of("row1", "row2");
+        }
+    }
+
+    static void main() {
+
+        // ---- Basic use — of / use ----
+
+        System.out.println("=== Basic use ===");
+
+        var connResource = Resource.of(
+            () -> new Connection("jdbc:h2:mem:sample"),
+            Connection::close
+        );
+
+        var result = connResource.use(
+            conn -> conn.query("SELECT 1")
+        );
+        System.out.println("Query result: " + result.getOrElse("none")); // result[SELECT 1@jdbc:h2:mem:sample]
+        // Connection is closed here even if query threw
+
+        // ---- fromAutoCloseable ----
+
+        System.out.println("\n=== fromAutoCloseable ===");
+
+        var readerClosed = new AtomicBoolean(false);
+        AutoCloseable fakeReader = () -> {
+            readerClosed.set(true);
+            System.out.println("Reader closed");
+        };
+        var readerResource = Resource.fromAutoCloseable(() -> fakeReader);
+
+        readerResource.use(_ -> "ok");
+        System.out.println("Reader closed after use: " + readerClosed.get()); // true
+
+        // ---- map — transform the resource value ----
+
+        System.out.println("\n=== map ===");
+
+        // Transform Connection → its URL string; the underlying Connection is still acquired/released
+        var urlResource = connResource.map(c -> c.url.toUpperCase());
+        var urlLength = urlResource.use(String::length);
+        System.out.println("URL length: " + urlLength.getOrElse(-1)); // 22
+        // Connection opened and closed automatically
+
+        // ---- flatMap — sequence two resources ----
+
+        System.out.println("\n=== flatMap (composed resources) ===");
+
+        var queryResource = connResource.flatMap(conn ->
+            Resource.of(
+                () -> new Statement(conn, "SELECT * FROM users"),
+                Statement::close
+            )
+        ).map(Statement::execute);
+
+        // Acquire order:  Connection → Statement
+        // Release order:  Statement  → Connection  (reverse)
+        var rowCount = queryResource.use(rows -> {
+            System.out.println("Rows: " + rows);
+            return rows.size();
+        });
+        System.out.println("Row count: " + rowCount.getOrElse(-1)); // 2
+
+        // ---- Release always runs, even when body throws ----
+
+        System.out.println("\n=== guaranteed release on failure ===");
+
+        var events = new ArrayList<>();
+        var tracked = Resource.of(
+            () -> {
+                events.add("acquire");
+                return "value";
+            },
+            _ -> events.add("release")
+        );
+
+        var failed = tracked.use(_ -> {
+            throw new RuntimeException("oops");
+        });
+        System.out.println("Failed: " + failed.isFailure());                  // true
+        System.out.println("Released anyway: " + events.contains("release")); // true
+
+        // ---- Exception suppression — body wins, release suppressed ----
+
+        System.out.println("\n=== exception suppression ===");
+
+        var bodyEx = new RuntimeException("body error");
+        var releaseEx = new RuntimeException("release error");
+        var bothThrow = Resource.of(
+            () -> "res",
+            _ -> {
+                throw releaseEx;
+            }
+        );
+
+        var bothFailed = bothThrow.use(_ -> {
+            throw bodyEx;
+        });
+        var cause = bothFailed.getCause();
+        System.out.println("Primary cause: " + cause.getMessage());                       // body error
+        System.out.println("Suppressed cause: " + cause.getSuppressed()[0].getMessage()); // release error
+
+        // ---- Reusability ----
+
+        System.out.println("\n=== reusability ===");
+
+        // Each call to use() independently acquires and releases
+        connResource.use(conn -> conn.query("SELECT 'first'"));
+        connResource.use(conn -> conn.query("SELECT 'second'"));
+        // Two connections opened and closed
+    }
+}

--- a/samples/src/main/java/dmx/fun/samples/ResourceSample.java
+++ b/samples/src/main/java/dmx/fun/samples/ResourceSample.java
@@ -1,6 +1,8 @@
 package dmx.fun.samples;
 
 import dmx.fun.Resource;
+import dmx.fun.Result;
+import dmx.fun.Try;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +33,10 @@ public class ResourceSample {
         String query(String sql) {
             return "result[" + sql + "@" + url + "]";
         }
+    }
+
+    sealed interface DbError permits DbError.QueryFailed {
+        record QueryFailed(String message) implements DbError {}
     }
 
     // Simulated prepared statement
@@ -160,5 +166,57 @@ public class ResourceSample {
         connResource.use(conn -> conn.query("SELECT 'first'"));
         connResource.use(conn -> conn.query("SELECT 'second'"));
         // Two connections opened and closed
+
+        // ---- eval — factory from a pre-computed Try ----
+
+        System.out.println("\n=== eval ===");
+
+        // Acquisition already happened; lift the result into a Resource
+        var tryConn = Try.of(() -> new Connection("jdbc:h2:mem:eval"));
+        var evalResource = Resource.eval(tryConn, Connection::close);
+        var evalResult = evalResource.use(conn -> conn.query("SELECT 'eval'"));
+        System.out.println("eval result: " + evalResult.getOrElse("none")); // result[SELECT 'eval'@...]
+
+        // If the Try was a failure, release is never called
+        var failedTry = Try.<Connection>failure(new RuntimeException("could not open"));
+        var failedEval = Resource.eval(failedTry, Connection::close);
+        var failedResult = failedEval.use(conn -> conn.query("SELECT 1"));
+        System.out.println("eval failure: " + failedResult.isFailure()); // true — release not called
+
+        // ---- useAsResult — Result-integrated execution ----
+
+        System.out.println("\n=== useAsResult ===");
+
+        // Body returns Result<R, E> — infrastructure Throwables are mapped to E via onError
+        Result<String, DbError> queryResult = connResource.useAsResult(
+            conn  -> Result.ok(conn.query("SELECT 'hello'")),
+            ex    -> new DbError.QueryFailed(ex.getMessage())
+        );
+        System.out.println("useAsResult ok: " + queryResult.isSuccess()); // true
+        System.out.println("value: " + queryResult.getOrElse("none"));    // result[SELECT 'hello'@...]
+
+        // Domain-level error (Err returned by body) passes through as-is
+        Result<String, DbError> domainErr = connResource.useAsResult(
+            _     -> Result.err(new DbError.QueryFailed("table not found")),
+            ex    -> new DbError.QueryFailed(ex.getMessage())
+        );
+        System.out.println("useAsResult err: " + domainErr.isError());    // true
+        System.out.println("error: " + domainErr.getError());             // QueryFailed[table not found]
+
+        // ---- mapTry — transform resource value with a Try-returning function ----
+
+        System.out.println("\n=== mapTry ===");
+
+        // Parse the query result string as JSON-like integer — simulate a fallible transform
+        var rawResource = Resource.of(() -> "42", s -> {});
+        var parsedResource = rawResource.mapTry(s -> Try.of(() -> Integer.parseInt(s)));
+        var parsedResult = parsedResource.use(n -> n * 2);
+        System.out.println("mapTry success: " + parsedResult.getOrElse(-1)); // 84
+
+        // If fn returns a failure the resource is still released
+        var badResource = Resource.of(() -> "not-a-number", s -> System.out.println("released"));
+        var badParsed = badResource.mapTry(s -> Try.of(() -> Integer.parseInt(s)));
+        var badResult = badParsed.use(n -> n * 2);
+        System.out.println("mapTry failure: " + badResult.isFailure()); // true (released was printed)
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/ResourceSample.java
+++ b/samples/src/main/java/dmx/fun/samples/ResourceSample.java
@@ -123,7 +123,7 @@ public class ResourceSample {
 
         System.out.println("\n=== guaranteed release on failure ===");
 
-        var events = new ArrayList<>();
+        List<String> events = new ArrayList<>();
         var tracked = Resource.of(
             () -> {
                 events.add("acquire");

--- a/site/src/data/code/guide/resource/creating-instances.mdx
+++ b/site/src/data/code/guide/resource/creating-instances.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Explicit acquire + release
+Resource<Connection> conn = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// AutoCloseable — close() is used as the release function
+Resource<BufferedReader> reader = Resource.fromAutoCloseable(
+    () -> new BufferedReader(new FileReader(path))
+);
+```

--- a/site/src/data/code/guide/resource/eval.mdx
+++ b/site/src/data/code/guide/resource/eval.mdx
@@ -1,0 +1,14 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// You already have a Try<Connection> from wrapping legacy code
+Try<Connection> tryConn = Try.of(() -> dataSource.getConnection());
+
+// Lift it into a Resource — release is skipped if acquisition already failed
+Resource<Connection> conn = Resource.eval(tryConn, Connection::close);
+
+Try<List<User>> users = conn.use(c -> fetchUsers(c));
+// If tryConn was a failure, users carries that failure and Connection::close is never called
+```

--- a/site/src/data/code/guide/resource/exception-contract.mdx
+++ b/site/src/data/code/guide/resource/exception-contract.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+RuntimeException bodyEx    = new RuntimeException("query failed");
+RuntimeException releaseEx = new RuntimeException("close failed");
+
+Resource<Connection> conn = Resource.of(
+    () -> openConnection(),
+    c  -> { c.close(); throw releaseEx; }   // release always runs, but it may throw
+);
+
+// Body throws, release also throws → release is suppressed onto body
+Try<Void> result = conn.use(c -> { throw bodyEx; });
+
+Throwable cause = result.getCause();
+System.out.println(cause.getMessage());                    // query failed
+System.out.println(cause.getSuppressed()[0].getMessage()); // close failed
+```

--- a/site/src/data/code/guide/resource/flat-map.mdx
+++ b/site/src/data/code/guide/resource/flat-map.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Resource<Connection> connResource = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// Sequence two resources — inner depends on outer
+Resource<PreparedStatement> stmtResource = connResource.flatMap(conn ->
+    Resource.of(
+        () -> conn.prepareStatement("SELECT * FROM users"),
+        PreparedStatement::close
+    )
+);
+
+// Acquire order:  Connection → PreparedStatement
+// Release order:  PreparedStatement → Connection  (reverse)
+Try<List<User>> users = stmtResource.use(ps -> mapRows(ps.executeQuery()));
+```

--- a/site/src/data/code/guide/resource/map-try.mdx
+++ b/site/src/data/code/guide/resource/map-try.mdx
@@ -1,0 +1,17 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// rawText resource acquires a file and reads its content
+Resource<String> rawText = Resource.fromAutoCloseable(
+    () -> new BufferedReader(new FileReader(configPath))
+).map(reader -> reader.lines().collect(joining("\n")));
+
+// mapTry chains a Try-returning function — if parsing fails, the resource is still released
+Resource<Config> configResource = rawText.mapTry(text ->
+    Try.of(() -> Config.parse(text))
+);
+
+Try<Integer> port = configResource.use(Config::port);
+```

--- a/site/src/data/code/guide/resource/map.mdx
+++ b/site/src/data/code/guide/resource/map.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Resource<Connection> conn = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// Transform the resource value — acquire/release lifecycle is unchanged
+Resource<String> schema = conn.map(c -> c.getSchema());
+
+Try<Integer> len = schema.use(String::length);
+// Connection was opened, getSchema() was called, connection was closed
+```

--- a/site/src/data/code/guide/resource/real-world-example.mdx
+++ b/site/src/data/code/guide/resource/real-world-example.mdx
@@ -21,9 +21,10 @@ Resource<PreparedStatement> stmtResource = connResource.flatMap(conn ->
 
 Try<List<OrderSummary>> result = stmtResource.use(ps -> {
     List<OrderSummary> rows = new ArrayList<>();
-    ResultSet rs = ps.executeQuery();
-    while (rs.next()) {
-        rows.add(new OrderSummary(rs.getLong("id"), rs.getString("name")));
+    try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+            rows.add(new OrderSummary(rs.getLong("id"), rs.getString("name")));
+        }
     }
     return rows;
 });

--- a/site/src/data/code/guide/resource/real-world-example.mdx
+++ b/site/src/data/code/guide/resource/real-world-example.mdx
@@ -1,0 +1,35 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Acquire a connection and a prepared statement, run a query, release both
+Resource<Connection>        connResource = Resource.of(
+    () -> dataSource.getConnection(), Connection::close);
+
+Resource<PreparedStatement> stmtResource = connResource.flatMap(conn ->
+    Resource.of(
+        () -> {
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT id, name FROM orders WHERE customer_id = ?");
+            ps.setLong(1, customerId);
+            return ps;
+        },
+        PreparedStatement::close
+    )
+);
+
+Try<List<OrderSummary>> result = stmtResource.use(ps -> {
+    List<OrderSummary> rows = new ArrayList<>();
+    ResultSet rs = ps.executeQuery();
+    while (rs.next()) {
+        rows.add(new OrderSummary(rs.getLong("id"), rs.getString("name")));
+    }
+    return rows;
+});
+
+// Both resources are released regardless of whether the body succeeded
+result
+    .onSuccess(orders -> orders.forEach(System.out::println))
+    .onFailure(ex     -> log.error("Query failed", ex));
+```

--- a/site/src/data/code/guide/resource/use-as-result.mdx
+++ b/site/src/data/code/guide/resource/use-as-result.mdx
@@ -1,0 +1,27 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+sealed interface DbError {
+    record QueryFailed(String message) implements DbError {}
+    record ConnectionFailed(String message) implements DbError {}
+}
+
+Resource<Connection> connResource = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// Body returns Result<R, E> — acquire/release Throwables are mapped to E via onError
+Result<List<User>, DbError> users = connResource.useAsResult(
+    conn  -> fetchUsers(conn),                          // returns Result<List<User>, DbError>
+    ex    -> new DbError.ConnectionFailed(ex.getMessage())
+);
+
+// No Try wrapping needed — result is already in the domain error type
+switch (users) {
+    case Ok<List<User>, DbError>  ok  -> ok.value().forEach(System.out::println);
+    case Err<List<User>, DbError> err -> System.err.println("DB error: " + err.error());
+}
+```

--- a/site/src/data/code/guide/resource/use.mdx
+++ b/site/src/data/code/guide/resource/use.mdx
@@ -1,0 +1,17 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Resource<Connection> conn = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// Resource is acquired, body runs, resource is always released
+Try<List<User>> users = conn.use(c -> fetchUsers(c));
+
+// Result is a Try — success or failure, release always happens
+users.onSuccess(list -> System.out.println("Users: " + list.size()))
+     .onFailure(ex  -> System.err.println("Failed: " + ex.getMessage()));
+```

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -19,7 +19,7 @@ import {Content as RealWorldExample}  from '../code/guide/resource/real-world-ex
 
 ## What is Resource&lt;T&gt;?
 
-`Resource<T>` models a value that must be **acquired before use** and **released afterwards**.
+`Resource<T>` models a value that must be **acquired before use** and **released afterward**.
 It is the composable alternative to Java's `try-with-resources` statement.
 
 Acquisition and release are declared together at construction time.

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -9,7 +9,10 @@ import {Content as CreatingInstances} from '../code/guide/resource/creating-inst
 import {Content as Use}               from '../code/guide/resource/use.mdx';
 import {Content as ExceptionContract} from '../code/guide/resource/exception-contract.mdx';
 import {Content as Map}               from '../code/guide/resource/map.mdx';
+import {Content as MapTry}            from '../code/guide/resource/map-try.mdx';
 import {Content as FlatMap}           from '../code/guide/resource/flat-map.mdx';
+import {Content as Eval}              from '../code/guide/resource/eval.mdx';
+import {Content as UseAsResult}       from '../code/guide/resource/use-as-result.mdx';
 import {Content as RealWorldExample}  from '../code/guide/resource/real-world-example.mdx';
 
 > **Runnable example:** [`ResourceSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResourceSample.java)
@@ -63,6 +66,15 @@ If `fn` throws, the underlying resource is still released.
 
 <Map/>
 
+### `mapTry(fn)`
+
+Like `map`, but the mapping function returns a `Try<R>`.
+Useful when the transformation is itself a fallible operation already wrapped in a `Try`
+(e.g., parsing, validation, or a `Try.of(...)`-wrapped API call).
+If `fn` returns a failure, the underlying resource is still released.
+
+<MapTry/>
+
 ### `flatMap(fn)`
 
 Sequences two resources. The inner resource is derived from the outer resource's value.
@@ -79,7 +91,7 @@ so you can build resource pipelines without deep nesting.
 |--------------------------|---------------------------------|-------------------------------------------|
 | Guaranteed release       | Yes                             | Yes                                       |
 | Composable               | Nested blocks only              | `map` / `flatMap` as values               |
-| Result as value          | No — exceptions propagate       | Yes — `Try<R>` returned                   |
+| Result as value          | No — exceptions propagate       | Yes — `Try<R>` or `Result<R,E>` returned  |
 | Multiple resources       | Separate `try` blocks           | `flatMap` chain                           |
 | Reusable                 | No                              | Yes — each `use()` is independent         |
 | Works with non-closeable | No — requires `AutoCloseable`   | Yes — any acquire/release pair            |
@@ -87,6 +99,23 @@ so you can build resource pipelines without deep nesting.
 Use `Resource<T>` when you need to **compose** multiple resources, reuse the acquire/release
 description across multiple call sites, or integrate with the dmx-fun type system.
 Use `try-with-resources` for simple, local, one-off resource management.
+
+## Interoperability
+
+### `Resource.eval(Try<T>, release)` — factory from a pre-computed `Try`
+
+Use this when acquisition has already been attempted and the result is a `Try<T>`.
+If the `Try` is a failure, `use` returns that failure immediately and `release` is never called.
+
+<Eval/>
+
+### `useAsResult(body, onError)` — Result-integrated execution
+
+The `Result`-counterpart of `use()`. The body returns a `Result<R, E>` directly.
+Any `Throwable` from acquire, release, or an unexpected body exception is mapped to `E` via
+`onError`, eliminating the `Try<Result<R, E>>` nesting.
+
+<UseAsResult/>
 
 ## Real-world example
 

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -1,0 +1,95 @@
+---
+title: "Resource<T> — Developer Guide"
+description: "Comprehensive guide to Resource<T>: composable managed resources, guaranteed release, and real-world pipelines."
+order: 11
+h1: "Resource<T>"
+---
+
+import {Content as CreatingInstances} from '../code/guide/resource/creating-instances.mdx';
+import {Content as Use}               from '../code/guide/resource/use.mdx';
+import {Content as ExceptionContract} from '../code/guide/resource/exception-contract.mdx';
+import {Content as Map}               from '../code/guide/resource/map.mdx';
+import {Content as FlatMap}           from '../code/guide/resource/flat-map.mdx';
+import {Content as RealWorldExample}  from '../code/guide/resource/real-world-example.mdx';
+
+> **Runnable example:** [`ResourceSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResourceSample.java)
+
+## What is Resource&lt;T&gt;?
+
+`Resource<T>` models a value that must be **acquired before use** and **released afterwards**.
+It is the composable alternative to Java's `try-with-resources` statement.
+
+Acquisition and release are declared together at construction time.
+The resource is only live during the execution of `use(fn)` — it is acquired just before the
+body runs, and the release function is _always_ called when the body completes, whether it
+succeeds or throws.
+
+The result is returned as a `Try<R>`, making both success and failure explicit values.
+
+## Creating instances
+
+<CreatingInstances/>
+
+Both `of` and `fromAutoCloseable` reject `null` arguments immediately with a
+`NullPointerException` that names the offending parameter.
+
+## Using a resource
+
+<Use/>
+
+Each call to `use()` is independent: it acquires the resource, runs the body, and releases the
+resource. The same `Resource<T>` can be used multiple times — each call goes through the full
+acquire/run/release cycle.
+
+## Exception-merging contract
+
+`Resource<T>` follows the same exception-suppression semantics as `try-with-resources`:
+
+| Body     | Release  | Outcome                                                                  |
+|----------|----------|--------------------------------------------------------------------------|
+| Success  | Success  | `Try.success(result)`                                                    |
+| Success  | Throws   | `Try.failure(releaseException)`                                          |
+| Throws   | Success  | `Try.failure(bodyException)`                                             |
+| Throws   | Throws   | `Try.failure(bodyException)` — release exception suppressed onto body    |
+
+<ExceptionContract/>
+
+## Transformations
+
+### `map(fn)`
+
+Transforms the resource value without changing acquire/release.
+If `fn` throws, the underlying resource is still released.
+
+<Map/>
+
+### `flatMap(fn)`
+
+Sequences two resources. The inner resource is derived from the outer resource's value.
+Both resources are released in **reverse acquisition order**: inner first, then outer.
+
+<FlatMap/>
+
+This mirrors nested `try-with-resources` blocks but composes as a value,
+so you can build resource pipelines without deep nesting.
+
+## Resource vs try-with-resources
+
+|                          | `try-with-resources`            | `Resource<T>`                             |
+|--------------------------|---------------------------------|-------------------------------------------|
+| Guaranteed release       | Yes                             | Yes                                       |
+| Composable               | Nested blocks only              | `map` / `flatMap` as values               |
+| Result as value          | No — exceptions propagate       | Yes — `Try<R>` returned                   |
+| Multiple resources       | Separate `try` blocks           | `flatMap` chain                           |
+| Reusable                 | No                              | Yes — each `use()` is independent         |
+| Works with non-closeable | No — requires `AutoCloseable`   | Yes — any acquire/release pair            |
+
+Use `Resource<T>` when you need to **compose** multiple resources, reuse the acquire/release
+description across multiple call sites, or integrate with the dmx-fun type system.
+Use `try-with-resources` for simple, local, one-off resource management.
+
+## Real-world example
+
+A database query that composes a `Connection` and a `PreparedStatement`:
+
+<RealWorldExample/>

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -84,6 +84,14 @@ const types = [
         tag: 'Collections',
     },
     {
+        name: 'Resource<T>',
+        href: `${base}guide/resource`,
+        summary: 'A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.',
+        whenToUse: 'You need to bracket an operation around a resource (file, connection, lock) and want to compose multiple resources safely.',
+        avoidWhen: 'A simple try-with-resources block suffices and no composition is needed.',
+        tag: 'Resource management',
+    },
+    {
         name: 'Checked interfaces',
         href: `${base}guide/checked-interfaces`,
         summary: 'Checked variants of Function, Supplier, Consumer, Runnable, plus TriFunction/QuadFunction.',


### PR DESCRIPTION
  Add Resource<T>, a functional bracket pattern that guarantees acquire/release
  are always paired. Includes of(), fromAutoCloseable(), use() → Try<R>, map(),
  flatMap() with reverse-order release, exception suppression, 21 unit tests,
  ResourceSample.java, developer guide page, and module-info.java entry.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #224

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Resource<T> API for managed acquire/use/release lifecycles with factories, reuse per use(), map/flatMap/mapTry composition, eval variant, and useAsResult integration; preserves try-with-resources suppression semantics.
* **Documentation**
  * Comprehensive guides, examples, and snippets covering creation, composition, exception contract, and real-world JDBC usage.
* **Tests**
  * New test suite covering lifecycle, composition, exception merging, null guards, and reusability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->