### PR TITLE
feature/guard/init implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Java library of functional types that make failures, absence, and validation explicit in the type system — without ceremony.
 
-`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, `NonEmptyList<T>`, `NonEmptyMap<K, V>`, and `NonEmptySet<T>` — each designed to compose cleanly with the others and with the Java standard library.
+`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, `NonEmptyList<T>`, `NonEmptyMap<K, V>`, `NonEmptySet<T>`, `Guard<T>`, and `Resource<T>` — each designed to compose cleanly with the others and with the Java standard library.
 
 ---
 
@@ -89,6 +89,8 @@ testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 | `NonEmptyList<T>`  | Collections           | A list guaranteed to have at least one element at compile time.                                          |
 | `NonEmptyMap<K,V>` | Collections           | A map guaranteed to have at least one entry at compile time. Insertion order preserved.                  |
 | `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved. |
+| `Guard<T>`         | Validation            | A composable, named predicate that produces a `Validated` result — the reusable building block for validation pipelines. |
+| `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.            |
 
 ---
 

--- a/lib/src/main/java/dmx/fun/Guard.java
+++ b/lib/src/main/java/dmx/fun/Guard.java
@@ -1,0 +1,214 @@
+package dmx.fun;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A named, composable predicate that produces a {@link Validated} result when applied to a value.
+ *
+ * <p>{@code Guard<T>} is a functional interface whose single abstract method is
+ * {@link #check(Object) check(T)}, which returns
+ * {@code Validated<NonEmptyList<String>, T>}: {@code Valid(value)} when the predicate passes,
+ * or {@code Invalid(errors)} when it fails.
+ *
+ * <p>Guards are designed to be defined once and reused across validation pipelines, eliminating
+ * the repetitive {@code if}/{@link Validated#invalidNel(Object)} pattern:
+ *
+ * <pre>{@code
+ * Guard<String> notBlank     = Guard.of(s -> !s.isBlank(),         "must not be blank");
+ * Guard<String> minLength3   = Guard.of(s -> s.length() >= 3,      "must be at least 3 chars");
+ * Guard<String> alphanumeric = Guard.of(s -> s.matches("[\\w]+"),  "must be alphanumeric");
+ *
+ * Guard<String> username = notBlank.and(minLength3).and(alphanumeric);
+ *
+ * username.check("al");  // Invalid(["must be at least 3 chars"])
+ * username.check("ok?"); // Invalid(["must be alphanumeric"])
+ * username.check("alice"); // Valid("alice")
+ * }</pre>
+ *
+ * <h2>Composition semantics</h2>
+ * <ul>
+ *   <li>{@link #and(Guard) and} — both guards must pass; errors from all failing guards are
+ *       accumulated (not fail-fast).</li>
+ *   <li>{@link #or(Guard) or} — the first passing guard short-circuits; if all fail, all errors
+ *       are accumulated.</li>
+ *   <li>{@link #negate() negate} / {@link #negate(String) negate(message)} — inverts the
+ *       predicate.</li>
+ * </ul>
+ *
+ * @param <T> the type of value being validated
+ */
+@FunctionalInterface
+@NullMarked
+public interface Guard<T> {
+
+    // -------------------------------------------------------------------------
+    // Core method
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies this guard to {@code value}.
+     *
+     * @param value the value to validate; must not be {@code null}
+     * @return {@code Valid(value)} if the predicate passes, or
+     *         {@code Invalid(errors)} if it fails
+     */
+    Validated<NonEmptyList<String>, T> check(T value);
+
+    // -------------------------------------------------------------------------
+    // Factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@code Guard<T>} from a predicate and a static error message.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     * }</pre>
+     *
+     * @param <T>          the value type
+     * @param predicate    the condition that must hold for the value to be valid
+     * @param errorMessage the error message produced when the predicate fails
+     * @return a new {@code Guard<T>}
+     * @throws NullPointerException if {@code predicate} or {@code errorMessage} is {@code null}
+     */
+    static <T> Guard<T> of(Predicate<? super T> predicate, String errorMessage) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(errorMessage, "errorMessage");
+        return value -> predicate.test(value)
+            ? Validated.valid(value)
+            : Validated.invalidNel(errorMessage);
+    }
+
+    /**
+     * Creates a {@code Guard<T>} from a predicate and a dynamic error message function.
+     *
+     * <p>The {@code errorMessageFn} receives the failing value so it can produce a
+     * context-specific message.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<Integer> max = Guard.of(
+     *     n -> n <= 100,
+     *     n -> "must be ≤ 100, got " + n
+     * );
+     * }</pre>
+     *
+     * @param <T>            the value type
+     * @param predicate      the condition that must hold for the value to be valid
+     * @param errorMessageFn function that produces an error message from the failing value
+     * @return a new {@code Guard<T>}
+     * @throws NullPointerException if {@code predicate} or {@code errorMessageFn} is {@code null}
+     */
+    static <T> Guard<T> of(Predicate<? super T> predicate, Function<? super T, String> errorMessageFn) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(errorMessageFn, "errorMessageFn");
+        return value -> predicate.test(value)
+            ? Validated.valid(value)
+            : Validated.invalidNel(errorMessageFn.apply(value));
+    }
+
+    // -------------------------------------------------------------------------
+    // Composition
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a composed guard that requires <em>both</em> this guard and {@code other} to pass.
+     *
+     * <p>Both guards are always evaluated — this is <strong>not</strong> fail-fast. Errors from
+     * all failing guards are accumulated into a single {@code NonEmptyList}, so the caller
+     * receives a complete picture of all violations at once.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<Integer> positive    = Guard.of(n -> n > 0,   "must be positive");
+     * Guard<Integer> lessThan100 = Guard.of(n -> n < 100, "must be less than 100");
+     * Guard<Integer> range = positive.and(lessThan100);
+     *
+     * range.check(-5);  // Invalid(["must be positive", "must be less than 100"])
+     *                   //  — both guards evaluated, both errors collected
+     * }</pre>
+     *
+     * @param other the guard that must also pass; must not be {@code null}
+     * @return a composed {@code Guard<T>}
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    default Guard<T> and(Guard<T> other) {
+        Objects.requireNonNull(other, "other");
+        return value -> this.check(value)
+            .combine(other.check(value), NonEmptyList::concat, (v1, v2) -> v1);
+    }
+
+    /**
+     * Returns a composed guard that passes when <em>at least one</em> of this guard or
+     * {@code other} passes.
+     *
+     * <p>Evaluation is <strong>short-circuit</strong>: if this guard passes, {@code other} is
+     * never evaluated. If both fail, errors from both guards are accumulated.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> email = Guard.of(s -> s.contains("@"),  "must contain @");
+     * Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be digits");
+     * Guard<String> contact = email.or(phone);
+     *
+     * contact.check("alice@example.com");  // Valid — email passes, phone not evaluated
+     * contact.check("12345");             // Valid — phone passes
+     * contact.check("hello");             // Invalid(["must contain @", "must be digits"])
+     * }</pre>
+     *
+     * @param other the alternative guard; must not be {@code null}
+     * @return a composed {@code Guard<T>}
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    default Guard<T> or(Guard<T> other) {
+        Objects.requireNonNull(other, "other");
+        return value -> {
+            Validated<NonEmptyList<String>, T> left = this.check(value);
+            if (left.isValid()) return left;
+            Validated<NonEmptyList<String>, T> right = other.check(value);
+            if (right.isValid()) return right;
+            return left.combine(right, NonEmptyList::concat, (v1, v2) -> v1);
+        };
+    }
+
+    /**
+     * Returns a guard that is the logical negation of this guard, using a generic error message.
+     *
+     * <p>The composed guard returns {@code Valid(value)} when this guard <em>fails</em>, and
+     * {@code Invalid(["must not satisfy the condition"])} when this guard <em>passes</em>.
+     * Use {@link #negate(String) negate(message)} to supply a domain-specific error message.
+     *
+     * @return the negated {@code Guard<T>}
+     */
+    default Guard<T> negate() {
+        return negate("must not satisfy the condition");
+    }
+
+    /**
+     * Returns a guard that is the logical negation of this guard, using the supplied error
+     * message when the original guard passes.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notAdmin = Guard.of(s -> s.equals("admin"), "is admin")
+     *                               .negate("username must not be 'admin'");
+     *
+     * notAdmin.check("alice"); // Valid("alice")
+     * notAdmin.check("admin"); // Invalid(["username must not be 'admin'"])
+     * }</pre>
+     *
+     * @param errorMessage the error message returned when the original guard passes
+     * @return the negated {@code Guard<T>}
+     * @throws NullPointerException if {@code errorMessage} is {@code null}
+     */
+    default Guard<T> negate(String errorMessage) {
+        Objects.requireNonNull(errorMessage, "errorMessage");
+        return value -> this.check(value).isValid()
+            ? Validated.invalidNel(errorMessage)
+            : Validated.valid(value);
+    }
+}

--- a/lib/src/main/java/dmx/fun/Guard.java
+++ b/lib/src/main/java/dmx/fun/Guard.java
@@ -124,12 +124,14 @@ public interface Guard<T> {
      *
      * <p>Example:
      * <pre>{@code
-     * Guard<Integer> positive    = Guard.of(n -> n > 0,   "must be positive");
-     * Guard<Integer> lessThan100 = Guard.of(n -> n < 100, "must be less than 100");
-     * Guard<Integer> range = positive.and(lessThan100);
+     * Guard<Integer> positive = Guard.of(n -> n > 0,      "must be positive");
+     * Guard<Integer> even     = Guard.of(n -> n % 2 == 0, "must be even");
+     * Guard<Integer> positiveEven = positive.and(even);
      *
-     * range.check(-5);  // Invalid(["must be positive", "must be less than 100"])
-     *                   //  — both guards evaluated, both errors collected
+     * positiveEven.check(4);   // Valid(4)
+     * positiveEven.check(3);   // Invalid(["must be even"])
+     * positiveEven.check(-1);  // Invalid(["must be positive", "must be even"])
+     *                          //  — both guards evaluated, both errors collected
      * }</pre>
      *
      * @param other the guard that must also pass; must not be {@code null}

--- a/lib/src/main/java/dmx/fun/Guard.java
+++ b/lib/src/main/java/dmx/fun/Guard.java
@@ -211,4 +211,135 @@ public interface Guard<T> {
             ? Validated.invalidNel(errorMessage)
             : Validated.valid(value);
     }
+
+    // -------------------------------------------------------------------------
+    // Interoperability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a standard {@link Predicate Predicate&lt;T&gt;} that returns {@code true} when this
+     * guard passes and {@code false} when it fails.
+     *
+     * <p>Use this to integrate guards with standard Java APIs that accept {@code Predicate}
+     * (e.g., {@link java.util.stream.Stream#filter Stream.filter},
+     * {@link java.util.Collection#removeIf Collection.removeIf}).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * List<String> valid = Stream.of("alice", "  ", "bob", "")
+     *     .filter(notBlank.asPredicate())
+     *     .toList();
+     * // ["alice", "bob"]
+     * }</pre>
+     *
+     * @return a {@code Predicate<T>} backed by this guard
+     */
+    default Predicate<T> asPredicate() {
+        return value -> this.check(value).isValid();
+    }
+
+    /**
+     * Returns a {@code Guard<U>} that applies {@code mapper} to its input before checking.
+     *
+     * <p>This is the <em>contravariant map</em> operation: it adapts a guard written for type
+     * {@code T} to work on an enclosing type {@code U} by projecting {@code U → T} first.
+     * It is the idiomatic way to reuse field-level guards on whole objects.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "username must not be blank");
+     *
+     * // Lift notBlank to validate User objects by their username field
+     * Guard<User> userGuard = notBlank.contramap(User::username);
+     *
+     * userGuard.check(new User("alice")); // Valid(user)
+     * userGuard.check(new User("   "));   // Invalid(["username must not be blank"])
+     * }</pre>
+     *
+     * @param <U>    the input type of the returned guard
+     * @param mapper function that extracts the {@code T} value from a {@code U}; must not be
+     *               {@code null}
+     * @return a new {@code Guard<U>} that projects {@code U → T} before checking
+     * @throws NullPointerException if {@code mapper} is {@code null}
+     */
+    default <U> Guard<U> contramap(Function<? super U, ? extends T> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return u -> {
+            Validated<NonEmptyList<String>, T> result = this.check(mapper.apply(u));
+            return result.isValid() ? Validated.valid(u) : Validated.invalid(result.getError());
+        };
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns a
+     * {@code Result<T, NonEmptyList<String>>}.
+     *
+     * <p>Equivalent to {@code this.check(value).toResult()} but removes the need to import and
+     * chain the conversion manually.
+     *
+     * @param value the value to validate
+     * @return {@code Result.ok(value)} if the guard passes, or
+     *         {@code Result.err(errors)} if it fails
+     */
+    default Result<T, NonEmptyList<String>> checkToResult(T value) {
+        return this.check(value).toResult();
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns a {@code Result<T, E>}, mapping the
+     * accumulated error list to a domain-specific error type via {@code toError}.
+     *
+     * <p>Use this at domain service boundaries where {@code Result} is the preferred
+     * container and the error type is richer than a plain list of strings.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = notBlank.and(minLength3);
+     *
+     * Result<String, ValidationException> result = username.checkToResult(
+     *     input,
+     *     errors -> new ValidationException("username", errors.toList())
+     * );
+     * }</pre>
+     *
+     * @param <E>     the domain error type
+     * @param value   the value to validate
+     * @param toError function mapping the accumulated error list to {@code E}
+     * @return {@code Result.ok(value)} on success, or {@code Result.err(toError(errors))} on
+     *         failure
+     * @throws NullPointerException if {@code toError} is {@code null}
+     */
+    default <E> Result<T, E> checkToResult(T value, Function<NonEmptyList<String>, E> toError) {
+        Objects.requireNonNull(toError, "toError");
+        return this.check(value).mapError(toError).toResult();
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns an {@link Option Option&lt;T&gt;}.
+     *
+     * <p>Returns {@code Some(value)} when the guard passes and {@link Option#none() None} when
+     * it fails, discarding the error details. Use this when you only need to know whether a
+     * value is valid, not why it is not.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * // Filter a stream keeping only valid values
+     * List<String> valid = Stream.of("alice", "  ", "bob")
+     *     .flatMap(s -> notBlank.checkToOption(s).stream())
+     *     .toList();
+     * // ["alice", "bob"]
+     * }</pre>
+     *
+     * @param value the value to validate
+     * @return {@code Option.some(value)} if the guard passes, or {@code Option.none()} if it
+     *         fails
+     */
+    default Option<T> checkToOption(T value) {
+        Validated<NonEmptyList<String>, T> result = this.check(value);
+        return result.isValid() ? Option.some(result.get()) : Option.none();
+    }
 }

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -21,6 +21,7 @@
  *   <li>{@link dmx.fun.NonEmptyList} — list guaranteed to contain at least one element</li>
  *   <li>{@link dmx.fun.NonEmptyMap}  — map guaranteed to contain at least one entry</li>
  *   <li>{@link dmx.fun.NonEmptySet}  — set guaranteed to contain at least one element</li>
+ *   <li>{@link dmx.fun.Guard}        — composable predicate blocks for Validated pipelines</li>
  *   <li>{@link dmx.fun.Resource}     — composable managed resource with guaranteed release</li>
  * </ul>
  *

--- a/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/lib/src/test/java/dmx/fun/GuardTest.java
@@ -1,5 +1,6 @@
 package dmx.fun;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -241,6 +242,144 @@ class GuardTest {
         Validated<NonEmptyList<String>, String> threeErrors = username.check("  ");
         assertThat(threeErrors.isValid()).isFalse();
         assertThat(threeErrors.getError().size()).isEqualTo(3);
+    }
+
+    // -------------------------------------------------------------------------
+    // asPredicate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void asPredicate_returnsTrue_whenGuardPasses() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        assertThat(g.asPredicate().test("hello")).isTrue();
+    }
+
+    @Test
+    void asPredicate_returnsFalse_whenGuardFails() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        assertThat(g.asPredicate().test("   ")).isFalse();
+    }
+
+    @Test
+    void asPredicate_usefulForStreamFilter() {
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+        List<String> valid = List.of("alice", "  ", "bob", "").stream()
+            .filter(notBlank.asPredicate())
+            .toList();
+        assertThat(valid).containsExactly("alice", "bob");
+    }
+
+    // -------------------------------------------------------------------------
+    // contramap
+    // -------------------------------------------------------------------------
+
+    record User(String name) {}
+
+    @Test
+    void contramap_returnsValid_whenProjectedValuePasses() {
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Guard<User> userGuard = notBlank.contramap(User::name);
+        Validated<NonEmptyList<String>, User> result = userGuard.check(new User("alice"));
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get().name()).isEqualTo("alice");
+    }
+
+    @Test
+    void contramap_returnsInvalid_withOriginalErrors_whenProjectedValueFails() {
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "username must not be blank");
+        Guard<User> userGuard = notBlank.contramap(User::name);
+        Validated<NonEmptyList<String>, User> result = userGuard.check(new User("  "));
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("username must not be blank");
+    }
+
+    @Test
+    void contramap_preservesOriginalInputOnSuccess() {
+        Guard<Integer> positive = Guard.of(n -> n > 0, "must be positive");
+        Guard<User> userGuard = positive.contramap(u -> u.name().length());
+        User user = new User("hi");
+        Validated<NonEmptyList<String>, User> result = userGuard.check(user);
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isSameAs(user); // original U value preserved
+    }
+
+    @Test
+    void contramap_shouldThrowNPE_whenMapperIsNull() {
+        Guard<String> g = Guard.of(s -> true, "msg");
+        assertThatThrownBy(() -> g.contramap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToResult
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToResult_noMapper_returnsOk_whenGuardPasses() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Result<String, NonEmptyList<String>> result = g.checkToResult("hello");
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void checkToResult_noMapper_returnsErr_whenGuardFails() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Result<String, NonEmptyList<String>> result = g.checkToResult("   ");
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError().toList()).containsExactly("must not be blank");
+    }
+
+    @Test
+    void checkToResult_withMapper_returnsOk_whenGuardPasses() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Result<String, String> result = g.checkToResult("hello", errors -> String.join(", ", errors.toList()));
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void checkToResult_withMapper_mapsErrors_whenGuardFails() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Result<String, String> result = g.checkToResult("   ", errors -> String.join(", ", errors.toList()));
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("must not be blank");
+    }
+
+    @Test
+    void checkToResult_withMapper_shouldThrowNPE_whenMapperIsNull() {
+        Guard<String> g = Guard.of(s -> true, "msg");
+        assertThatThrownBy(() -> g.checkToResult("x", (java.util.function.Function<NonEmptyList<String>, String>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("toError");
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToOption
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToOption_returnsSome_whenGuardPasses() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Option<String> result = g.checkToOption("hello");
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void checkToOption_returnsNone_whenGuardFails() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Option<String> result = g.checkToOption("   ");
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void checkToOption_usefulForStreamFlatMap() {
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+        List<String> valid = List.of("alice", "  ", "bob").stream()
+            .flatMap(s -> notBlank.checkToOption(s).stream())
+            .toList();
+        assertThat(valid).containsExactly("alice", "bob");
     }
 
     @Test

--- a/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/lib/src/test/java/dmx/fun/GuardTest.java
@@ -1,0 +1,261 @@
+package dmx.fun;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GuardTest {
+
+    // -------------------------------------------------------------------------
+    // of — static message
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_staticMessage_returnsValid_whenPredicatePasses() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Validated<NonEmptyList<String>, String> result = g.check("hello");
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void of_staticMessage_returnsInvalid_whenPredicateFails() {
+        Guard<String> g = Guard.of(s -> !s.isBlank(), "must not be blank");
+        Validated<NonEmptyList<String>, String> result = g.check("   ");
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("must not be blank");
+    }
+
+    @Test
+    void of_staticMessage_shouldThrowNPE_whenPredicateIsNull() {
+        assertThatThrownBy(() -> Guard.of(null, "msg"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("predicate");
+    }
+
+    @Test
+    void of_staticMessage_shouldThrowNPE_whenMessageIsNull() {
+        assertThatThrownBy(() -> Guard.of(s -> true, (String) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorMessage");
+    }
+
+    // -------------------------------------------------------------------------
+    // of — dynamic message
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_dynamicMessage_returnsValid_whenPredicatePasses() {
+        Guard<Integer> g = Guard.of(n -> n > 0, n -> "must be positive, got " + n);
+        assertThat(g.check(5).isValid()).isTrue();
+    }
+
+    @Test
+    void of_dynamicMessage_includesValueInError_whenPredicateFails() {
+        Guard<Integer> g = Guard.of(n -> n > 0, n -> "must be positive, got " + n);
+        Validated<NonEmptyList<String>, Integer> result = g.check(-3);
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("must be positive, got -3");
+    }
+
+    @Test
+    void of_dynamicMessage_shouldThrowNPE_whenPredicateIsNull() {
+        assertThatThrownBy(() -> Guard.of(null, n -> "msg"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("predicate");
+    }
+
+    @Test
+    void of_dynamicMessage_shouldThrowNPE_whenMessageFnIsNull() {
+        assertThatThrownBy(() -> Guard.of(n -> true, (java.util.function.Function<Object, String>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorMessageFn");
+    }
+
+    // -------------------------------------------------------------------------
+    // and
+    // -------------------------------------------------------------------------
+
+    @Test
+    void and_returnsValid_whenBothPass() {
+        Guard<Integer> positive    = Guard.of(n -> n > 0,   "must be positive");
+        Guard<Integer> lessThan100 = Guard.of(n -> n < 100, "must be less than 100");
+        assertThat(positive.and(lessThan100).check(50).isValid()).isTrue();
+    }
+
+    @Test
+    void and_returnsLeftError_whenOnlyLeftFails() {
+        Guard<Integer> positive    = Guard.of(n -> n > 0,   "must be positive");
+        Guard<Integer> lessThan100 = Guard.of(n -> n < 100, "must be less than 100");
+        Validated<NonEmptyList<String>, Integer> result = positive.and(lessThan100).check(-1);
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("must be positive");
+    }
+
+    @Test
+    void and_returnsRightError_whenOnlyRightFails() {
+        Guard<Integer> positive    = Guard.of(n -> n > 0,   "must be positive");
+        Guard<Integer> lessThan100 = Guard.of(n -> n < 100, "must be less than 100");
+        Validated<NonEmptyList<String>, Integer> result = positive.and(lessThan100).check(150);
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("must be less than 100");
+    }
+
+    @Test
+    void and_accumulatesAllErrors_whenBothFail() {
+        Guard<Integer> positive = Guard.of(n -> n > 0,      "must be positive");
+        Guard<Integer> even     = Guard.of(n -> n % 2 == 0, "must be even");
+        // -1: fails positive (not > 0) and fails even (-1 % 2 != 0)
+        Validated<NonEmptyList<String>, Integer> result = positive.and(even).check(-1);
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList())
+            .containsExactly("must be positive", "must be even");
+    }
+
+    @Test
+    void and_evaluatesBothGuards_evenWhenFirstFails() {
+        AtomicInteger rightCallCount = new AtomicInteger(0);
+        Guard<Integer> alwaysFail = Guard.of(n -> false, "first");
+        Guard<Integer> counter    = Guard.of(n -> { rightCallCount.incrementAndGet(); return true; }, "second");
+        alwaysFail.and(counter).check(1);
+        assertThat(rightCallCount.get()).isEqualTo(1); // right was evaluated
+    }
+
+    @Test
+    void and_shouldThrowNPE_whenOtherIsNull() {
+        Guard<String> g = Guard.of(s -> true, "msg");
+        assertThatThrownBy(() -> g.and(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("other");
+    }
+
+    // -------------------------------------------------------------------------
+    // or
+    // -------------------------------------------------------------------------
+
+    @Test
+    void or_returnsValid_whenLeftPasses() {
+        Guard<String> email = Guard.of(s -> s.contains("@"), "must contain @");
+        Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be digits");
+        assertThat(email.or(phone).check("alice@example.com").isValid()).isTrue();
+    }
+
+    @Test
+    void or_returnsValid_whenLeftFailsAndRightPasses() {
+        Guard<String> email = Guard.of(s -> s.contains("@"), "must contain @");
+        Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be digits");
+        assertThat(email.or(phone).check("12345").isValid()).isTrue();
+    }
+
+    @Test
+    void or_accumulatesAllErrors_whenBothFail() {
+        Guard<String> email = Guard.of(s -> s.contains("@"), "must contain @");
+        Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be digits");
+        Validated<NonEmptyList<String>, String> result = email.or(phone).check("hello");
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList())
+            .containsExactly("must contain @", "must be digits");
+    }
+
+    @Test
+    void or_shortCircuits_whenLeftPasses() {
+        AtomicInteger rightCallCount = new AtomicInteger(0);
+        Guard<String> alwaysPass = Guard.of(s -> true, "first");
+        Guard<String> counter    = Guard.of(s -> { rightCallCount.incrementAndGet(); return true; }, "second");
+        alwaysPass.or(counter).check("x");
+        assertThat(rightCallCount.get()).isEqualTo(0); // right was NOT evaluated
+    }
+
+    @Test
+    void or_shouldThrowNPE_whenOtherIsNull() {
+        Guard<String> g = Guard.of(s -> true, "msg");
+        assertThatThrownBy(() -> g.or(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("other");
+    }
+
+    // -------------------------------------------------------------------------
+    // negate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void negate_returnsInvalid_whenOriginalPasses() {
+        Guard<String> notAdmin = Guard.<String>of(s -> s.equals("admin"), "is admin").negate();
+        assertThat(notAdmin.check("admin").isValid()).isFalse();
+    }
+
+    @Test
+    void negate_returnsValid_whenOriginalFails() {
+        Guard<String> notAdmin = Guard.<String>of(s -> s.equals("admin"), "is admin").negate();
+        assertThat(notAdmin.check("alice").isValid()).isTrue();
+    }
+
+    @Test
+    void negate_usesGenericMessage_whenNoMessageSupplied() {
+        Guard<String> g = Guard.<String>of(s -> true, "always passes").negate();
+        Validated<NonEmptyList<String>, String> result = g.check("x");
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().head()).isEqualTo("must not satisfy the condition");
+    }
+
+    @Test
+    void negate_withMessage_usesProvidedErrorMessage() {
+        Guard<String> noAdmin = Guard.<String>of(s -> s.equals("admin"), "is admin")
+            .negate("username must not be 'admin'");
+        Validated<NonEmptyList<String>, String> result = noAdmin.check("admin");
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("username must not be 'admin'");
+    }
+
+    @Test
+    void negate_withMessage_shouldThrowNPE_whenMessageIsNull() {
+        Guard<String> g = Guard.of(s -> true, "msg");
+        assertThatThrownBy(() -> g.negate(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorMessage");
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration — chained composition
+    // -------------------------------------------------------------------------
+
+    @Test
+    void check_composedChain_collectsAllViolations() {
+        Guard<String> notBlank    = Guard.of(s -> !s.isBlank(),              "must not be blank");
+        Guard<String> minLength   = Guard.of(s -> s.length() >= 3,           "min 3 chars");
+        Guard<String> alphanumeric = Guard.of(s -> s.matches("[a-zA-Z0-9]+"), "must be alphanumeric");
+
+        Guard<String> username = notBlank.and(minLength).and(alphanumeric);
+
+        // Passes all
+        assertThat(username.check("alice").isValid()).isTrue();
+
+        // Fails minLength and alphanumeric ("a!") — notBlank passes
+        Validated<NonEmptyList<String>, String> twoErrors = username.check("a!");
+        assertThat(twoErrors.isValid()).isFalse();
+        assertThat(twoErrors.getError().toList()).containsExactly("min 3 chars", "must be alphanumeric");
+
+        // Blank string ("  ") fails all three
+        Validated<NonEmptyList<String>, String> threeErrors = username.check("  ");
+        assertThat(threeErrors.isValid()).isFalse();
+        assertThat(threeErrors.getError().size()).isEqualTo(3);
+    }
+
+    @Test
+    void check_integratesWithValidatedCombine_toAccumulateAcrossFields() {
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "username must not be blank");
+        Guard<String> email    = Guard.of(s -> s.contains("@"), "email must contain @");
+
+        Validated<NonEmptyList<String>, String> username = notBlank.check("  ");
+        Validated<NonEmptyList<String>, String> emailVal = email.check("not-an-email");
+
+        Validated<NonEmptyList<String>, String> combined =
+            username.combine(emailVal, NonEmptyList::concat, (u, e) -> u + "/" + e);
+
+        assertThat(combined.isValid()).isFalse();
+        assertThat(combined.getError().toList())
+            .containsExactly("username must not be blank", "email must contain @");
+    }
+}

--- a/samples/src/main/java/dmx/fun/samples/GuardSample.java
+++ b/samples/src/main/java/dmx/fun/samples/GuardSample.java
@@ -2,7 +2,10 @@ package dmx.fun.samples;
 
 import dmx.fun.Guard;
 import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Result;
 import dmx.fun.Validated;
+import java.util.List;
 
 /**
  * Demonstrates Guard<T>: composable, named predicates that produce Validated results.
@@ -11,6 +14,7 @@ import dmx.fun.Validated;
 public class GuardSample {
 
     record RegistrationForm(String username, String email, int age) {}
+    record User(String name) {}
 
     static void main() {
 
@@ -96,5 +100,45 @@ public class GuardSample {
         // Error: must be alphanumeric
         // Error: must contain @
         // Error: age must be positive
+
+        // ---- asPredicate — Java stdlib interop ----
+
+        System.out.println("\n=== asPredicate ===");
+
+        List<String> valid = List.of("alice", "  ", "bob", "").stream()
+            .filter(notBlank.asPredicate())
+            .toList();
+        System.out.println("Valid names: " + valid); // [alice, bob]
+
+        // ---- contramap — adapt a field guard to a whole object ----
+
+        System.out.println("\n=== contramap ===");
+
+        Guard<User> userGuard = notBlank.contramap(User::name);
+        System.out.println(userGuard.check(new User("alice")).isValid());  // true
+        System.out.println(userGuard.check(new User("  ")).isValid());     // false
+
+        // ---- checkToResult — Result integration ----
+
+        System.out.println("\n=== checkToResult ===");
+
+        Result<String, NonEmptyList<String>> r1 = username.checkToResult("alice");
+        System.out.println("checkToResult ok: " + r1.isSuccess()); // true
+
+        Result<String, String> r2 = username.checkToResult(
+            "a!", errors -> String.join("; ", errors.toList()));
+        System.out.println("checkToResult err: " + r2.getError()); // min 3 chars; must be alphanumeric
+
+        // ---- checkToOption — discard errors ----
+
+        System.out.println("\n=== checkToOption ===");
+
+        Option<String> opt1 = username.checkToOption("alice");
+        System.out.println("checkToOption some: " + opt1.isDefined()); // true
+
+        List<String> validOnly = List.of("alice", "a!", "bob").stream()
+            .flatMap(s -> username.checkToOption(s).stream())
+            .toList();
+        System.out.println("Valid only: " + validOnly); // [alice, bob]
     }
 }

--- a/samples/src/main/java/dmx/fun/samples/GuardSample.java
+++ b/samples/src/main/java/dmx/fun/samples/GuardSample.java
@@ -4,6 +4,7 @@ import dmx.fun.Guard;
 import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
 import dmx.fun.Result;
+import dmx.fun.Tuple2;
 import dmx.fun.Validated;
 import java.util.List;
 
@@ -90,8 +91,8 @@ public class GuardSample {
 
         // Combine all three — errors accumulate across fields
         Validated<NonEmptyList<String>, RegistrationForm> form =
-            usernameV.combine(emailV, NonEmptyList::concat, (u, e) -> u + "/" + e)
-                     .combine(ageV,   NonEmptyList::concat, (ue, age) -> new RegistrationForm(ue, ue, age));
+            usernameV.combine(emailV, NonEmptyList::concat, Tuple2::new)
+                     .combine(ageV,   NonEmptyList::concat, (ue, age) -> new RegistrationForm(ue._1(), ue._2(), age));
 
         System.out.println("Valid: " + form.isValid());                       // false
         form.peekError(errors -> errors.toList().forEach(

--- a/samples/src/main/java/dmx/fun/samples/GuardSample.java
+++ b/samples/src/main/java/dmx/fun/samples/GuardSample.java
@@ -1,0 +1,100 @@
+package dmx.fun.samples;
+
+import dmx.fun.Guard;
+import dmx.fun.NonEmptyList;
+import dmx.fun.Validated;
+
+/**
+ * Demonstrates Guard<T>: composable, named predicates that produce Validated results.
+ * Use Guard to define validation rules once and compose them declaratively into pipelines.
+ */
+public class GuardSample {
+
+    record RegistrationForm(String username, String email, int age) {}
+
+    static void main() {
+
+        // ---- Basic usage — of with static message ----
+
+        System.out.println("=== Basic usage ===");
+
+        Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+
+        System.out.println(notBlank.check("hello").isValid());  // true
+        System.out.println(notBlank.check("   ").isValid());    // false
+        System.out.println(notBlank.check("   ").getError());   // [must not be blank]
+
+        // ---- Dynamic message — value included in error ----
+
+        System.out.println("\n=== Dynamic error message ===");
+
+        Guard<Integer> max100 = Guard.of(
+            n -> n <= 100,
+            n -> "must be ≤ 100, got " + n
+        );
+
+        System.out.println(max100.check(50).isValid());                      // true
+        System.out.println(max100.check(150).getError().head());             // must be ≤ 100, got 150
+
+        // ---- and — accumulates errors from all failing guards ----
+
+        System.out.println("\n=== and (error accumulation) ===");
+
+        Guard<String> minLength3   = Guard.of(s -> s.length() >= 3,            "min 3 chars");
+        Guard<String> alphanumeric = Guard.of(s -> s.matches("[a-zA-Z0-9]+"),   "must be alphanumeric");
+
+        Guard<String> username = notBlank.and(minLength3).and(alphanumeric);
+
+        System.out.println(username.check("alice").isValid());               // true
+        System.out.println(username.check("a!").getError().toList());        // [min 3 chars, must be alphanumeric]
+        System.out.println(username.check("  ").getError().size());          // 3 — all three fail
+
+        // ---- or — first passing guard short-circuits ----
+
+        System.out.println("\n=== or (short-circuit) ===");
+
+        Guard<String> email = Guard.of(s -> s.contains("@"),   "must contain @");
+        Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be all digits");
+
+        Guard<String> contact = email.or(phone);
+
+        System.out.println(contact.check("alice@example.com").isValid());    // true — email passes
+        System.out.println(contact.check("12345").isValid());                // true — phone passes
+        System.out.println(contact.check("hello").getError().toList());      // [must contain @, must be all digits]
+
+        // ---- negate ----
+
+        System.out.println("\n=== negate ===");
+
+        Guard<String> noAdmin = Guard.<String>of(s -> s.equals("admin"), "is admin")
+            .negate("username must not be 'admin'");
+
+        System.out.println(noAdmin.check("alice").isValid());                // true
+        System.out.println(noAdmin.check("admin").getError().head());        // username must not be 'admin'
+
+        // ---- Integration with Validated.combine ----
+
+        System.out.println("\n=== Validated.combine ===");
+
+        Guard<Integer> positive  = Guard.of(n -> n > 0,   "age must be positive");
+        Guard<Integer> maxAge    = Guard.of(n -> n <= 120, "age must be ≤ 120");
+        Guard<Integer> ageGuard  = positive.and(maxAge);
+
+        Validated<NonEmptyList<String>, String>  usernameV = username.check("al!");
+        Validated<NonEmptyList<String>, String>  emailV    = email.check("not-an-email");
+        Validated<NonEmptyList<String>, Integer> ageV      = ageGuard.check(-5);
+
+        // Combine all three — errors accumulate across fields
+        Validated<NonEmptyList<String>, RegistrationForm> form =
+            usernameV.combine(emailV, NonEmptyList::concat, (u, e) -> u + "/" + e)
+                     .combine(ageV,   NonEmptyList::concat, (ue, age) -> new RegistrationForm(ue, ue, age));
+
+        System.out.println("Valid: " + form.isValid());                       // false
+        form.peekError(errors -> errors.toList().forEach(
+            e -> System.out.println("Error: " + e)));
+        // Error: min 3 chars
+        // Error: must be alphanumeric
+        // Error: must contain @
+        // Error: age must be positive
+    }
+}

--- a/site/src/data/code/guide/guard/and.mdx
+++ b/site/src/data/code/guide/guard/and.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Guard<String> notBlank    = Guard.of(s -> !s.isBlank(),             "must not be blank");
+Guard<String> minLength3  = Guard.of(s -> s.length() >= 3,          "min 3 chars");
+Guard<String> alphanumeric = Guard.of(s -> s.matches("[a-zA-Z0-9]+"), "must be alphanumeric");
+
+// Both guards are always evaluated — errors accumulate (not fail-fast)
+Guard<String> username = notBlank.and(minLength3).and(alphanumeric);
+
+username.check("alice");  // Valid("alice")
+username.check("a!");     // Invalid(["min 3 chars", "must be alphanumeric"])
+username.check("  ");     // Invalid(["must not be blank", "min 3 chars", "must be alphanumeric"])
+```

--- a/site/src/data/code/guide/guard/creating-guards.mdx
+++ b/site/src/data/code/guide/guard/creating-guards.mdx
@@ -1,0 +1,20 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// Static error message
+Guard<String> notBlank   = Guard.of(s -> !s.isBlank(),    "must not be blank");
+Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+
+// Dynamic error message — the failing value is passed to the function
+Guard<Integer> max = Guard.of(
+    n -> n <= 100,
+    n -> "must be ≤ 100, got " + n
+);
+
+// Apply
+notBlank.check("hello"); // Valid("hello")
+notBlank.check("   ");   // Invalid(["must not be blank"])
+max.check(150);          // Invalid(["must be ≤ 100, got 150"])
+```

--- a/site/src/data/code/guide/guard/interop.mdx
+++ b/site/src/data/code/guide/guard/interop.mdx
@@ -1,0 +1,40 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Guard<String> notBlank   = Guard.of(s -> !s.isBlank(),    "must not be blank");
+Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "min 3 chars");
+Guard<String> username   = notBlank.and(minLength3);
+
+// asPredicate() — Java stdlib interop
+List<String> validNames = Stream.of("alice", "  ", "bob")
+    .filter(notBlank.asPredicate())   // standard Predicate<String>
+    .toList();
+// ["alice", "bob"]
+
+// contramap(fn) — adapt a field guard to an enclosing type
+record User(String name) {}
+Guard<User> userGuard = notBlank.contramap(User::name);
+userGuard.check(new User("alice")); // Valid(User[name=alice])
+userGuard.check(new User("   "));  // Invalid(["must not be blank"])
+
+// checkToResult(value) — direct Result<T, NonEmptyList<String>>
+Result<String, NonEmptyList<String>> r1 = username.checkToResult("alice");
+// Result.ok("alice")
+
+// checkToResult(value, mapper) — map errors to a domain type
+Result<String, String> r2 = username.checkToResult(
+    "a!", errors -> String.join("; ", errors.toList()));
+// Result.err("min 3 chars")
+
+// checkToOption(value) — discard errors, keep value or None
+Option<String> opt = username.checkToOption("alice");   // Some("alice")
+username.checkToOption("a!");                           // None
+
+// flatMap over a stream, keeping only valid values
+List<String> valid = Stream.of("alice", "a!", "bob")
+    .flatMap(s -> username.checkToOption(s).stream())
+    .toList();
+// ["alice", "bob"]
+```

--- a/site/src/data/code/guide/guard/negate.mdx
+++ b/site/src/data/code/guide/guard/negate.mdx
@@ -1,0 +1,16 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// negate(message) — inverts the predicate with a domain-specific error
+Guard<String> noAdmin = Guard.<String>of(s -> s.equals("admin"), "reserved")
+    .negate("username must not be 'admin'");
+
+noAdmin.check("alice"); // Valid("alice")
+noAdmin.check("admin"); // Invalid(["username must not be 'admin'"])
+
+// negate() with no argument uses a generic message
+Guard<String> notReserved = Guard.<String>of(s -> s.equals("root"), "is root").negate();
+notReserved.check("root"); // Invalid(["must not satisfy the condition"])
+```

--- a/site/src/data/code/guide/guard/or.mdx
+++ b/site/src/data/code/guide/guard/or.mdx
@@ -1,0 +1,15 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+Guard<String> email = Guard.of(s -> s.contains("@"),   "must contain @");
+Guard<String> phone = Guard.of(s -> s.matches("\\d+"), "must be all digits");
+
+// First passing guard short-circuits; all errors accumulated on total failure
+Guard<String> contact = email.or(phone);
+
+contact.check("alice@example.com");  // Valid — email passes, phone not evaluated
+contact.check("12345");              // Valid — phone passes
+contact.check("hello");             // Invalid(["must contain @", "must be all digits"])
+```

--- a/site/src/data/code/guide/guard/real-world-example.mdx
+++ b/site/src/data/code/guide/guard/real-world-example.mdx
@@ -1,0 +1,39 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// ---- Define reusable rules once ----
+
+Guard<String> notBlank     = Guard.of(s -> !s.isBlank(),              "must not be blank");
+Guard<String> minLength3   = Guard.of(s -> s.length() >= 3,           "min 3 chars");
+Guard<String> maxLength50  = Guard.of(s -> s.length() <= 50,          "max 50 chars");
+Guard<String> alphanumeric = Guard.of(s -> s.matches("[a-zA-Z0-9_]+"), "must be alphanumeric or _");
+Guard<String> emailFormat  = Guard.of(s -> s.contains("@") && s.contains("."), "invalid email format");
+Guard<Integer> adultAge    = Guard.of(n -> n >= 18, "must be at least 18");
+
+// ---- Compose into domain rules ----
+
+Guard<String> usernameGuard = notBlank.and(minLength3).and(maxLength50).and(alphanumeric);
+Guard<String> emailGuard    = notBlank.and(emailFormat);
+
+// ---- Validate all fields and accumulate errors ----
+
+static Validated<NonEmptyList<String>, RegistrationForm> validate(
+        String rawUsername, String rawEmail, int age) {
+
+    Validated<NonEmptyList<String>, String>  username = usernameGuard.check(rawUsername);
+    Validated<NonEmptyList<String>, String>  email    = emailGuard.check(rawEmail);
+    Validated<NonEmptyList<String>, Integer> ageV     = adultAge.check(age);
+
+    return username
+        .combine(email,  NonEmptyList::concat, (u, e) -> u + "/" + e)
+        .combine(ageV,   NonEmptyList::concat, (ue, a) -> {
+            String[] parts = ue.split("/");
+            return new RegistrationForm(parts[0], parts[1], a);
+        });
+}
+
+// validate("al", "not-an-email", 15)
+// → Invalid(["min 3 chars", "invalid email format", "must be at least 18"])
+```

--- a/site/src/data/code/guide/guard/real-world-example.mdx
+++ b/site/src/data/code/guide/guard/real-world-example.mdx
@@ -27,11 +27,8 @@ static Validated<NonEmptyList<String>, RegistrationForm> validate(
     Validated<NonEmptyList<String>, Integer> ageV     = adultAge.check(age);
 
     return username
-        .combine(email,  NonEmptyList::concat, (u, e) -> u + "/" + e)
-        .combine(ageV,   NonEmptyList::concat, (ue, a) -> {
-            String[] parts = ue.split("/");
-            return new RegistrationForm(parts[0], parts[1], a);
-        });
+        .combine(email,  NonEmptyList::concat, Tuple2::new)
+        .combine(ageV,   NonEmptyList::concat, (ue, a) -> new RegistrationForm(ue._1(), ue._2(), a));
 }
 
 // validate("al", "not-an-email", 15)

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -1,0 +1,92 @@
+---
+title: "Guard<T> — Developer Guide"
+description: "Comprehensive guide to Guard<T>: composable predicate blocks for Validated pipelines, and, or, negate combinators."
+order: 5
+h1: "Guard<T>"
+---
+
+import {Content as CreatingGuards}   from '../code/guide/guard/creating-guards.mdx';
+import {Content as And}              from '../code/guide/guard/and.mdx';
+import {Content as Or}               from '../code/guide/guard/or.mdx';
+import {Content as Negate}           from '../code/guide/guard/negate.mdx';
+import {Content as RealWorldExample} from '../code/guide/guard/real-world-example.mdx';
+
+> **Runnable example:** [`GuardSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/GuardSample.java)
+
+## What is Guard&lt;T&gt;?
+
+`Guard<T>` is a `@FunctionalInterface` that wraps a single validation rule:
+a predicate over `T` with an associated error message.
+Applying a guard via `check(value)` returns a
+`Validated<NonEmptyList<String>, T>` — `Valid(value)` when the rule passes,
+or `Invalid(errors)` when it fails.
+
+Guards are the composable building block for [`Validated`](validated) pipelines.
+Instead of writing repeated `if`/`Validated.invalidNel(...)` branches, define each
+rule once as a `Guard` and compose them with `and`, `or`, and `negate`.
+
+## Creating guards
+
+<CreatingGuards/>
+
+Both factory overloads throw `NullPointerException` for `null` predicate or message arguments.
+
+## `and(other)` — accumulate all errors
+
+Both guards are **always evaluated** — `and` is not fail-fast.
+Errors from all failing guards are accumulated into a single `NonEmptyList` so the caller
+receives a complete picture of every violation.
+
+<And/>
+
+## `or(other)` — pass on first success
+
+Evaluation is **short-circuit**: if the left guard passes, the right guard is never evaluated.
+If all guards fail, errors from all of them are accumulated.
+
+<Or/>
+
+Use `or` when a value is allowed to satisfy any one of several alternative formats
+(e.g., email or phone number, UUID or slug).
+
+## `negate()` / `negate(message)`
+
+Inverts the predicate. Use `negate(message)` to supply a domain-specific error
+message; `negate()` falls back to the generic message `"must not satisfy the condition"`.
+
+<Negate/>
+
+## Integrating with `Validated.combine`
+
+Guards produce `Validated<NonEmptyList<String>, T>` values, which compose naturally with
+[`Validated.combine`](validated#combining-results). Apply one guard per field, then combine
+them to accumulate errors across an entire form or command object:
+
+```java
+Validated<NonEmptyList<String>, String>  username = usernameGuard.check(rawUsername);
+Validated<NonEmptyList<String>, String>  email    = emailGuard.check(rawEmail);
+
+Validated<NonEmptyList<String>, Form> form =
+    username.combine(email, NonEmptyList::concat, Form::new);
+// Invalid(["min 3 chars", "must be alphanumeric", "invalid email format"])
+```
+
+## Real-world example
+
+A registration form validator that composes rules across three fields:
+
+<RealWorldExample/>
+
+## Guard vs raw Validated
+
+|                          | Raw `Validated.invalidNel`      | `Guard<T>`                              |
+|--------------------------|---------------------------------|-----------------------------------------|
+| Rule definition          | Inline `if`/`invalidNel`        | Named value — defined once, used anywhere |
+| Reuse across call sites  | Copy-paste                      | Reference the same `Guard` constant     |
+| Composition              | Manual chaining                 | `and`, `or`, `negate`                   |
+| Error accumulation       | Explicit `combine` calls        | Built into `and` / `or`                 |
+| Dynamic error messages   | Inline string interpolation     | `Guard.of(pred, value -> "... " + value)` |
+
+Use `Guard` when the same rule appears in more than one place, when rules are composed
+from smaller building blocks, or when you want a named, self-documenting validation vocabulary.
+For a single, one-off check, a direct `Validated.invalidNel` is simpler.

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -9,6 +9,7 @@ import {Content as CreatingGuards}   from '../code/guide/guard/creating-guards.m
 import {Content as And}              from '../code/guide/guard/and.mdx';
 import {Content as Or}               from '../code/guide/guard/or.mdx';
 import {Content as Negate}           from '../code/guide/guard/negate.mdx';
+import {Content as Interop}          from '../code/guide/guard/interop.mdx';
 import {Content as RealWorldExample} from '../code/guide/guard/real-world-example.mdx';
 
 > **Runnable example:** [`GuardSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/GuardSample.java)
@@ -70,6 +71,18 @@ Validated<NonEmptyList<String>, Form> form =
     username.combine(email, NonEmptyList::concat, Form::new);
 // Invalid(["min 3 chars", "must be alphanumeric", "invalid email format"])
 ```
+
+## Interoperability
+
+| Method | Returns | Use case |
+|---|---|---|
+| `asPredicate()` | `Predicate<T>` | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
+| `contramap(fn)` | `Guard<U>` | Adapt a field guard to validate the enclosing object type |
+| `checkToResult(value)` | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic |
+| `checkToResult(value, mapper)` | `Result<T, E>` | Map errors to a domain-specific error type at service boundaries |
+| `checkToOption(value)` | `Option<T>` | Discard errors — keep only valid values (stream filtering) |
+
+<Interop/>
 
 ## Real-world example
 

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -84,6 +84,14 @@ const types = [
         tag: 'Collections',
     },
     {
+        name: 'Guard<T>',
+        href: `${base}guide/guard`,
+        summary: 'A composable, named predicate that produces a Validated result — the reusable building block for validation pipelines.',
+        whenToUse: 'You have repeated if/invalidNel validation patterns that should be defined once and composed declaratively.',
+        avoidWhen: 'A single ad-hoc check is simpler — Guard shines when rules are reused or composed.',
+        tag: 'Validation',
+    },
+    {
         name: 'Resource<T>',
         href: `${base}guide/resource`,
         summary: 'A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.',


### PR DESCRIPTION
- **feat(Guard): add composable predicate blocks for Validated pipelines (issue #230)**
- **feat(Guard): add interop methods for stdlib, Result, and Option integration**
- **docs(README): add Guard and Resource to types list and description**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #230

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Guard<T>`, a composable validation type for building reusable predicate-based validators with error accumulation
  * Supports logical composition: `and()` for accumulating errors, `or()` for short-circuit evaluation, and `negate()` for predicate inversion
  * Integrates seamlessly with existing validation types and Java streams

* **Documentation**
  * Added comprehensive guides and examples demonstrating Guard creation, composition, and interoperability patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->