### PR TITLE
feat(lib): add Accumulator<E, A> — value with accumulated side-channel (issue #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 | `NonEmptyMap<K,V>` | Collections           | A map guaranteed to have at least one entry at compile time. Insertion order preserved.                                                                                   |
 | `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved.                                                                  |
 | `Guard<T>`         | Validation            | A composable, named predicate that produces a `Validated` result — the reusable building block for validation pipelines.                                                  |
-| `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.                                                                             |
-| `Accumulator<E,A>` | Tracing               | A value paired with a side-channel accumulation (log, metrics, audit trail). Threads cross-cutting concerns through pure computation chains without shared mutable state. |
+| `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup.                                                                                       |
+| `Accumulator<E, A>` | Tracing              | A value paired with a side-channel accumulation (log, metrics, audit trail). Threads cross-cutting concerns through pure computation chains without shared mutable state. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Java library of functional types that make failures, absence, and validation explicit in the type system — without ceremony.
 
-`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, `NonEmptyList<T>`, `NonEmptyMap<K, V>`, `NonEmptySet<T>`, `Guard<T>`, and `Resource<T>` — each designed to compose cleanly with the others and with the Java standard library.
+`Option<T>`, `Result<V, E>`, `Try<V>`, `Validated<E, A>`, `Either<L, R>`, `Lazy<T>`, `Tuple2/3/4`, `NonEmptyList<T>`, `NonEmptyMap<K, V>`, `NonEmptySet<T>`, `Guard<T>`, `Resource<T>`, and `Accumulator<E, A>` — each designed to compose cleanly with the others and with the Java standard library.
 
 ---
 
@@ -91,6 +91,7 @@ testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 | `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved. |
 | `Guard<T>`         | Validation            | A composable, named predicate that produces a `Validated` result — the reusable building block for validation pipelines. |
 | `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.            |
+| `Accumulator<E,A>` | Tracing               | A value paired with a side-channel accumulation (log, metrics, audit trail). Threads cross-cutting concerns through pure computation chains without shared mutable state. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,20 +77,20 @@ testImplementation("codes.domix:fun-assertj:LATEST_VERSION")
 
 ## Types
 
-| Type               | Tag                   | When to use                                                                                              |
-|--------------------|-----------------------|----------------------------------------------------------------------------------------------------------|
-| `Option<T>`        | Nullability           | A value that may or may not be present. The null-safe alternative to `@Nullable`.                        |
-| `Result<V, E>`     | Error handling        | An operation that can succeed or fail with a typed error.                                                |
-| `Try<V>`           | Exception handling    | Wraps a computation that may throw. Turns exceptions into values.                                        |
-| `Validated<E, A>`  | Validation            | Like `Result` but accumulates all errors instead of failing on the first.                                |
-| `Either<L, R>`     | Disjoint union        | A value that is one of two types with no success/failure semantics.                                      |
-| `Lazy<T>`          | Deferred computation  | A value computed at most once, on first access. Thread-safe memoization.                                 |
-| `Tuple2/3/4`       | Product types         | Typed heterogeneous tuples without a dedicated class.                                                    |
-| `NonEmptyList<T>`  | Collections           | A list guaranteed to have at least one element at compile time.                                          |
-| `NonEmptyMap<K,V>` | Collections           | A map guaranteed to have at least one entry at compile time. Insertion order preserved.                  |
-| `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved. |
-| `Guard<T>`         | Validation            | A composable, named predicate that produces a `Validated` result — the reusable building block for validation pipelines. |
-| `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.            |
+| Type               | Tag                   | When to use                                                                                                                                                               |
+|--------------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Option<T>`        | Nullability           | A value that may or may not be present. The null-safe alternative to `@Nullable`.                                                                                         |
+| `Result<V, E>`     | Error handling        | An operation that can succeed or fail with a typed error.                                                                                                                 |
+| `Try<V>`           | Exception handling    | Wraps a computation that may throw. Turns exceptions into values.                                                                                                         |
+| `Validated<E, A>`  | Validation            | Like `Result` but accumulates all errors instead of failing on the first.                                                                                                 |
+| `Either<L, R>`     | Disjoint union        | A value that is one of two types with no success/failure semantics.                                                                                                       |
+| `Lazy<T>`          | Deferred computation  | A value computed at most once, on first access. Thread-safe memoization.                                                                                                  |
+| `Tuple2/3/4`       | Product types         | Typed heterogeneous tuples without a dedicated class.                                                                                                                     |
+| `NonEmptyList<T>`  | Collections           | A list guaranteed to have at least one element at compile time.                                                                                                           |
+| `NonEmptyMap<K,V>` | Collections           | A map guaranteed to have at least one entry at compile time. Insertion order preserved.                                                                                   |
+| `NonEmptySet<T>`   | Collections           | A set guaranteed to have at least one element at compile time. No duplicates, insertion order preserved.                                                                  |
+| `Guard<T>`         | Validation            | A composable, named predicate that produces a `Validated` result — the reusable building block for validation pipelines.                                                  |
+| `Resource<T>`      | Resource management   | A composable managed resource: acquire, use, and release with a guaranteed cleanup guarantee.                                                                             |
 | `Accumulator<E,A>` | Tracing               | A value paired with a side-channel accumulation (log, metrics, audit trail). Threads cross-cutting concerns through pure computation chains without shared mutable state. |
 
 ---

--- a/lib/src/main/java/dmx/fun/Accumulator.java
+++ b/lib/src/main/java/dmx/fun/Accumulator.java
@@ -529,4 +529,26 @@ public record Accumulator<E, A>(@Nullable A value, E accumulated) {
     public Tuple2<E, @Nullable A> toTuple2() {
         return new Tuple2<>(accumulated, value);
     }
+
+    /**
+     * Converts this accumulator to a {@link Result}: {@link Result#ok(Object)} when
+     * {@link #hasValue()} is {@code true}, or {@link Result#err(Object)} carrying the
+     * accumulated side-channel when this accumulator was created by {@link #tell(Object)}.
+     *
+     * <p>Use this at the boundary between a traced computation chain and error-handling code:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Config> acc = loadAndTrace(path);
+     *
+     * Result<Config, List<String>> result = acc.toResult();
+     * // Ok(config)        — when a value was computed
+     * // Err(["entry..."])  — when only tell() steps ran (no real value was produced)
+     * }</pre>
+     *
+     * @return {@code Ok(value)} when {@link #hasValue()}, or {@code Err(accumulated)} otherwise
+     */
+    @SuppressWarnings("NullAway")
+    public Result<A, E> toResult() {
+        return hasValue() ? Result.ok(value) : Result.err(accumulated);
+    }
 }

--- a/lib/src/main/java/dmx/fun/Accumulator.java
+++ b/lib/src/main/java/dmx/fun/Accumulator.java
@@ -1,0 +1,532 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable pair of a computed value {@code A} and a side-channel accumulation {@code E}.
+ *
+ * <p>{@code Accumulator<E, A>} is the functional alternative to mutable global state for
+ * cross-cutting concerns such as logging, metrics, audit trails, and diagnostics. It threads
+ * a growing accumulation value through a computation chain without passing it explicitly as
+ * an argument or storing it in a shared mutable field.
+ *
+ * <p>The key invariant: <strong>accumulation always continues</strong>. Unlike
+ * {@link Result} or {@link Try}, there is no failure path — every step contributes to both
+ * the value and the accumulation. This makes {@code Accumulator} the natural choice when you
+ * want to record a trace of what happened, not just whether it succeeded.
+ *
+ * <h2>Quick start</h2>
+ * <pre>{@code
+ * // ---- Build a traced computation ----
+ *
+ * Accumulator<List<String>, Integer> step1 = Accumulator.of(10, List.of("loaded base value"));
+ *
+ * // flatMap chains steps and merges their logs
+ * BinaryOperator<List<String>> concat = (a, b) -> {
+ *     var merged = new ArrayList<>(a);
+ *     merged.addAll(b);
+ *     return merged;
+ * };
+ *
+ * Accumulator<List<String>, Integer> result = step1
+ *     .flatMap(v -> Accumulator.of(v * 2, List.of("doubled")), concat)
+ *     .flatMap(v -> Accumulator.of(v + 5, List.of("added 5")), concat);
+ *
+ * result.value();        // 25
+ * result.accumulated();  // ["loaded base value", "doubled", "added 5"]
+ * }</pre>
+ *
+ * <h2>Typical accumulation types</h2>
+ * <ul>
+ *   <li>{@code List<String>} — ordered log entries; merged with list concatenation.</li>
+ *   <li>{@link NonEmptyList}{@code <String>} — same guarantee as for {@link Validated} errors;
+ *       merged with {@link NonEmptyList#concat}.</li>
+ *   <li>{@code int} / {@code long} — counters; merged with addition.</li>
+ *   <li>Custom event types — domain audit entries; merged with
+ *       {@code NonEmptyList} or {@code List} append.</li>
+ * </ul>
+ *
+ * <h2>Accessing the value</h2>
+ * <p>{@link #value()} returns {@code @Nullable A}. For accumulators created via
+ * {@link #of(Object, Object)} or {@link #pure(Object, Object)}, the value is always
+ * non-null. Accumulators created via {@link #tell(Object)} carry a {@code null} value
+ * (the accumulation side-channel is the only meaningful payload). Call
+ * {@link #hasValue()} before calling {@link #value()} if the source is not known.
+ *
+ * @param <E>         the accumulation type (log entries, metrics, etc.)
+ * @param <A>         the value type
+ * @param value       the computed value; {@code null} only for accumulators created by
+ *                    {@link #tell(Object)}
+ * @param accumulated the side-channel accumulation; never {@code null}
+ */
+@NullMarked
+public record Accumulator<E, A>(@Nullable A value, E accumulated) {
+
+    /**
+     * Compact canonical constructor — validates that {@code accumulated} is non-null.
+     *
+     * @throws NullPointerException if {@code accumulated} is {@code null}
+     */
+    public Accumulator {
+        Objects.requireNonNull(accumulated, "accumulated");
+    }
+
+    // -------------------------------------------------------------------------
+    // Factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an {@code Accumulator} pairing a computed value with an initial accumulation.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("computed answer"));
+     * acc.value();        // 42
+     * acc.accumulated();  // ["computed answer"]
+     * }</pre>
+     *
+     * @param <E>         the accumulation type
+     * @param <A>         the value type
+     * @param value       the computed value; must not be {@code null}
+     * @param accumulated the initial accumulation; must not be {@code null}
+     * @return a new {@code Accumulator<E, A>}
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    public static <E, A> Accumulator<E, A> of(A value, E accumulated) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(accumulated, "accumulated");
+        return new Accumulator<>(value, accumulated);
+    }
+
+    /**
+     * Creates an {@code Accumulator} with a value and an empty (identity) accumulation.
+     *
+     * <p>Use this as the starting point of a chain when the first step has no entries
+     * to record. The caller provides the {@code empty} value because Java does not have
+     * type classes; common choices are {@code List.of()}, {@code 0}, or an empty string.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> start = Accumulator.pure(42, List.of());
+     * // start has value 42 and an empty log
+     * }</pre>
+     *
+     * @param <E>   the accumulation type
+     * @param <A>   the value type
+     * @param value the value; must not be {@code null}
+     * @param empty the identity / empty accumulation; must not be {@code null}
+     * @return a new {@code Accumulator<E, A>} with empty accumulation
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    public static <E, A> Accumulator<E, A> pure(A value, E empty) {
+        return of(value, empty);
+    }
+
+    /**
+     * Creates an {@code Accumulator} that records something without producing a meaningful value.
+     *
+     * <p>The resulting accumulator's {@link #value()} is {@code null} (type {@code Void}).
+     * Use it at the start of a chain or inside a {@link #flatMap(Function, BinaryOperator)}
+     * step that ignores the incoming value and contributes only to the accumulation:
+     *
+     * <pre>{@code
+     * BinaryOperator<List<String>> concat = (a, b) -> {
+     *     var merged = new ArrayList<>(a);
+     *     merged.addAll(b);
+     *     return merged;
+     * };
+     *
+     * Accumulator<List<String>, Integer> result =
+     *     Accumulator.tell(List.of("pre-check passed"))
+     *         .flatMap(__ -> Accumulator.of(42, List.of("computed")), concat);
+     *
+     * result.value();        // 42
+     * result.accumulated();  // ["pre-check passed", "computed"]
+     * }</pre>
+     *
+     * <p><strong>Note:</strong> calling {@link #map(Function)} on a {@code tell} result throws
+     * {@link NullPointerException} because {@code value()} is {@code null}. Chain with
+     * {@link #flatMap(Function, BinaryOperator)} to produce a real value first.
+     *
+     * @param <E>         the accumulation type
+     * @param accumulated the entry to record; must not be {@code null}
+     * @return a new {@code Accumulator<E, Void>} with {@code null} value
+     * @throws NullPointerException if {@code accumulated} is {@code null}
+     */
+    @SuppressWarnings("NullAway") // null is the only valid Void value; tell() is its sole producer
+    public static <E> Accumulator<E, @Nullable Void> tell(E accumulated) {
+        Objects.requireNonNull(accumulated, "accumulated");
+        return new Accumulator<>(null, accumulated);
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if this accumulator was created with {@link #of(Object, Object)} or
+     * {@link #pure(Object, Object)} and therefore carries a non-null value.
+     *
+     * <p>Returns {@code false} only for accumulators created by {@link #tell(Object)}.
+     *
+     * @return {@code true} when {@link #value()} is non-null
+     */
+    public boolean hasValue() {
+        return value != null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Transforms the value, leaving the accumulation unchanged.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("step 1"));
+     * Accumulator<List<String>, String>  str = acc.map(Object::toString);
+     * // ("42", ["step 1"])
+     * }</pre>
+     *
+     * <p><strong>Note:</strong> calling this method on a {@link #tell(Object)} result throws
+     * {@link NullPointerException} because the value is {@code null}. Use
+     * {@link #flatMap(Function, BinaryOperator)} to produce a real value from a
+     * {@code tell} accumulator.
+     *
+     * @param <B> the type of the new value
+     * @param f   the transformation function; must not be {@code null}
+     * @return a new {@code Accumulator<E, B>} with the transformed value and unchanged accumulation
+     * @throws NullPointerException if {@code f} is {@code null}, or if this accumulator was
+     *                              created by {@link #tell(Object)} (its value is {@code null})
+     */
+    @SuppressWarnings("NullAway")
+    public <B> Accumulator<E, B> map(Function<? super A, ? extends B> f) {
+        Objects.requireNonNull(f, "f");
+        Objects.requireNonNull(value, "cannot map over a tell() accumulator — use flatMap instead");
+        return Accumulator.of(f.apply(value), accumulated);
+    }
+
+    /**
+     * Chains a computation that itself produces an {@code Accumulator}, merging both
+     * accumulations using {@code merge}.
+     *
+     * <p>This is the primary composition combinator: it is the functional equivalent of
+     * "run step 1, append its log to the current log, then run step 2 with its result."
+     *
+     * <p>Example:
+     * <pre>{@code
+     * BinaryOperator<List<String>> concat = (a, b) -> {
+     *     var merged = new ArrayList<>(a);
+     *     merged.addAll(b);
+     *     return merged;
+     * };
+     *
+     * Accumulator<List<String>, Integer> result =
+     *     Accumulator.of(10, List.of("step 1"))
+     *         .flatMap(v -> Accumulator.of(v * 2, List.of("step 2")), concat)
+     *         .flatMap(v -> Accumulator.of(v + 5, List.of("step 3")), concat);
+     *
+     * result.value();        // 25
+     * result.accumulated();  // ["step 1", "step 2", "step 3"]
+     * }</pre>
+     *
+     * @param <B>   the value type produced by the next step
+     * @param f     function from the current value to the next {@code Accumulator};
+     *              must not be {@code null} and must not return {@code null}
+     * @param merge function that combines the current accumulation with the next step's
+     *              accumulation; must not be {@code null}
+     * @return a new {@code Accumulator<E, B>} with the chained value and merged accumulation
+     * @throws NullPointerException if {@code f} or {@code merge} is {@code null}, or if
+     *                              {@code f} returns {@code null}
+     */
+    @SuppressWarnings("NullAway")
+    public <B> Accumulator<E, B> flatMap(
+            Function<? super A, ? extends Accumulator<E, B>> f,
+            BinaryOperator<E> merge) {
+        Objects.requireNonNull(f, "f");
+        Objects.requireNonNull(merge, "merge");
+        Accumulator<E, B> next = f.apply(value);
+        Objects.requireNonNull(next, "flatMap function must not return null");
+        return new Accumulator<>(next.value(), merge.apply(accumulated, next.accumulated()));
+    }
+
+    /**
+     * Transforms the accumulation, leaving the value unchanged.
+     *
+     * <p>Use this to convert between accumulation types — for example, to count log entries
+     * or to transform raw strings into structured domain objects:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> raw   = Accumulator.of(42, List.of("event 1"));
+     * Accumulator<Integer, Integer>      count = raw.mapAccumulated(List::size);
+     * // count.value()       == 42
+     * // count.accumulated() == 1
+     * }</pre>
+     *
+     * @param <F> the new accumulation type
+     * @param f   the transformation function; must not be {@code null} and must not return
+     *            {@code null}
+     * @return a new {@code Accumulator<F, A>} with the transformed accumulation and unchanged value
+     * @throws NullPointerException if {@code f} is {@code null} or returns {@code null}
+     */
+    public <F> Accumulator<F, A> mapAccumulated(Function<? super E, ? extends F> f) {
+        Objects.requireNonNull(f, "f");
+        F newAccumulated = f.apply(accumulated);
+        Objects.requireNonNull(newAccumulated, "mapAccumulated function must not return null");
+        return new Accumulator<>(value, newAccumulated);
+    }
+
+    // -------------------------------------------------------------------------
+    // Combination
+    // -------------------------------------------------------------------------
+
+    /**
+     * Combines this accumulator with {@code other} by merging their accumulations and applying
+     * {@code f} to both values to produce a new value.
+     *
+     * <p>Both accumulators are evaluated independently — unlike {@link #flatMap}, there is no
+     * sequential dependency between them. Use this when two parallel computations each produce
+     * an accumulator and you want to combine their results and logs in one step:
+     *
+     * <pre>{@code
+     * BinaryOperator<List<String>> concat = ...;
+     *
+     * Accumulator<List<String>, User>  userAcc  = fetchUser(userId);
+     * Accumulator<List<String>, Order> orderAcc = fetchOrder(orderId);
+     *
+     * Accumulator<List<String>, Dashboard> dash =
+     *     userAcc.combine(orderAcc, concat, Dashboard::new);
+     *
+     * // dash.accumulated() contains entries from both userAcc and orderAcc
+     * }</pre>
+     *
+     * @param <B>   the value type of {@code other}
+     * @param <C>   the combined value type
+     * @param other the second accumulator; must not be {@code null} and must not have been
+     *              created by {@link #tell(Object)} (its value must be non-null)
+     * @param merge function that combines the two accumulations; must not be {@code null}
+     * @param f     function that combines the two values; must not be {@code null}
+     * @return a new {@code Accumulator<E, C>} with the combined value and merged accumulation
+     * @throws NullPointerException if any argument is {@code null}, or if either accumulator
+     *                              was created by {@link #tell(Object)}
+     */
+    @SuppressWarnings("NullAway")
+    public <B, C> Accumulator<E, C> combine(
+            Accumulator<E, B> other,
+            BinaryOperator<E> merge,
+            BiFunction<? super A, ? super B, ? extends C> f) {
+        Objects.requireNonNull(other, "other");
+        Objects.requireNonNull(merge, "merge");
+        Objects.requireNonNull(f, "f");
+        Objects.requireNonNull(value,
+            "cannot combine a tell() accumulator — use flatMap to assign a value first");
+        Objects.requireNonNull(other.value(),
+            "cannot combine a tell() accumulator — use flatMap to assign a value first");
+        return Accumulator.of(
+            f.apply(value, other.value()),
+            merge.apply(accumulated, other.accumulated())
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Static combination
+    // -------------------------------------------------------------------------
+
+    /**
+     * Folds a list of accumulators into a single {@code Accumulator<E, List<A>>}, merging all
+     * accumulations left-to-right using {@code merge}, starting from {@code empty}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * BinaryOperator<List<String>> concat = ...;
+     *
+     * List<Accumulator<List<String>, Integer>> steps = List.of(
+     *     Accumulator.of(1, List.of("step A")),
+     *     Accumulator.of(2, List.of("step B")),
+     *     Accumulator.of(3, List.of("step C"))
+     * );
+     *
+     * Accumulator<List<String>, List<Integer>> result =
+     *     Accumulator.sequence(steps, concat, List.of());
+     *
+     * result.value();        // [1, 2, 3]
+     * result.accumulated();  // ["step A", "step B", "step C"]
+     * }</pre>
+     *
+     * @param <E>          the accumulation type
+     * @param <A>          the value type of each accumulator
+     * @param accumulators the list of accumulators to fold; must not be {@code null} and no
+     *                     element may be {@code null} or created by {@link #tell(Object)}
+     * @param merge        function that combines two accumulations; must not be {@code null}
+     * @param empty        the identity accumulation used as the starting value;
+     *                     must not be {@code null}
+     * @return a single {@code Accumulator<E, List<A>>} containing all values and the merged log
+     * @throws NullPointerException if any argument is {@code null}, if any element of
+     *                              {@code accumulators} is {@code null}, or if any accumulator
+     *                              in the list was created by {@link #tell(Object)}
+     */
+    public static <E, A> Accumulator<E, List<A>> sequence(
+            List<? extends Accumulator<E, A>> accumulators,
+            BinaryOperator<E> merge,
+            E empty) {
+        Objects.requireNonNull(accumulators, "accumulators");
+        Objects.requireNonNull(merge, "merge");
+        Objects.requireNonNull(empty, "empty");
+        E acc = empty;
+        List<A> values = new ArrayList<>(accumulators.size());
+        for (int i = 0; i < accumulators.size(); i++) {
+            Accumulator<E, A> a = accumulators.get(i);
+            Objects.requireNonNull(a, "accumulators[" + i + "] must not be null");
+            A v = a.value();
+            Objects.requireNonNull(v,
+                "accumulators[" + i + "] was created by tell() and has no value");
+            values.add(v);
+            acc = merge.apply(acc, a.accumulated());
+        }
+        return Accumulator.of(List.copyOf(values), acc);
+    }
+
+    /**
+     * Lifts an {@link Option} value into an {@code Accumulator}, recording a log entry for
+     * both the present and absent cases.
+     *
+     * <p>Use this to thread option-returning operations through a traced computation chain
+     * while keeping a record of whether each lookup succeeded:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Option<User>> acc = Accumulator.liftOption(
+     *     userRepo.findById(id),
+     *     user -> List.of("user found: " + user.name()),
+     *     List.of("user not found for id: " + id)
+     * );
+     * // if found:     (Some(user), ["user found: Alice"])
+     * // if not found: (None,       ["user not found for id: 42"])
+     * }</pre>
+     *
+     * @param <E>      the accumulation type
+     * @param <A>      the value type inside the option
+     * @param option   the option to lift; must not be {@code null}
+     * @param someLog  function that produces the accumulation entry when the option is present;
+     *                 must not be {@code null} and must not return {@code null}
+     * @param noneLog  the accumulation entry recorded when the option is absent;
+     *                 must not be {@code null}
+     * @return an {@code Accumulator<E, Option<A>>} pairing the option value with its log entry
+     * @throws NullPointerException if any argument is {@code null} or if {@code someLog}
+     *                              returns {@code null}
+     */
+    public static <E, A> Accumulator<E, Option<A>> liftOption(
+            Option<A> option,
+            Function<? super A, ? extends E> someLog,
+            E noneLog) {
+        Objects.requireNonNull(option, "option");
+        Objects.requireNonNull(someLog, "someLog");
+        Objects.requireNonNull(noneLog, "noneLog");
+        if (option.isDefined()) {
+            A v = option.get();
+            E log = someLog.apply(v);
+            Objects.requireNonNull(log, "someLog function must not return null");
+            return Accumulator.of(Option.some(v), log);
+        }
+        return Accumulator.of(Option.none(), noneLog);
+    }
+
+    /**
+     * Lifts a {@link Try} value into an {@code Accumulator}, recording a log entry via
+     * {@code successLog} on success or {@code failureLog} on failure.
+     *
+     * <p>The {@code Try<A>} itself becomes the value of the returned accumulator, preserving
+     * full access to the outcome. The log records what happened regardless of which branch was
+     * taken:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Try<Config>> acc = Accumulator.liftTry(
+     *     Try.of(() -> ConfigLoader.load(path)),
+     *     cfg  -> List.of("config loaded from " + path),
+     *     ex   -> List.of("config load failed: " + ex.getMessage())
+     * );
+     *
+     * acc.accumulated();  // always set — success or failure
+     * acc.value();        // Try<Config> — caller decides how to handle it
+     * }</pre>
+     *
+     * @param <E>        the accumulation type
+     * @param <A>        the success value type of the Try
+     * @param result     the Try to lift; must not be {@code null}
+     * @param successLog function that produces the log entry on success; must not be {@code null}
+     *                   and must not return {@code null}
+     * @param failureLog function that produces the log entry on failure; must not be {@code null}
+     *                   and must not return {@code null}
+     * @return an {@code Accumulator<E, Try<A>>} pairing the Try result with its log entry
+     * @throws NullPointerException if any argument is {@code null} or if either log function
+     *                              returns {@code null}
+     */
+    public static <E, A> Accumulator<E, Try<A>> liftTry(
+            Try<A> result,
+            Function<? super A, ? extends E> successLog,
+            Function<? super Throwable, ? extends E> failureLog) {
+        Objects.requireNonNull(result, "result");
+        Objects.requireNonNull(successLog, "successLog");
+        Objects.requireNonNull(failureLog, "failureLog");
+        if (result.isSuccess()) {
+            E log = successLog.apply(result.get());
+            Objects.requireNonNull(log, "successLog function must not return null");
+            return Accumulator.of(result, log);
+        }
+        E log = failureLog.apply(result.getCause());
+        Objects.requireNonNull(log, "failureLog function must not return null");
+        return Accumulator.of(result, log);
+    }
+
+    // -------------------------------------------------------------------------
+    // Interoperability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the value wrapped in {@link Option#some(Object)}, or {@link Option#none()} if
+     * this accumulator was created by {@link #tell(Object)} and has no value.
+     *
+     * <p>The accumulation is discarded. Use this when only the presence or absence of a value
+     * matters, not the log:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("step 1"));
+     * acc.toOption();  // Some(42)
+     *
+     * Accumulator<List<String>, Void> tell = Accumulator.tell(List.of("entry"));
+     * tell.toOption(); // None
+     * }</pre>
+     *
+     * @return {@code Some(value)} when {@link #hasValue()} is {@code true}, or {@code None}
+     *         for {@link #tell(Object)} results
+     */
+    public Option<A> toOption() {
+        return value != null ? Option.some(value) : Option.none();
+    }
+
+    /**
+     * Converts this accumulator to a {@link Tuple2} of {@code (accumulated, value)}.
+     *
+     * <p>The accumulation occupies the first position ({@code _1}) and the value occupies
+     * the second ({@code _2}), following the Writer-monad unpacking convention.
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("step 1"));
+     * Tuple2<List<String>, Integer> pair = acc.toTuple2();
+     * pair._1();  // ["step 1"]
+     * pair._2();  // 42
+     * }</pre>
+     *
+     * @return a {@code Tuple2<E, A>} with accumulated as {@code _1} and value as {@code _2}
+     */
+    public Tuple2<E, @Nullable A> toTuple2() {
+        return new Tuple2<>(accumulated, value);
+    }
+}

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -23,6 +23,7 @@
  *   <li>{@link dmx.fun.NonEmptySet}  — set guaranteed to contain at least one element</li>
  *   <li>{@link dmx.fun.Guard}        — composable predicate blocks for Validated pipelines</li>
  *   <li>{@link dmx.fun.Resource}     — composable managed resource with guaranteed release</li>
+ *   <li>{@link dmx.fun.Accumulator}  — value paired with a side-channel accumulation (Writer monad)</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/AccumulatorTest.java
+++ b/lib/src/test/java/dmx/fun/AccumulatorTest.java
@@ -1,0 +1,570 @@
+package dmx.fun;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BinaryOperator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AccumulatorTest {
+
+    // Merge helper used throughout
+    static final BinaryOperator<List<String>> CONCAT = (a, b) -> {
+        var merged = new ArrayList<>(a);
+        merged.addAll(b);
+        return merged;
+    };
+
+    // -------------------------------------------------------------------------
+    // of — factory
+    // -------------------------------------------------------------------------
+
+    @Test
+    void of_storesValueAndAccumulated() {
+        var acc = Accumulator.of(42, List.of("step 1"));
+        assertThat(acc.value()).isEqualTo(42);
+        assertThat(acc.accumulated()).containsExactly("step 1");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenValueIsNull() {
+        assertThatThrownBy(() -> Accumulator.of(null, List.of()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("value");
+    }
+
+    @Test
+    void of_shouldThrowNPE_whenAccumulatedIsNull() {
+        assertThatThrownBy(() -> Accumulator.of(42, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("accumulated");
+    }
+
+    // -------------------------------------------------------------------------
+    // pure — factory
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pure_storesValueWithEmptyAccumulation() {
+        var acc = Accumulator.pure("hello", List.of());
+        assertThat(acc.value()).isEqualTo("hello");
+        assertThat(acc.accumulated()).isEmpty();
+    }
+
+    @Test
+    void pure_shouldThrowNPE_whenValueIsNull() {
+        assertThatThrownBy(() -> Accumulator.pure(null, List.of()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("value");
+    }
+
+    // -------------------------------------------------------------------------
+    // tell — factory
+    // -------------------------------------------------------------------------
+
+    @Test
+    void tell_accumulationIsSet_valueIsNull() {
+        var acc = Accumulator.tell(List.of("audit entry"));
+        assertThat(acc.value()).isNull();
+        assertThat(acc.accumulated()).containsExactly("audit entry");
+    }
+
+    @Test
+    void tell_hasValue_returnsFalse() {
+        var acc = Accumulator.tell(List.of("entry"));
+        assertThat(acc.hasValue()).isFalse();
+    }
+
+    @Test
+    void tell_shouldThrowNPE_whenAccumulatedIsNull() {
+        assertThatThrownBy(() -> Accumulator.tell(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("accumulated");
+    }
+
+    // -------------------------------------------------------------------------
+    // hasValue
+    // -------------------------------------------------------------------------
+
+    @Test
+    void hasValue_returnsTrueForOf() {
+        assertThat(Accumulator.of(1, List.of()).hasValue()).isTrue();
+    }
+
+    @Test
+    void hasValue_returnsTrueForPure() {
+        assertThat(Accumulator.pure("x", List.of()).hasValue()).isTrue();
+    }
+
+    @Test
+    void hasValue_returnsFalseForTell() {
+        assertThat(Accumulator.tell(List.of("e")).hasValue()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // map
+    // -------------------------------------------------------------------------
+
+    @Test
+    void map_transformsValue_accumulationUnchanged() {
+        var result = Accumulator.of(42, List.of("step 1")).map(Object::toString);
+        assertThat(result.value()).isEqualTo("42");
+        assertThat(result.accumulated()).containsExactly("step 1");
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenFunctionIsNull() {
+        assertThatThrownBy(() -> Accumulator.of(1, List.of()).map(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void map_onTell_shouldThrowNPE() {
+        var tell = Accumulator.tell(List.of("e"));
+        assertThatThrownBy(() -> tell.map(v -> v + "x"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void map_chain_accumulationCarriedThrough() {
+        var result = Accumulator.of(5, List.of("a"))
+            .map(v -> v * 2)
+            .map(v -> v + 1);
+        assertThat(result.value()).isEqualTo(11);
+        assertThat(result.accumulated()).containsExactly("a");
+    }
+
+    // -------------------------------------------------------------------------
+    // flatMap
+    // -------------------------------------------------------------------------
+
+    @Test
+    void flatMap_chainsValueAndMergesAccumulation() {
+        var result = Accumulator.of(10, List.of("step 1"))
+            .flatMap(v -> Accumulator.of(v * 2, List.of("step 2")), CONCAT);
+        assertThat(result.value()).isEqualTo(20);
+        assertThat(result.accumulated()).containsExactly("step 1", "step 2");
+    }
+
+    @Test
+    void flatMap_multipleSteps_accumulatesAll() {
+        var result = Accumulator.of(10, List.of("step 1"))
+            .flatMap(v -> Accumulator.of(v * 2, List.of("step 2")), CONCAT)
+            .flatMap(v -> Accumulator.of(v + 5, List.of("step 3")), CONCAT);
+        assertThat(result.value()).isEqualTo(25);
+        assertThat(result.accumulated()).containsExactly("step 1", "step 2", "step 3");
+    }
+
+    @Test
+    void flatMap_withNonEmptyList_mergesCorrectly() {
+        var result = Accumulator.of(1, NonEmptyList.of("a", List.of()))
+            .flatMap(v -> Accumulator.of(v + 1, NonEmptyList.of("b", List.of())), NonEmptyList::concat);
+        assertThat(result.value()).isEqualTo(2);
+        assertThat(result.accumulated().toList()).containsExactly("a", "b");
+    }
+
+    @Test
+    void flatMap_afterTell_producesValueAndMergedLog() {
+        var result = Accumulator.tell(List.of("pre-check"))
+            .flatMap(__ -> Accumulator.of(42, List.of("computed")), CONCAT);
+        assertThat(result.value()).isEqualTo(42);
+        assertThat(result.accumulated()).containsExactly("pre-check", "computed");
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenFunctionIsNull() {
+        Accumulator<List<String>, Integer> acc = Accumulator.of(1, List.of());
+        assertThatThrownBy(() -> acc.flatMap(null, CONCAT))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMergeIsNull() {
+        Accumulator<List<String>, Integer> acc = Accumulator.of(1, List.of());
+        assertThatThrownBy(() -> acc.flatMap(v -> Accumulator.of(v, List.of()), null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenFunctionReturnsNull() {
+        Accumulator<List<String>, Integer> acc = Accumulator.of(1, List.of());
+        assertThatThrownBy(() -> acc.flatMap(v -> null, CONCAT))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // mapAccumulated
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapAccumulated_transformsAccumulation_valueUnchanged() {
+        var result = Accumulator.of(42, List.of("a", "b", "c")).mapAccumulated(List::size);
+        assertThat(result.value()).isEqualTo(42);
+        assertThat(result.accumulated()).isEqualTo(3);
+    }
+
+    @Test
+    void mapAccumulated_shouldThrowNPE_whenFunctionIsNull() {
+        assertThatThrownBy(() -> Accumulator.of(1, List.of()).mapAccumulated(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapAccumulated_shouldThrowNPE_whenFunctionReturnsNull() {
+        assertThatThrownBy(() -> Accumulator.of(1, List.of("a")).mapAccumulated(l -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // toTuple2
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toTuple2_firstIsAccumulated_secondIsValue() {
+        var acc  = Accumulator.of(42, List.of("step 1"));
+        var pair = acc.toTuple2();
+        assertThat(pair._1()).containsExactly("step 1");
+        assertThat(pair._2()).isEqualTo(42);
+    }
+
+    @Test
+    void toTuple2_onTell_valueIsNull() {
+        var acc  = Accumulator.tell(List.of("entry"));
+        var pair = acc.toTuple2();
+        assertThat(pair._1()).containsExactly("entry");
+        assertThat(pair._2()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // record: equals, hashCode, toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void equals_sameValueAndAccumulation() {
+        var a = Accumulator.of(42, List.of("x"));
+        var b = Accumulator.of(42, List.of("x"));
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    void equals_differentValue_notEqual() {
+        var a = Accumulator.of(42, List.of("x"));
+        var b = Accumulator.of(99, List.of("x"));
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void hashCode_sameForEqualAccumulators() {
+        var a = Accumulator.of("hello", List.of("log"));
+        var b = Accumulator.of("hello", List.of("log"));
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void toString_containsValueAndAccumulated() {
+        var acc = Accumulator.of(42, List.of("step 1")).toString();
+        assertThat(acc).contains("42").contains("step 1");
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration — real-world audit chain
+    // -------------------------------------------------------------------------
+
+    @Test
+    void integration_orderProcessingChain_accumulatesAuditLog() {
+        record Order(String id, double total) {}
+
+        var result = Accumulator.of(new Order("ord-1", 95.00), List.of("order loaded"))
+            .flatMap(o -> {
+                double discounted = o.total() * 0.9;
+                return Accumulator.of(new Order(o.id(), discounted), List.of("10% discount applied"));
+            }, CONCAT)
+            .flatMap(o -> {
+                double taxed = o.total() * 1.07;
+                return Accumulator.of(new Order(o.id(), Math.round(taxed * 100.0) / 100.0), List.of("tax applied"));
+            }, CONCAT)
+            .map(o -> "Order " + o.id() + " total: " + o.total());
+
+        assertThat(result.value()).isEqualTo("Order ord-1 total: 91.49");
+        assertThat(result.accumulated())
+            .containsExactly("order loaded", "10% discount applied", "tax applied");
+    }
+
+    @Test
+    void integration_counterAccumulation() {
+        BinaryOperator<Integer> add = Integer::sum;
+
+        var result = Accumulator.of("alice", 0)
+            .flatMap(name -> Accumulator.of(name.toUpperCase(), 1), add)
+            .flatMap(name -> Accumulator.of(name + "!", 1), add);
+
+        assertThat(result.value()).isEqualTo("ALICE!");
+        assertThat(result.accumulated()).isEqualTo(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // combine
+    // -------------------------------------------------------------------------
+
+    @Test
+    void combine_mergesValuesAndAccumulations() {
+        var a = Accumulator.of("Alice", List.of("user loaded"));
+        var b = Accumulator.of(42,     List.of("score loaded"));
+
+        var result = a.combine(b, CONCAT, (name, score) -> name + ":" + score);
+
+        assertThat(result.value()).isEqualTo("Alice:42");
+        assertThat(result.accumulated()).containsExactly("user loaded", "score loaded");
+    }
+
+    @Test
+    void combine_shouldThrowNPE_whenOtherIsNull() {
+        Accumulator<List<String>, Integer> acc = Accumulator.of(1, List.of());
+        assertThatThrownBy(() -> acc.combine(null, CONCAT, Integer::sum))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void combine_shouldThrowNPE_whenMergeIsNull() {
+        Accumulator<List<String>, Integer> a = Accumulator.of(1, List.of());
+        Accumulator<List<String>, Integer> b = Accumulator.of(2, List.of());
+        assertThatThrownBy(() -> a.combine(b, null, Integer::sum))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void combine_shouldThrowNPE_whenFunctionIsNull() {
+        Accumulator<List<String>, Integer> a = Accumulator.of(1, List.of());
+        Accumulator<List<String>, Integer> b = Accumulator.of(2, List.of());
+        assertThatThrownBy(() -> a.<Integer, Integer>combine(b, CONCAT, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void combine_shouldThrowNPE_whenThisIsTell() {
+        Accumulator<List<String>, Void> tell = Accumulator.tell(List.of("entry"));
+        Accumulator<List<String>, Integer> other = Accumulator.of(42, List.of());
+        assertThatThrownBy(() -> tell.combine(other, CONCAT, (a, b) -> b))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void combine_shouldThrowNPE_whenOtherIsTell() {
+        Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of());
+        Accumulator<List<String>, Void> tell    = Accumulator.tell(List.of("entry"));
+        assertThatThrownBy(() -> acc.combine(tell, CONCAT, (a, b) -> a))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequence_foldsListIntoSingleAccumulator() {
+        var steps = List.of(
+            Accumulator.of(1, List.of("step A")),
+            Accumulator.of(2, List.of("step B")),
+            Accumulator.of(3, List.of("step C"))
+        );
+
+        var result = Accumulator.sequence(steps, CONCAT, List.of());
+
+        assertThat(result.value()).containsExactly(1, 2, 3);
+        assertThat(result.accumulated()).containsExactly("step A", "step B", "step C");
+    }
+
+    @Test
+    void sequence_emptyList_returnsEmptyValueAndEmptyAccumulation() {
+        var result = Accumulator.<List<String>, Integer>sequence(List.of(), CONCAT, List.of());
+        assertThat(result.value()).isEmpty();
+        assertThat(result.accumulated()).isEmpty();
+    }
+
+    @Test
+    void sequence_shouldThrowNPE_whenListIsNull() {
+        assertThatThrownBy(() -> Accumulator.<List<String>, Integer>sequence(null, CONCAT, List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void sequence_shouldThrowNPE_whenElementIsTell() {
+        // Use the canonical record constructor directly to put a null-value element in the list
+        // (mirrors the tell() case without the Void type mismatch)
+        var noValue = new Accumulator<List<String>, Integer>(null, List.of("tell — no value"));
+        List<Accumulator<List<String>, Integer>> steps = List.of(
+            Accumulator.of(1, List.of("ok")),
+            noValue
+        );
+        assertThatThrownBy(() -> Accumulator.sequence(steps, CONCAT, List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // toOption
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toOption_returnsSome_forOfAccumulator() {
+        var acc = Accumulator.of(42, List.of("log"));
+        assertThat(acc.toOption().isDefined()).isTrue();
+        assertThat(acc.toOption().get()).isEqualTo(42);
+    }
+
+    @Test
+    void toOption_returnsNone_forTellAccumulator() {
+        var acc = Accumulator.tell(List.of("log"));
+        assertThat(acc.toOption().isEmpty()).isTrue();
+    }
+
+    @Test
+    void toOption_discardsAccumulation() {
+        var acc = Accumulator.of("value", List.of("important log"));
+        Option<String> opt = acc.toOption();
+        assertThat(opt.get()).isEqualTo("value");
+        // accumulated is not accessible through Option — that's by design
+    }
+
+    // -------------------------------------------------------------------------
+    // liftOption
+    // -------------------------------------------------------------------------
+
+    @Test
+    void liftOption_some_appliesSomeLog() {
+        var result = Accumulator.liftOption(
+            Option.some("alice"),
+            name -> List.of("found: " + name),
+            List.of("not found")
+        );
+        assertThat(result.value()).isEqualTo(Option.some("alice"));
+        assertThat(result.accumulated()).containsExactly("found: alice");
+    }
+
+    @Test
+    void liftOption_none_usesNoneLog() {
+        var result = Accumulator.liftOption(
+            Option.<String>none(),
+            name -> List.of("found: " + name),
+            List.of("not found")
+        );
+        assertThat(result.value().isEmpty()).isTrue();
+        assertThat(result.accumulated()).containsExactly("not found");
+    }
+
+    @Test
+    void liftOption_shouldThrowNPE_whenOptionIsNull() {
+        assertThatThrownBy(() -> Accumulator.liftOption(null, v -> List.of(), List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftOption_shouldThrowNPE_whenSomeLogReturnsNull() {
+        assertThatThrownBy(() -> Accumulator.liftOption(Option.some("x"), v -> null, List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // liftTry
+    // -------------------------------------------------------------------------
+
+    @Test
+    void liftTry_success_appliesSuccessLog() {
+        var result = Accumulator.liftTry(
+            Try.success(42),
+            v  -> List.of("loaded: " + v),
+            ex -> List.of("failed: " + ex.getMessage())
+        );
+        assertThat(result.value().isSuccess()).isTrue();
+        assertThat(result.value().get()).isEqualTo(42);
+        assertThat(result.accumulated()).containsExactly("loaded: 42");
+    }
+
+    @Test
+    void liftTry_failure_appliesFailureLog() {
+        var ex = new RuntimeException("boom");
+        var result = Accumulator.liftTry(
+            Try.failure(ex),
+            v  -> List.of("loaded: " + v),
+            e  -> List.of("failed: " + e.getMessage())
+        );
+        assertThat(result.value().isFailure()).isTrue();
+        assertThat(result.accumulated()).containsExactly("failed: boom");
+    }
+
+    @Test
+    void liftTry_shouldThrowNPE_whenTryIsNull() {
+        assertThatThrownBy(() -> Accumulator.liftTry(null, v -> List.of(), ex -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftTry_shouldThrowNPE_whenSuccessLogReturnsNull() {
+        assertThatThrownBy(() -> Accumulator.liftTry(Try.success(1), v -> null, ex -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftTry_shouldThrowNPE_whenFailureLogReturnsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftTry(Try.failure(new RuntimeException()), v -> List.of(), ex -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration — combine + sequence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void integration_combineThreeAccumulators_viaPairwise() {
+        var a = Accumulator.of("Alice", List.of("user"));
+        var b = Accumulator.of(42,     List.of("score"));
+        var c = Accumulator.of(true,   List.of("active"));
+
+        var result = a
+            .combine(b, CONCAT, (name, score) -> name + "/" + score)
+            .combine(Accumulator.of(true, List.of("active")), CONCAT,
+                (nameScore, active) -> nameScore + "/" + active);
+
+        assertThat(result.value()).isEqualTo("Alice/42/true");
+        assertThat(result.accumulated()).containsExactly("user", "score", "active");
+
+        // suppress unused variable warning
+        var _ = c;
+    }
+
+    @Test
+    void integration_sequenceThenMap() {
+        var steps = List.of(
+            Accumulator.of(10, List.of("a")),
+            Accumulator.of(20, List.of("b")),
+            Accumulator.of(30, List.of("c"))
+        );
+
+        var result = Accumulator.sequence(steps, CONCAT, List.of())
+            .map(values -> values.stream().mapToInt(Integer::intValue).sum());
+
+        assertThat(result.value()).isEqualTo(60);
+        assertThat(result.accumulated()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void integration_liftOptionInChain() {
+        var concat = CONCAT;
+
+        var result = Accumulator.liftOption(
+                Option.some("config.yaml"),
+                path -> List.of("config path resolved: " + path),
+                List.of("config not found, using defaults")
+            )
+            .flatMap(opt -> opt.isDefined()
+                ? Accumulator.of(opt.get().toUpperCase(), List.of("path normalized"))
+                : Accumulator.of("DEFAULT", List.of("using default")),
+                concat);
+
+        assertThat(result.value()).isEqualTo("CONFIG.YAML");
+        assertThat(result.accumulated())
+            .containsExactly("config path resolved: config.yaml", "path normalized");
+    }
+}

--- a/lib/src/test/java/dmx/fun/AccumulatorTest.java
+++ b/lib/src/test/java/dmx/fun/AccumulatorTest.java
@@ -428,6 +428,26 @@ class AccumulatorTest {
     }
 
     // -------------------------------------------------------------------------
+    // toResult
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toResult_ofAccumulator_returnsOk() {
+        var acc = Accumulator.of(42, List.of("step 1"));
+        Result<Integer, List<String>> result = acc.toResult();
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get()).isEqualTo(42);
+    }
+
+    @Test
+    void toResult_tellAccumulator_returnsErr() {
+        var acc = Accumulator.tell(List.of("entry"));
+        Result<Void, List<String>> result = acc.toResult();
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).containsExactly("entry");
+    }
+
+    // -------------------------------------------------------------------------
     // liftOption
     // -------------------------------------------------------------------------
 
@@ -524,14 +544,10 @@ class AccumulatorTest {
 
         var result = a
             .combine(b, CONCAT, (name, score) -> name + "/" + score)
-            .combine(Accumulator.of(true, List.of("active")), CONCAT,
-                (nameScore, active) -> nameScore + "/" + active);
+            .combine(c, CONCAT, (nameScore, active) -> nameScore + "/" + active);
 
         assertThat(result.value()).isEqualTo("Alice/42/true");
         assertThat(result.accumulated()).containsExactly("user", "score", "active");
-
-        // suppress unused variable warning
-        var _ = c;
     }
 
     @Test

--- a/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java
+++ b/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java
@@ -1,0 +1,237 @@
+package dmx.fun.samples;
+
+import dmx.fun.Accumulator;
+import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Try;
+import dmx.fun.Tuple2;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BinaryOperator;
+
+/**
+ * Demonstrates Accumulator<E, A>: a computed value paired with a side-channel accumulation
+ * (log entries, metrics, audit trail). The functional alternative to mutable shared state
+ * for cross-cutting concerns.
+ */
+public class AccumulatorSample {
+
+    record Order(String id, double basePrice) {}
+    record PricedOrder(String id, double price, String currency) {}
+
+    static void main() {
+
+        // ---- Basic usage ----
+
+        System.out.println("=== Basic usage ===");
+
+        Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("computed answer"));
+        System.out.println("value:       " + acc.value());       // 42
+        System.out.println("accumulated: " + acc.accumulated()); // [computed answer]
+
+        // ---- pure — value with empty accumulation ----
+
+        System.out.println("\n=== pure (empty accumulation) ===");
+
+        Accumulator<List<String>, String> pure = Accumulator.pure("hello", List.of());
+        System.out.println("value:       " + pure.value());       // hello
+        System.out.println("accumulated: " + pure.accumulated()); // []
+
+        // ---- tell — record without producing a value ----
+
+        System.out.println("\n=== tell ===");
+
+        BinaryOperator<List<String>> concat = (a, b) -> {
+            var merged = new ArrayList<>(a);
+            merged.addAll(b);
+            return merged;
+        };
+
+        Accumulator<List<String>, Integer> fromTell =
+            Accumulator.tell(List.of("pre-check passed"))
+                .flatMap(__ -> Accumulator.of(42, List.of("value computed")), concat);
+
+        System.out.println("value:       " + fromTell.value());       // 42
+        System.out.println("accumulated: " + fromTell.accumulated()); // [pre-check passed, value computed]
+
+        // ---- map — transform value, accumulation unchanged ----
+
+        System.out.println("\n=== map ===");
+
+        Accumulator<List<String>, String> mapped =
+            Accumulator.of(42, List.of("original")).map(Object::toString);
+        System.out.println("value:       " + mapped.value());       // 42
+        System.out.println("accumulated: " + mapped.accumulated()); // [original]
+
+        // ---- flatMap — chain computations, merge accumulations ----
+
+        System.out.println("\n=== flatMap (chain) ===");
+
+        Accumulator<List<String>, Integer> chained =
+            Accumulator.of(10, List.of("step 1"))
+                .flatMap(v -> Accumulator.of(v * 2, List.of("step 2")), concat)
+                .flatMap(v -> Accumulator.of(v + 5, List.of("step 3")), concat);
+
+        System.out.println("value:       " + chained.value());        // 25
+        System.out.println("accumulated: " + chained.accumulated());  // [step 1, step 2, step 3]
+
+        // ---- flatMap — with NonEmptyList ----
+
+        System.out.println("\n=== flatMap (NonEmptyList accumulation) ===");
+
+        Accumulator<NonEmptyList<String>, Integer> nelChain =
+            Accumulator.of(1, NonEmptyList.of("a", List.of()))
+                .flatMap(v -> Accumulator.of(v + 1, NonEmptyList.of("b", List.of())), NonEmptyList::concat)
+                .flatMap(v -> Accumulator.of(v + 1, NonEmptyList.of("c", List.of())), NonEmptyList::concat);
+
+        System.out.println("value:       " + nelChain.value());                   // 3
+        System.out.println("accumulated: " + nelChain.accumulated().toList());    // [a, b, c]
+
+        // ---- mapAccumulated — transform the accumulation ----
+
+        System.out.println("\n=== mapAccumulated ===");
+
+        Accumulator<Integer, Integer> countOnly =
+            Accumulator.of(42, List.of("a", "b", "c")).mapAccumulated(List::size);
+        System.out.println("value:       " + countOnly.value());       // 42
+        System.out.println("accumulated: " + countOnly.accumulated()); // 3
+
+        // ---- toTuple2 — interop ----
+
+        System.out.println("\n=== toTuple2 ===");
+
+        Tuple2<List<String>, Integer> pair = chained.toTuple2();
+        System.out.println("_1 (accumulated): " + pair._1()); // [step 1, step 2, step 3]
+        System.out.println("_2 (value):       " + pair._2()); // 25
+
+        // ---- hasValue ----
+
+        System.out.println("\n=== hasValue ===");
+
+        System.out.println("of.hasValue():   " + Accumulator.of(1, List.of()).hasValue());    // true
+        System.out.println("tell.hasValue(): " + Accumulator.tell(List.of("x")).hasValue());  // false
+
+        // ---- Real-world: order pricing with audit trail ----
+
+        System.out.println("\n=== Real-world: order pricing audit ===");
+
+        Accumulator<List<String>, PricedOrder> priced =
+            Accumulator.of(new Order("ord-7", 100.0), List.of("order loaded"))
+                .flatMap(o -> {
+                    double discounted = o.basePrice() * 0.85;
+                    return Accumulator.of(
+                        new Order(o.id(), discounted),
+                        List.of("15% discount applied → " + discounted)
+                    );
+                }, concat)
+                .flatMap(o -> {
+                    double taxed = o.basePrice() * 1.21;
+                    return Accumulator.of(
+                        new PricedOrder(o.id(), Math.round(taxed * 100.0) / 100.0, "USD"),
+                        List.of("21% VAT applied → " + Math.round(taxed * 100.0) / 100.0)
+                    );
+                }, concat);
+
+        System.out.println("Result:  " + priced.value());
+        System.out.println("Audit trail:");
+        priced.accumulated().forEach(entry -> System.out.println("  - " + entry));
+        // Result:  PricedOrder[id=ord-7, price=102.85, currency=USD]
+        // Audit trail:
+        //   - order loaded
+        //   - 15% discount applied → 85.0
+        //   - 21% VAT applied → 102.85
+
+        // ---- Real-world: counter accumulation ----
+
+        // ---- combine — independent accumulators ----
+
+        System.out.println("\n=== combine ===");
+
+        Accumulator<List<String>, String>  userAcc  = Accumulator.of("Alice", List.of("user loaded"));
+        Accumulator<List<String>, Integer> scoreAcc = Accumulator.of(98,      List.of("score loaded"));
+
+        Accumulator<List<String>, String> dashboard = userAcc.combine(scoreAcc, concat,
+            (name, score) -> name + " — score: " + score);
+
+        System.out.println("value:       " + dashboard.value());       // Alice — score: 98
+        System.out.println("accumulated: " + dashboard.accumulated()); // [user loaded, score loaded]
+
+        // ---- sequence — fold a list of accumulators ----
+
+        System.out.println("\n=== sequence ===");
+
+        var steps = List.of(
+            Accumulator.of(10, List.of("step A")),
+            Accumulator.of(20, List.of("step B")),
+            Accumulator.of(30, List.of("step C"))
+        );
+
+        Accumulator<List<String>, List<Integer>> seqResult =
+            Accumulator.sequence(steps, concat, List.of());
+
+        System.out.println("value:       " + seqResult.value());       // [10, 20, 30]
+        System.out.println("accumulated: " + seqResult.accumulated()); // [step A, step B, step C]
+
+        // ---- toOption ----
+
+        System.out.println("\n=== toOption ===");
+
+        System.out.println("of.toOption():   " + Accumulator.of(42, List.of()).toOption());    // Some(42)
+        System.out.println("tell.toOption(): " + Accumulator.tell(List.of("x")).toOption());   // None
+
+        // ---- liftOption — log presence/absence ----
+
+        System.out.println("\n=== liftOption ===");
+
+        Accumulator<List<String>, Option<String>> optFound = Accumulator.liftOption(
+            Option.some("config.yaml"),
+            path -> List.of("config found: " + path),
+            List.of("config not found, using defaults")
+        );
+        System.out.println("value:       " + optFound.value());       // Some(config.yaml)
+        System.out.println("accumulated: " + optFound.accumulated()); // [config found: config.yaml]
+
+        Accumulator<List<String>, Option<String>> optMissing = Accumulator.liftOption(
+            Option.none(),
+            path -> List.of("config found: " + path),
+            List.of("config not found, using defaults")
+        );
+        System.out.println("value:       " + optMissing.value());       // None
+        System.out.println("accumulated: " + optMissing.accumulated()); // [config not found, using defaults]
+
+        // ---- liftTry — log success/failure ----
+
+        System.out.println("\n=== liftTry ===");
+
+        Accumulator<List<String>, Try<Integer>> tryOk = Accumulator.liftTry(
+            Try.of(() -> Integer.parseInt("42")),
+            v  -> List.of("parsed: " + v),
+            ex -> List.of("parse failed: " + ex.getMessage())
+        );
+        System.out.println("value:       " + tryOk.value());       // Success(42)
+        System.out.println("accumulated: " + tryOk.accumulated()); // [parsed: 42]
+
+        Accumulator<List<String>, Try<Integer>> tryFail = Accumulator.liftTry(
+            Try.of(() -> Integer.parseInt("not-a-number")),
+            v  -> List.of("parsed: " + v),
+            ex -> List.of("parse failed: " + ex.getMessage())
+        );
+        System.out.println("value.isFailure: " + tryFail.value().isFailure());  // true
+        System.out.println("accumulated:     " + tryFail.accumulated());        // [parse failed: ...]
+
+        // ---- Real-world: step counter ----
+
+        System.out.println("\n=== Real-world: step counter ===");
+
+        BinaryOperator<Integer> add = Integer::sum;
+
+        Accumulator<Integer, String> processed =
+            Accumulator.pure("raw input", 0)
+                .flatMap(s -> Accumulator.of(s.trim(), 1), add)
+                .flatMap(s -> Accumulator.of(s.toUpperCase(), 1), add)
+                .flatMap(s -> Accumulator.of("[" + s + "]", 1), add);
+
+        System.out.println("value:  " + processed.value());       // [RAW INPUT]
+        System.out.println("steps:  " + processed.accumulated()); // 3
+    }
+}

--- a/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java
+++ b/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java
@@ -3,8 +3,11 @@ package dmx.fun.samples;
 import dmx.fun.Accumulator;
 import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
+import dmx.fun.Result;
 import dmx.fun.Try;
 import dmx.fun.Tuple2;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BinaryOperator;
@@ -16,8 +19,8 @@ import java.util.function.BinaryOperator;
  */
 public class AccumulatorSample {
 
-    record Order(String id, double basePrice) {}
-    record PricedOrder(String id, double price, String currency) {}
+    record Order(String id, BigDecimal basePrice) {}
+    record PricedOrder(String id, BigDecimal price, String currency) {}
 
     static void main() {
 
@@ -116,19 +119,21 @@ public class AccumulatorSample {
         System.out.println("\n=== Real-world: order pricing audit ===");
 
         Accumulator<List<String>, PricedOrder> priced =
-            Accumulator.of(new Order("ord-7", 100.0), List.of("order loaded"))
+            Accumulator.of(new Order("ord-7", BigDecimal.valueOf(100.0)), List.of("order loaded"))
                 .flatMap(o -> {
-                    double discounted = o.basePrice() * 0.85;
+                    BigDecimal discounted = o.basePrice().multiply(BigDecimal.valueOf(0.85));
                     return Accumulator.of(
                         new Order(o.id(), discounted),
                         List.of("15% discount applied → " + discounted)
                     );
                 }, concat)
                 .flatMap(o -> {
-                    double taxed = o.basePrice() * 1.21;
+                    BigDecimal taxed = o.basePrice()
+                        .multiply(BigDecimal.valueOf(1.21))
+                        .setScale(2, RoundingMode.HALF_UP);
                     return Accumulator.of(
-                        new PricedOrder(o.id(), Math.round(taxed * 100.0) / 100.0, "USD"),
-                        List.of("21% VAT applied → " + Math.round(taxed * 100.0) / 100.0)
+                        new PricedOrder(o.id(), taxed, "USD"),
+                        List.of("21% VAT applied → " + taxed)
                     );
                 }, concat);
 
@@ -138,7 +143,7 @@ public class AccumulatorSample {
         // Result:  PricedOrder[id=ord-7, price=102.85, currency=USD]
         // Audit trail:
         //   - order loaded
-        //   - 15% discount applied → 85.0
+        //   - 15% discount applied → 85.00
         //   - 21% VAT applied → 102.85
 
         // ---- Real-world: counter accumulation ----
@@ -178,6 +183,16 @@ public class AccumulatorSample {
 
         System.out.println("of.toOption():   " + Accumulator.of(42, List.of()).toOption());    // Some(42)
         System.out.println("tell.toOption(): " + Accumulator.tell(List.of("x")).toOption());   // None
+
+        // ---- toResult — convert to Result ----
+
+        System.out.println("\n=== toResult ===");
+
+        Result<Integer, List<String>> okResult = Accumulator.of(42, List.of("step")).toResult();
+        System.out.println("of.toResult():   " + okResult);  // Ok(42)
+
+        Result<Void, List<String>> errResult = Accumulator.tell(List.of("only log")).toResult();
+        System.out.println("tell.toResult(): " + errResult); // Err([only log])
 
         // ---- liftOption — log presence/absence ----
 

--- a/site/src/data/code/guide/accumulator/flat-map.mdx
+++ b/site/src/data/code/guide/accumulator/flat-map.mdx
@@ -1,0 +1,28 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+BinaryOperator<List<String>> concat = (a, b) -> {
+    var merged = new ArrayList<>(a);
+    merged.addAll(b);
+    return merged;
+};
+
+Accumulator<List<String>, Integer> result =
+    Accumulator.of(10, List.of("step 1"))
+        .flatMap(v -> Accumulator.of(v * 2, List.of("step 2")), concat)
+        .flatMap(v -> Accumulator.of(v + 5, List.of("step 3")), concat);
+
+result.value();        // 25
+result.accumulated();  // ["step 1", "step 2", "step 3"]
+
+// With NonEmptyList — mirrors the Validated error accumulation pattern
+Accumulator<NonEmptyList<String>, Integer> nel =
+    Accumulator.of(1, NonEmptyList.of("a", List.of()))
+        .flatMap(v -> Accumulator.of(v + 1, NonEmptyList.of("b", List.of())), NonEmptyList::concat)
+        .flatMap(v -> Accumulator.of(v + 1, NonEmptyList.of("c", List.of())), NonEmptyList::concat);
+
+nel.value();                   // 3
+nel.accumulated().toList();    // ["a", "b", "c"]
+```

--- a/site/src/data/code/guide/accumulator/interop.mdx
+++ b/site/src/data/code/guide/accumulator/interop.mdx
@@ -1,0 +1,59 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+BinaryOperator<List<String>> concat = (a, b) -> {
+    var merged = new ArrayList<>(a);
+    merged.addAll(b);
+    return merged;
+};
+
+// ---- combine — two independent accumulators ----
+
+Accumulator<List<String>, String>  userAcc  = fetchUser(id);    // ("Alice", ["user loaded"])
+Accumulator<List<String>, Integer> scoreAcc = fetchScore(id);   // (98, ["score loaded"])
+
+Accumulator<List<String>, String> dashboard =
+    userAcc.combine(scoreAcc, concat, (name, score) -> name + " — score: " + score);
+
+dashboard.value();        // "Alice — score: 98"
+dashboard.accumulated();  // ["user loaded", "score loaded"]
+
+// ---- sequence — fold a list ----
+
+List<Accumulator<List<String>, Integer>> steps = List.of(
+    Accumulator.of(10, List.of("step A")),
+    Accumulator.of(20, List.of("step B")),
+    Accumulator.of(30, List.of("step C"))
+);
+
+Accumulator<List<String>, List<Integer>> all = Accumulator.sequence(steps, concat, List.of());
+all.value();        // [10, 20, 30]
+all.accumulated();  // ["step A", "step B", "step C"]
+
+// ---- toOption — discard accumulation ----
+
+Accumulator.of(42, List.of("log")).toOption();    // Some(42)
+Accumulator.tell(List.of("entry")).toOption();    // None
+
+// ---- liftOption — log present / absent paths ----
+
+Accumulator<List<String>, Option<String>> acc = Accumulator.liftOption(
+    userRepo.findName(id),
+    name -> List.of("found: " + name),       // called when Some
+    List.of("not found")                     // used when None
+);
+// Some("Alice") → ("Some(Alice)", ["found: Alice"])
+// None          → ("None",        ["not found"])
+
+// ---- liftTry — log success / failure ----
+
+Accumulator<List<String>, Try<Config>> loaded = Accumulator.liftTry(
+    Try.of(() -> ConfigLoader.load(path)),
+    cfg -> List.of("config loaded from " + path),
+    ex  -> List.of("config load failed: " + ex.getMessage())
+);
+loaded.accumulated();  // always set — success or failure
+loaded.value();        // Try<Config> — caller decides what to do with it
+```

--- a/site/src/data/code/guide/accumulator/map-accumulated.mdx
+++ b/site/src/data/code/guide/accumulator/map-accumulated.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// map — transform the value, accumulation unchanged
+Accumulator<List<String>, String> str =
+    Accumulator.of(42, List.of("step 1")).map(Object::toString);
+
+str.value();        // "42"
+str.accumulated();  // ["step 1"]
+
+// mapAccumulated — transform the accumulation, value unchanged
+Accumulator<Integer, Integer> countOnly =
+    Accumulator.of(42, List.of("a", "b", "c")).mapAccumulated(List::size);
+
+countOnly.value();        // 42
+countOnly.accumulated();  // 3
+```

--- a/site/src/data/code/guide/accumulator/of-pure-tell.mdx
+++ b/site/src/data/code/guide/accumulator/of-pure-tell.mdx
@@ -1,0 +1,29 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+BinaryOperator<List<String>> concat = (a, b) -> {
+    var merged = new ArrayList<>(a);
+    merged.addAll(b);
+    return merged;
+};
+
+// of — value + initial accumulation
+Accumulator<List<String>, Integer> a = Accumulator.of(42, List.of("computed answer"));
+a.value();        // 42
+a.accumulated();  // ["computed answer"]
+
+// pure — value with empty accumulation (caller provides the empty)
+Accumulator<List<String>, Integer> p = Accumulator.pure(42, List.of());
+p.value();        // 42
+p.accumulated();  // []
+
+// tell — record without producing a value
+Accumulator<List<String>, Integer> t =
+    Accumulator.tell(List.of("pre-check passed"))
+        .flatMap(__ -> Accumulator.of(42, List.of("value computed")), concat);
+
+t.value();        // 42
+t.accumulated();  // ["pre-check passed", "value computed"]
+```

--- a/site/src/data/code/guide/accumulator/real-world-example.mdx
+++ b/site/src/data/code/guide/accumulator/real-world-example.mdx
@@ -3,8 +3,11 @@ fileName: 'Demo.java'
 ---
 
 ```java
-record Order(String id, double basePrice) {}
-record PricedOrder(String id, double price, String currency) {}
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+record Order(String id, BigDecimal basePrice) {}
+record PricedOrder(String id, BigDecimal price, String currency) {}
 
 BinaryOperator<List<String>> concat = (a, b) -> {
     var merged = new ArrayList<>(a);
@@ -13,19 +16,21 @@ BinaryOperator<List<String>> concat = (a, b) -> {
 };
 
 Accumulator<List<String>, PricedOrder> priced =
-    Accumulator.of(new Order("ord-7", 100.0), List.of("order loaded"))
+    Accumulator.of(new Order("ord-7", BigDecimal.valueOf(100.0)), List.of("order loaded"))
         .flatMap(o -> {
-            double discounted = o.basePrice() * 0.85;
+            BigDecimal discounted = o.basePrice().multiply(BigDecimal.valueOf(0.85));
             return Accumulator.of(
                 new Order(o.id(), discounted),
                 List.of("15% discount applied → " + discounted)
             );
         }, concat)
         .flatMap(o -> {
-            double taxed = o.basePrice() * 1.21;
+            BigDecimal taxed = o.basePrice()
+                .multiply(BigDecimal.valueOf(1.21))
+                .setScale(2, RoundingMode.HALF_UP);
             return Accumulator.of(
-                new PricedOrder(o.id(), Math.round(taxed * 100.0) / 100.0, "USD"),
-                List.of("21% VAT applied → " + Math.round(taxed * 100.0) / 100.0)
+                new PricedOrder(o.id(), taxed, "USD"),
+                List.of("21% VAT applied → " + taxed)
             );
         }, concat);
 
@@ -34,6 +39,6 @@ System.out.println(priced.value());
 
 priced.accumulated().forEach(e -> System.out.println("  - " + e));
 // - order loaded
-// - 15% discount applied → 85.0
+// - 15% discount applied → 85.00
 // - 21% VAT applied → 102.85
 ```

--- a/site/src/data/code/guide/accumulator/real-world-example.mdx
+++ b/site/src/data/code/guide/accumulator/real-world-example.mdx
@@ -1,0 +1,39 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+record Order(String id, double basePrice) {}
+record PricedOrder(String id, double price, String currency) {}
+
+BinaryOperator<List<String>> concat = (a, b) -> {
+    var merged = new ArrayList<>(a);
+    merged.addAll(b);
+    return merged;
+};
+
+Accumulator<List<String>, PricedOrder> priced =
+    Accumulator.of(new Order("ord-7", 100.0), List.of("order loaded"))
+        .flatMap(o -> {
+            double discounted = o.basePrice() * 0.85;
+            return Accumulator.of(
+                new Order(o.id(), discounted),
+                List.of("15% discount applied → " + discounted)
+            );
+        }, concat)
+        .flatMap(o -> {
+            double taxed = o.basePrice() * 1.21;
+            return Accumulator.of(
+                new PricedOrder(o.id(), Math.round(taxed * 100.0) / 100.0, "USD"),
+                List.of("21% VAT applied → " + Math.round(taxed * 100.0) / 100.0)
+            );
+        }, concat);
+
+System.out.println(priced.value());
+// PricedOrder[id=ord-7, price=102.85, currency=USD]
+
+priced.accumulated().forEach(e -> System.out.println("  - " + e));
+// - order loaded
+// - 15% discount applied → 85.0
+// - 21% VAT applied → 102.85
+```

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -1,0 +1,124 @@
+---
+title: "Accumulator<E, A> — Developer Guide"
+description: "Comprehensive guide to Accumulator<E, A>: threading a side-channel accumulation (log, metrics, audit trail) through a computation chain without shared mutable state."
+order: 12
+h1: "Accumulator<E, A>"
+---
+
+import {Content as OfPureTell}        from '../code/guide/accumulator/of-pure-tell.mdx';
+import {Content as FlatMap}           from '../code/guide/accumulator/flat-map.mdx';
+import {Content as MapAccumulated}    from '../code/guide/accumulator/map-accumulated.mdx';
+import {Content as Interop}           from '../code/guide/accumulator/interop.mdx';
+import {Content as RealWorldExample}  from '../code/guide/accumulator/real-world-example.mdx';
+
+> **Runnable example:** [`AccumulatorSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java)
+
+## What is Accumulator&lt;E, A&gt;?
+
+`Accumulator<E, A>` pairs a computed value `A` with a side-channel accumulation `E`
+(log entries, metrics, warnings, audit trail). It is the functional alternative to mutable
+global state for cross-cutting concerns:
+
+- Instead of calling `logger.info(...)` inside a method body, return the log entries as part of the result.
+- Instead of incrementing a shared counter, accumulate a count alongside the value.
+- Instead of writing to an audit log as a side effect, thread audit events through the return type.
+
+The key invariant: **accumulation always continues**. Unlike [`Result`](result) or
+[`Try`](try), there is no failure path — every step contributes to both the value and
+the accumulation. This makes `Accumulator` unsuitable for error handling (use
+[`Result`](result) for that) and ideal for scenarios where every step always produces
+something, but you also want a trace of what happened along the way.
+
+This type is sometimes called the **Writer monad** in functional programming literature.
+
+## Factories
+
+<OfPureTell/>
+
+**Summary:**
+
+| Factory | Value | Accumulated |
+|---|---|---|
+| `Accumulator.of(value, log)` | provided | provided |
+| `Accumulator.pure(value, empty)` | provided | empty (identity) |
+| `Accumulator.tell(log)` | `null` (`Void`) | provided |
+
+For `pure`, the caller provides the empty / identity value because Java does not have type
+classes. Common choices: `List.of()`, `0`, `""`, `NonEmptyList` with a starting element.
+
+For `tell`, the value is always `null`. Call `hasValue()` to distinguish `tell` results
+from `of`/`pure` results. Do **not** call `map` on a `tell` result — use `flatMap` to
+produce a real value first.
+
+## `flatMap` — chain and merge
+
+`flatMap` is the primary composition combinator. It:
+
+1. Passes the current value to `f`.
+2. Gets back the next `Accumulator<E, B>`.
+3. Merges the two accumulations using the provided `BinaryOperator<E>`.
+
+<FlatMap/>
+
+The merge function determines how accumulations combine. Common choices:
+
+| Accumulation type | Merge function |
+|---|---|
+| `List<T>` | list concatenation (new list + addAll) |
+| `NonEmptyList<T>` | `NonEmptyList::concat` |
+| `int` / `long` | `Integer::sum` / `Long::sum` |
+| `String` | `String::concat` or `(a, b) -> a + "\n" + b` |
+
+## `map` and `mapAccumulated`
+
+<MapAccumulated/>
+
+Use `map` for pure value transformations where the accumulation is unchanged.
+Use `mapAccumulated` to convert between accumulation types — for example, to count
+log entries (`List::size`) or to convert raw strings to structured event objects.
+
+## Interoperability
+
+<Interop/>
+
+| Method / Factory | Returns | Use case |
+|---|---|---|
+| `combine(other, merge, f)` | `Accumulator<E, C>` | Combine two independent accumulators; both logs merged |
+| `sequence(list, merge, empty)` | `Accumulator<E, List<A>>` | Fold a list of accumulators into one |
+| `toOption()` | `Option<A>` | Extract value as Option; `None` for `tell` results; accumulation discarded |
+| `liftOption(opt, someLog, noneLog)` | `Accumulator<E, Option<A>>` | Log the presence or absence of an Option value |
+| `liftTry(t, successLog, failureLog)` | `Accumulator<E, Try<A>>` | Log the success or failure of a Try; the Try itself is the value |
+| `toTuple2()` | `Tuple2<E, A>` | Structural decomposition; `_1` is accumulated, `_2` is value |
+| `hasValue()` | `boolean` | Distinguish `of`/`pure` results from `tell` results |
+| `value()` | `@Nullable A` | Extract the value; `null` for `tell` results |
+| `accumulated()` | `E` | Extract the accumulation; always non-null |
+
+## Real-world example
+
+Pricing pipeline that threads an audit log through each transformation step:
+
+<RealWorldExample/>
+
+Every method in the pipeline is a pure function: no logger injection, no shared state,
+no side effects. The audit log is assembled as a first-class value alongside the result.
+The caller decides what to do with it — print it, persist it, or discard it.
+
+## When to use Accumulator
+
+| Scenario | Right tool |
+|---|---|
+| Record log entries alongside a computation | `Accumulator<List<String>, T>` |
+| Count steps or operations without a counter field | `Accumulator<Integer, T>` |
+| Thread domain audit events through a pipeline | `Accumulator<NonEmptyList<AuditEvent>, T>` |
+| Collect warnings without aborting the computation | `Accumulator<List<Warning>, T>` |
+| A step can fail — caller needs error handling | [`Result<T, E>`](result) instead |
+| Multiple independent validations accumulating errors | [`Validated<E, A>`](validated) instead |
+
+## Accumulator vs Result vs Validated
+
+|                        | `Accumulator<E, A>`      | `Result<V, E>`             | `Validated<E, A>`         |
+|------------------------|--------------------------|----------------------------|---------------------------|
+| Always succeeds?       | Yes                      | No — can be `Err`          | No — can be `Invalid`     |
+| Accumulates per step?  | Yes — always             | No — stops at first error  | Yes — collects all errors |
+| Accumulation purpose   | Side-channel (log, trace)| Error reporting             | Validation errors          |
+| Composition            | `flatMap` + merge        | `flatMap` (short-circuit)  | `combine` (parallel)       |

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -37,11 +37,11 @@ This type is sometimes called the **Writer monad** in functional programming lit
 
 **Summary:**
 
-| Factory | Value | Accumulated |
-|---|---|---|
-| `Accumulator.of(value, log)` | provided | provided |
-| `Accumulator.pure(value, empty)` | provided | empty (identity) |
-| `Accumulator.tell(log)` | `null` (`Void`) | provided |
+| Factory                          | Value           | Accumulated      |
+|----------------------------------|-----------------|------------------|
+| `Accumulator.of(value, log)`     | provided        | provided         |
+| `Accumulator.pure(value, empty)` | provided        | empty (identity) |
+| `Accumulator.tell(log)`          | `null` (`Void`) | provided         |
 
 For `pure`, the caller provides the empty / identity value because Java does not have type
 classes. Common choices: `List.of()`, `0`, `""`, `NonEmptyList` with a starting element.
@@ -62,12 +62,12 @@ produce a real value first.
 
 The merge function determines how accumulations combine. Common choices:
 
-| Accumulation type | Merge function |
-|---|---|
-| `List<T>` | list concatenation (new list + addAll) |
-| `NonEmptyList<T>` | `NonEmptyList::concat` |
-| `int` / `long` | `Integer::sum` / `Long::sum` |
-| `String` | `String::concat` or `(a, b) -> a + "\n" + b` |
+| Accumulation type | Merge function                               |
+|-------------------|----------------------------------------------|
+| `List<T>`         | list concatenation (new list + addAll)       |
+| `NonEmptyList<T>` | `NonEmptyList::concat`                       |
+| `int` / `long`    | `Integer::sum` / `Long::sum`                 |
+| `String`          | `String::concat` or `(a, b) -> a + "\n" + b` |
 
 ## `map` and `mapAccumulated`
 
@@ -81,17 +81,17 @@ log entries (`List::size`) or to convert raw strings to structured event objects
 
 <Interop/>
 
-| Method / Factory | Returns | Use case |
-|---|---|---|
-| `combine(other, merge, f)` | `Accumulator<E, C>` | Combine two independent accumulators; both logs merged |
-| `sequence(list, merge, empty)` | `Accumulator<E, List<A>>` | Fold a list of accumulators into one |
-| `toOption()` | `Option<A>` | Extract value as Option; `None` for `tell` results; accumulation discarded |
-| `liftOption(opt, someLog, noneLog)` | `Accumulator<E, Option<A>>` | Log the presence or absence of an Option value |
-| `liftTry(t, successLog, failureLog)` | `Accumulator<E, Try<A>>` | Log the success or failure of a Try; the Try itself is the value |
-| `toTuple2()` | `Tuple2<E, A>` | Structural decomposition; `_1` is accumulated, `_2` is value |
-| `hasValue()` | `boolean` | Distinguish `of`/`pure` results from `tell` results |
-| `value()` | `@Nullable A` | Extract the value; `null` for `tell` results |
-| `accumulated()` | `E` | Extract the accumulation; always non-null |
+| Method / Factory                     | Returns                     | Use case                                                                   |
+|--------------------------------------|-----------------------------|----------------------------------------------------------------------------|
+| `combine(other, merge, f)`           | `Accumulator<E, C>`         | Combine two independent accumulators; both logs merged                     |
+| `sequence(list, merge, empty)`       | `Accumulator<E, List<A>>`   | Fold a list of accumulators into one                                       |
+| `toOption()`                         | `Option<A>`                 | Extract value as Option; `None` for `tell` results; accumulation discarded |
+| `liftOption(opt, someLog, noneLog)`  | `Accumulator<E, Option<A>>` | Log the presence or absence of an Option value                             |
+| `liftTry(t, successLog, failureLog)` | `Accumulator<E, Try<A>>`    | Log the success or failure of a Try; the Try itself is the value           |
+| `toTuple2()`                         | `Tuple2<E, A>`              | Structural decomposition; `_1` is accumulated, `_2` is value               |
+| `hasValue()`                         | `boolean`                   | Distinguish `of`/`pure` results from `tell` results                        |
+| `value()`                            | `@Nullable A`               | Extract the value; `null` for `tell` results                               |
+| `accumulated()`                      | `E`                         | Extract the accumulation; always non-null                                  |
 
 ## Real-world example
 
@@ -105,20 +105,20 @@ The caller decides what to do with it — print it, persist it, or discard it.
 
 ## When to use Accumulator
 
-| Scenario | Right tool |
-|---|---|
-| Record log entries alongside a computation | `Accumulator<List<String>, T>` |
-| Count steps or operations without a counter field | `Accumulator<Integer, T>` |
-| Thread domain audit events through a pipeline | `Accumulator<NonEmptyList<AuditEvent>, T>` |
-| Collect warnings without aborting the computation | `Accumulator<List<Warning>, T>` |
-| A step can fail — caller needs error handling | [`Result<T, E>`](result) instead |
-| Multiple independent validations accumulating errors | [`Validated<E, A>`](validated) instead |
+| Scenario                                             | Right tool                                 |
+|------------------------------------------------------|--------------------------------------------|
+| Record log entries alongside a computation           | `Accumulator<List<String>, T>`             |
+| Count steps or operations without a counter field    | `Accumulator<Integer, T>`                  |
+| Thread domain audit events through a pipeline        | `Accumulator<NonEmptyList<AuditEvent>, T>` |
+| Collect warnings without aborting the computation    | `Accumulator<List<Warning>, T>`            |
+| A step can fail — caller needs error handling        | [`Result<T, E>`](result) instead           |
+| Multiple independent validations accumulating errors | [`Validated<E, A>`](validated) instead     |
 
 ## Accumulator vs Result vs Validated
 
-|                        | `Accumulator<E, A>`      | `Result<V, E>`             | `Validated<E, A>`         |
-|------------------------|--------------------------|----------------------------|---------------------------|
-| Always succeeds?       | Yes                      | No — can be `Err`          | No — can be `Invalid`     |
-| Accumulates per step?  | Yes — always             | No — stops at first error  | Yes — collects all errors |
-| Accumulation purpose   | Side-channel (log, trace)| Error reporting             | Validation errors          |
-| Composition            | `flatMap` + merge        | `flatMap` (short-circuit)  | `combine` (parallel)       |
+|                       | `Accumulator<E, A>`       | `Result<V, E>`            | `Validated<E, A>`         |
+|-----------------------|---------------------------|---------------------------|---------------------------|
+| Always succeeds?      | Yes                       | No — can be `Err`         | No — can be `Invalid`     |
+| Accumulates per step? | Yes — always              | No — stops at first error | Yes — collects all errors |
+| Accumulation purpose  | Side-channel (log, trace) | Error reporting           | Validation errors         |
+| Composition           | `flatMap` + merge         | `flatMap` (short-circuit) | `combine` (parallel)      |

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -44,7 +44,7 @@ This type is sometimes called the **Writer monad** in functional programming lit
 | `Accumulator.tell(log)`          | `null` (`Void`) | provided         |
 
 For `pure`, the caller provides the empty / identity value because Java does not have type
-classes. Common choices: `List.of()`, `0`, `""`, `NonEmptyList` with a starting element.
+classes. Common choices: `List.of()`, `0`, `""`.
 
 For `tell`, the value is always `null`. Call `hasValue()` to distinguish `tell` results
 from `of`/`pure` results. Do **not** call `map` on a `tell` result — use `flatMap` to
@@ -88,6 +88,7 @@ log entries (`List::size`) or to convert raw strings to structured event objects
 | `toOption()`                         | `Option<A>`                 | Extract value as Option; `None` for `tell` results; accumulation discarded |
 | `liftOption(opt, someLog, noneLog)`  | `Accumulator<E, Option<A>>` | Log the presence or absence of an Option value                             |
 | `liftTry(t, successLog, failureLog)` | `Accumulator<E, Try<A>>`    | Log the success or failure of a Try; the Try itself is the value           |
+| `toResult()`                         | `Result<A, E>`              | `Ok(value)` when has value; `Err(accumulated)` for `tell` results          |
 | `toTuple2()`                         | `Tuple2<E, A>`              | Structural decomposition; `_1` is accumulated, `_2` is value               |
 | `hasValue()`                         | `boolean`                   | Distinguish `of`/`pure` results from `tell` results                        |
 | `value()`                            | `@Nullable A`               | Extract the value; `null` for `tell` results                               |

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -44,14 +44,14 @@ in the same test class without naming conflict, because the argument types diffe
 
 ## Assertions reference
 
-| Type | Methods |
-|------|---------|
-| `Option<T>` | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)` |
-| `Result<V, E>` | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)` |
-| `Try<V>` | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)` |
-| `Validated<E, A>` | `isValid()`, `isInvalid()`, `containsValue(expected)`, `hasError(expected)` |
-| `Tuple2<A, B>` | `hasFirst(expected)`, `hasSecond(expected)` |
-| `Tuple3<A, B, C>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)` |
+| Type                 | Methods                                                                                  |
+|----------------------|------------------------------------------------------------------------------------------|
+| `Option<T>`          | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)`        |
+| `Result<V, E>`       | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)`                |
+| `Try<V>`             | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)`      |
+| `Validated<E, A>`    | `isValid()`, `isInvalid()`, `containsValue(expected)`, `hasError(expected)`              |
+| `Tuple2<A, B>`       | `hasFirst(expected)`, `hasSecond(expected)`                                              |
+| `Tuple3<A, B, C>`    | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`                        |
 | `Tuple4<A, B, C, D>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`, `hasFourth(expected)` |
 
 ## `Option<T>` assertions

--- a/site/src/data/guide/checked-interfaces.mdx
+++ b/site/src/data/guide/checked-interfaces.mdx
@@ -27,12 +27,12 @@ so that throwing method references can be used directly.
 
 ## Checked functional interfaces
 
-| Interface                  | Checked equivalent of     | Signature                          |
-|----------------------------|---------------------------|------------------------------------|
-| `CheckedFunction<T, R>`    | `Function<T, R>`          | `R apply(T t) throws Exception`    |
-| `CheckedSupplier<T>`       | `Supplier<T>`             | `T get() throws Exception`         |
-| `CheckedConsumer<T>`       | `Consumer<T>`             | `void accept(T t) throws Exception`|
-| `CheckedRunnable`          | `Runnable`                | `void run() throws Exception`      |
+| Interface               | Checked equivalent of | Signature                           |
+|-------------------------|-----------------------|-------------------------------------|
+| `CheckedFunction<T, R>` | `Function<T, R>`      | `R apply(T t) throws Exception`     |
+| `CheckedSupplier<T>`    | `Supplier<T>`         | `T get() throws Exception`          |
+| `CheckedConsumer<T>`    | `Consumer<T>`         | `void accept(T t) throws Exception` |
+| `CheckedRunnable`       | `Runnable`            | `void run() throws Exception`       |
 
 All four are `@FunctionalInterface` and `@NullMarked`.
 
@@ -63,15 +63,15 @@ standard library interfaces.
 
 ## When to use each
 
-| Scenario                                                         | Interface                      |
-|------------------------------------------------------------------|--------------------------------|
-| Pass a throwing method reference to a functional API             | `CheckedFunction` / `CheckedSupplier` |
-| Wrap a throwing void action (e.g. DB migration, file write)      | `CheckedRunnable`              |
-| Side-effecting loop body that throws                             | `CheckedConsumer`              |
-| Feed a throwing supplier into `Try.of()`                        | `CheckedSupplier`              |
-| Collapse a `Tuple3` into a single value                         | `TriFunction`                  |
-| Collapse a `Tuple4` into a single value                         | `QuadFunction`                 |
-| Combine more than two values in a `Validated.combine` chain     | `TriFunction` / `QuadFunction` |
+| Scenario                                                    | Interface                             |
+|-------------------------------------------------------------|---------------------------------------|
+| Pass a throwing method reference to a functional API        | `CheckedFunction` / `CheckedSupplier` |
+| Wrap a throwing void action (e.g. DB migration, file write) | `CheckedRunnable`                     |
+| Side-effecting loop body that throws                        | `CheckedConsumer`                     |
+| Feed a throwing supplier into `Try.of()`                    | `CheckedSupplier`                     |
+| Collapse a `Tuple3` into a single value                     | `TriFunction`                         |
+| Collapse a `Tuple4` into a single value                     | `QuadFunction`                        |
+| Combine more than two values in a `Validated.combine` chain | `TriFunction` / `QuadFunction`        |
 
 ## Real-world example
 

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -14,12 +14,12 @@ This page covers everything you need to go from a fresh clone to a passing build
 
 ## Prerequisites
 
-| Tool | Version | Notes |
-|---|---|---|
-| Java | 25+ | Use the Gradle toolchain — no manual install needed if you have a JDK provider |
-| Gradle | wrapper (`./gradlew`) | Never install Gradle globally; always use the wrapper |
-| Node.js | 18+ | Only needed to run or build the documentation site |
-| npm | bundled with Node.js | Run from the `site/` directory |
+| Tool    | Version               | Notes                                                                          |
+|---------|-----------------------|--------------------------------------------------------------------------------|
+| Java    | 25+                   | Use the Gradle toolchain — no manual install needed if you have a JDK provider |
+| Gradle  | wrapper (`./gradlew`) | Never install Gradle globally; always use the wrapper                          |
+| Node.js | 18+                   | Only needed to run or build the documentation site                             |
+| npm     | bundled with Node.js  | Run from the `site/` directory                                                 |
 
 No other global tools are required.
 
@@ -84,15 +84,15 @@ void emptyOption_mapReturnsNone() { ... }
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/):
 
-| Type | When to use |
-|---|---|
-| `feat` | New public API or behaviour |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
+| Type       | When to use                          |
+|------------|--------------------------------------|
+| `feat`     | New public API or behaviour          |
+| `fix`      | Bug fix                              |
+| `docs`     | Documentation only                   |
 | `refactor` | Code change with no behaviour change |
-| `test` | Adding or updating tests |
-| `chore` | Build, CI, dependencies |
-| `perf` | Performance improvement |
+| `test`     | Adding or updating tests             |
+| `chore`    | Build, CI, dependencies              |
+| `perf`     | Performance improvement              |
 
 Always reference the issue number: `feat(option): add mapBoth combinator (close #42)`.
 

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -74,13 +74,13 @@ Validated<NonEmptyList<String>, Form> form =
 
 ## Interoperability
 
-| Method | Returns | Use case |
-|---|---|---|
-| `asPredicate()` | `Predicate<T>` | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
-| `contramap(fn)` | `Guard<U>` | Adapt a field guard to validate the enclosing object type |
-| `checkToResult(value)` | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic |
-| `checkToResult(value, mapper)` | `Result<T, E>` | Map errors to a domain-specific error type at service boundaries |
-| `checkToOption(value)` | `Option<T>` | Discard errors — keep only valid values (stream filtering) |
+| Method                         | Returns                           | Use case                                                                |
+|--------------------------------|-----------------------------------|-------------------------------------------------------------------------|
+| `asPredicate()`                | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
+| `contramap(fn)`                | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
+| `checkToResult(value)`         | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic                       |
+| `checkToResult(value, mapper)` | `Result<T, E>`                    | Map errors to a domain-specific error type at service boundaries        |
+| `checkToOption(value)`         | `Option<T>`                       | Discard errors — keep only valid values (stream filtering)              |
 
 <Interop/>
 
@@ -92,13 +92,13 @@ A registration form validator that composes rules across three fields:
 
 ## Guard vs raw Validated
 
-|                          | Raw `Validated.invalidNel`      | `Guard<T>`                              |
-|--------------------------|---------------------------------|-----------------------------------------|
-| Rule definition          | Inline `if`/`invalidNel`        | Named value — defined once, used anywhere |
-| Reuse across call sites  | Copy-paste                      | Reference the same `Guard` constant     |
-| Composition              | Manual chaining                 | `and`, `or`, `negate`                   |
-| Error accumulation       | Explicit `combine` calls        | Built into `and` / `or`                 |
-| Dynamic error messages   | Inline string interpolation     | `Guard.of(pred, value -> "... " + value)` |
+|                         | Raw `Validated.invalidNel`  | `Guard<T>`                                |
+|-------------------------|-----------------------------|-------------------------------------------|
+| Rule definition         | Inline `if`/`invalidNel`    | Named value — defined once, used anywhere |
+| Reuse across call sites | Copy-paste                  | Reference the same `Guard` constant       |
+| Composition             | Manual chaining             | `and`, `or`, `negate`                     |
+| Error accumulation      | Explicit `combine` calls    | Built into `and` / `or`                   |
+| Dynamic error messages  | Inline string interpolation | `Guard.of(pred, value -> "... " + value)` |
 
 Use `Guard` when the same rule appears in more than one place, when rules are composed
 from smaller building blocks, or when you want a named, self-documenting validation vocabulary.

--- a/site/src/data/guide/introduction.mdx
+++ b/site/src/data/guide/introduction.mdx
@@ -56,6 +56,7 @@ without `instanceof` boilerplate, and with destructuring built in.
 | `Lazy<T>`          | A value computed at most once, cached after first access   | <a href={`${base}guide/lazy`}>Lazy guide</a>                             |
 | `Tuple2/3/4`       | Typed heterogeneous groupings without a named class        | <a href={`${base}guide/tuples`}>Tuples guide</a>                         |
 | `NonEmptyList<T>`  | A list with at least one element, enforced at compile time | <a href={`${base}guide/non-empty-list`}>NEL guide</a>                    |
+| `Accumulator<E, A>` | A value paired with a side-channel accumulation (log, metrics, audit trail) | <a href={`${base}guide/accumulator`}>Accumulator guide</a>               |
 | Checked interfaces | `CheckedFunction`, `TriFunction`, `QuadFunction`, and more | <a href={`${base}guide/checked-interfaces`}>Checked interfaces guide</a> |
 
 ## How to read this guide

--- a/site/src/data/guide/introduction.mdx
+++ b/site/src/data/guide/introduction.mdx
@@ -46,17 +46,17 @@ without `instanceof` boilerplate, and with destructuring built in.
 
 ## The type landscape
 
-| Type                    | One-liner                                                  | Guide                              |
-|-------------------------|------------------------------------------------------------|------------------------------------|
-| `Option<T>`             | A value that may or may not be present                     | <a href={`${base}guide/option`}>Option guide</a>      |
-| `Result<V, E>`          | Either a success value or a typed domain error             | <a href={`${base}guide/result`}>Result guide</a>      |
-| `Try<V>`                | A computation that may throw, turned into a value          | <a href={`${base}guide/try`}>Try guide</a>            |
-| `Validated<E, A>`       | Like Result, but accumulates all errors instead of one     | <a href={`${base}guide/validated`}>Validated guide</a>|
-| `Either<L, R>`          | A neutral disjoint union — neither side means failure      | <a href={`${base}guide/either`}>Either guide</a>      |
-| `Lazy<T>`               | A value computed at most once, cached after first access   | <a href={`${base}guide/lazy`}>Lazy guide</a>          |
-| `Tuple2/3/4`            | Typed heterogeneous groupings without a named class        | <a href={`${base}guide/tuples`}>Tuples guide</a>      |
-| `NonEmptyList<T>`       | A list with at least one element, enforced at compile time | <a href={`${base}guide/non-empty-list`}>NEL guide</a> |
-| Checked interfaces      | `CheckedFunction`, `TriFunction`, `QuadFunction`, and more | <a href={`${base}guide/checked-interfaces`}>Checked interfaces guide</a> |
+| Type               | One-liner                                                  | Guide                                                                    |
+|--------------------|------------------------------------------------------------|--------------------------------------------------------------------------|
+| `Option<T>`        | A value that may or may not be present                     | <a href={`${base}guide/option`}>Option guide</a>                         |
+| `Result<V, E>`     | Either a success value or a typed domain error             | <a href={`${base}guide/result`}>Result guide</a>                         |
+| `Try<V>`           | A computation that may throw, turned into a value          | <a href={`${base}guide/try`}>Try guide</a>                               |
+| `Validated<E, A>`  | Like Result, but accumulates all errors instead of one     | <a href={`${base}guide/validated`}>Validated guide</a>                   |
+| `Either<L, R>`     | A neutral disjoint union — neither side means failure      | <a href={`${base}guide/either`}>Either guide</a>                         |
+| `Lazy<T>`          | A value computed at most once, cached after first access   | <a href={`${base}guide/lazy`}>Lazy guide</a>                             |
+| `Tuple2/3/4`       | Typed heterogeneous groupings without a named class        | <a href={`${base}guide/tuples`}>Tuples guide</a>                         |
+| `NonEmptyList<T>`  | A list with at least one element, enforced at compile time | <a href={`${base}guide/non-empty-list`}>NEL guide</a>                    |
+| Checked interfaces | `CheckedFunction`, `TriFunction`, `QuadFunction`, and more | <a href={`${base}guide/checked-interfaces`}>Checked interfaces guide</a> |
 
 ## How to read this guide
 

--- a/site/src/data/guide/jackson.mdx
+++ b/site/src/data/guide/jackson.mdx
@@ -37,17 +37,17 @@ without any explicit wiring.
 
 ## JSON shapes
 
-| Type                | Success / present                  | Failure / absent                  |
-|---------------------|------------------------------------|-----------------------------------|
-| `Option<T>`         | `v` (unwrapped)                    | `null`                            |
-| `Result<V, E>`      | `{"ok": v}`                        | `{"err": e}`                      |
-| `Try<V>`            | `v` (unwrapped)                    | `{"error": "message"}`            |
-| `Validated<E, A>`   | `{"valid": a}`                     | `{"invalid": e}`                  |
-| `Either<L, R>`      | `{"right": v}`                     | `{"left": v}`                     |
-| `Tuple2<A, B>`      | `[a, b]`                           | —                                 |
-| `Tuple3<A, B, C>`   | `[a, b, c]`                        | —                                 |
-| `Tuple4<A, B, C, D>`| `[a, b, c, d]`                     | —                                 |
-| `NonEmptyList<T>`   | `[head, ...tail]`                  | —                                 |
+| Type                 | Success / present | Failure / absent       |
+|----------------------|-------------------|------------------------|
+| `Option<T>`          | `v` (unwrapped)   | `null`                 |
+| `Result<V, E>`       | `{"ok": v}`       | `{"err": e}`           |
+| `Try<V>`             | `v` (unwrapped)   | `{"error": "message"}` |
+| `Validated<E, A>`    | `{"valid": a}`    | `{"invalid": e}`       |
+| `Either<L, R>`       | `{"right": v}`    | `{"left": v}`          |
+| `Tuple2<A, B>`       | `[a, b]`          | —                      |
+| `Tuple3<A, B, C>`    | `[a, b, c]`       | —                      |
+| `Tuple4<A, B, C, D>` | `[a, b, c, d]`    | —                      |
+| `NonEmptyList<T>`    | `[head, ...tail]` | —                      |
 
 ## Round-trip examples
 

--- a/site/src/data/guide/lazy.mdx
+++ b/site/src/data/guide/lazy.mdx
@@ -58,27 +58,27 @@ until the terminal `get()` is invoked on the result.
 
 ## Interoperability
 
-| Method / Factory                    | Forces evaluation? | Returns                               | Notes                                              |
-|-------------------------------------|--------------------|---------------------------------------|----------------------------------------------------|
-| `get()`                             | Yes                | `T`                                   | Rethrows supplier exceptions.                      |
-| `toTry()`                           | Yes                | `Try<T>`                              | Captures exceptions as `Failure`; result memoized. |
-| `toResult()`                        | Yes                | `Result<T, Throwable>`                | Exception becomes `Err`.                           |
-| `toResult(errorMapper)`             | Yes                | `Result<T, E>`                        | Maps exception to a domain error.                  |
-| `toOption()`                        | Yes                | `Option<T>`                           | Throws if supplier throws.                         |
-| `toFuture()`                        | If already cached  | `CompletableFuture<T>`                | Returns completed future if cached; async otherwise. |
-| `Lazy.fromFuture(future)`           | No                 | `Lazy<T>`                             | Defers the blocking join to `get()` time.          |
+| Method / Factory          | Forces evaluation? | Returns                | Notes                                                |
+|---------------------------|--------------------|------------------------|------------------------------------------------------|
+| `get()`                   | Yes                | `T`                    | Rethrows supplier exceptions.                        |
+| `toTry()`                 | Yes                | `Try<T>`               | Captures exceptions as `Failure`; result memoized.   |
+| `toResult()`              | Yes                | `Result<T, Throwable>` | Exception becomes `Err`.                             |
+| `toResult(errorMapper)`   | Yes                | `Result<T, E>`         | Maps exception to a domain error.                    |
+| `toOption()`              | Yes                | `Option<T>`            | Throws if supplier throws.                           |
+| `toFuture()`              | If already cached  | `CompletableFuture<T>` | Returns completed future if cached; async otherwise. |
+| `Lazy.fromFuture(future)` | No                 | `Lazy<T>`              | Defers the blocking join to `get()` time.            |
 
 <InteropConversions/>
 
 ## When to use `Lazy`
 
-| Scenario                                                          | Recommendation              |
-|-------------------------------------------------------------------|-----------------------------|
-| Expensive singleton computed once across the app                  | `Lazy<T>` as a static field |
-| Default value that is expensive to compute                        | `getOrElseGet(lazy::get)`   |
-| Optional expensive computation (result may be absent)             | `Lazy<Option<T>>`           |
-| Computation that should repeat on every call                      | Plain supplier — not `Lazy` |
-| Async computation whose result you want to defer                  | `Lazy.fromFuture(...)`      |
+| Scenario                                              | Recommendation              |
+|-------------------------------------------------------|-----------------------------|
+| Expensive singleton computed once across the app      | `Lazy<T>` as a static field |
+| Default value that is expensive to compute            | `getOrElseGet(lazy::get)`   |
+| Optional expensive computation (result may be absent) | `Lazy<Option<T>>`           |
+| Computation that should repeat on every call          | Plain supplier — not `Lazy` |
+| Async computation whose result you want to defer      | `Lazy.fromFuture(...)`      |
 
 ## Common pitfalls
 

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -57,11 +57,11 @@ And add its source directory to the `aggregateJavadoc` task's `--module-source-p
 
 Four workflow files reference module paths — update all of them:
 
-| Workflow | Where to add |
-|---|---|
-| `.github/workflows/gradle.yml` | `paths:` block (push) and `dorny/paths-filter` filters |
-| `.github/workflows/publish.yml` | `paths:` block |
-| `.github/workflows/publish-snapshot.yml` | `paths:` block |
+| Workflow                                 | Where to add                                           |
+|------------------------------------------|--------------------------------------------------------|
+| `.github/workflows/gradle.yml`           | `paths:` block (push) and `dorny/paths-filter` filters |
+| `.github/workflows/publish.yml`          | `paths:` block                                         |
+| `.github/workflows/publish-snapshot.yml` | `paths:` block                                         |
 
 ### 5. Add a compatibility matrix workflow
 
@@ -103,11 +103,11 @@ Add a card to the `modules` array in `site/src/pages/guide/index.astro`:
 
 ## Naming conventions
 
-| Artifact | Pattern | Example |
-|---|---|---|
-| Directory | `{integration-name}` | `fun-spring` |
-| `artifactId` | `fun-{integration-name}` | `fun-spring` |
-| POM `name` | `dmx-fun {Integration} integration` | `dmx-fun Spring integration` |
-| Java module name | `dmx.fun.{integration}` | `dmx.fun.spring` |
-| Base package | `dmx.fun.{integration}` | `dmx.fun.spring` |
-| Guide slug | `{integration-name}` | `/guide/fun-spring` |
+| Artifact         | Pattern                             | Example                      |
+|------------------|-------------------------------------|------------------------------|
+| Directory        | `{integration-name}`                | `fun-spring`                 |
+| `artifactId`     | `fun-{integration-name}`            | `fun-spring`                 |
+| POM `name`       | `dmx-fun {Integration} integration` | `dmx-fun Spring integration` |
+| Java module name | `dmx.fun.{integration}`             | `dmx.fun.spring`             |
+| Base package     | `dmx.fun.{integration}`             | `dmx.fun.spring`             |
+| Guide slug       | `{integration-name}`                | `/guide/fun-spring`          |

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -44,13 +44,13 @@ Use it when:
 
 ## Creating instances
 
-| Factory                                            | When input is empty?          |
-|----------------------------------------------------|-------------------------------|
-| `NonEmptyList.of(head, tail)`                      | N/A — head is always required |
-| `NonEmptyList.singleton(head)`                     | N/A — always one element      |
-| `NonEmptyList.fromList(list)`                      | Returns `None`                |
-| `stream.collect(NonEmptyList.collector())`         | Returns `None`                |
-| `stream.collect(NonEmptyList.toNonEmptyList())`    | Returns `None`                |
+| Factory                                         | When input is empty?          |
+|-------------------------------------------------|-------------------------------|
+| `NonEmptyList.of(head, tail)`                   | N/A — head is always required |
+| `NonEmptyList.singleton(head)`                  | N/A — always one element      |
+| `NonEmptyList.fromList(list)`                   | Returns `None`                |
+| `stream.collect(NonEmptyList.collector())`      | Returns `None`                |
+| `stream.collect(NonEmptyList.toNonEmptyList())` | Returns `None`                |
 
 <CreatingInstances/>
 
@@ -120,13 +120,13 @@ are equal if and only if their element sequences are equal.
 
 ## When to use `NonEmptyList` vs plain `List`
 
-| Scenario                                              | Recommendation                               |
-|-------------------------------------------------------|----------------------------------------------|
-| At least one element required by contract             | `NonEmptyList<T>`                            |
-| Collection may legitimately be empty                  | `List<T>`                                    |
-| Accumulating validation errors                        | `Validated<NonEmptyList<E>, A>`              |
-| Reading from a source that could be empty             | `NonEmptyList.fromList(list)` → handle `None`|
-| Stream whose emptiness depends on runtime data        | `.collect(NonEmptyList.collector())`         |
+| Scenario                                       | Recommendation                                |
+|------------------------------------------------|-----------------------------------------------|
+| At least one element required by contract      | `NonEmptyList<T>`                             |
+| Collection may legitimately be empty           | `List<T>`                                     |
+| Accumulating validation errors                 | `Validated<NonEmptyList<E>, A>`               |
+| Reading from a source that could be empty      | `NonEmptyList.fromList(list)` → handle `None` |
+| Stream whose emptiness depends on runtime data | `.collect(NonEmptyList.collector())`          |
 
 ## Real-world example
 

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -39,11 +39,11 @@ Use it when:
 
 ## Creating instances
 
-| Factory                                       | When input is empty?          |
-|-----------------------------------------------|-------------------------------|
-| `NonEmptyMap.of(key, value, rest)`            | N/A — head entry is always required |
-| `NonEmptyMap.singleton(key, value)`           | N/A — always one entry        |
-| `NonEmptyMap.fromMap(map)`                    | Returns `None`                |
+| Factory                             | When input is empty?                |
+|-------------------------------------|-------------------------------------|
+| `NonEmptyMap.of(key, value, rest)`  | N/A — head entry is always required |
+| `NonEmptyMap.singleton(key, value)` | N/A — always one entry              |
+| `NonEmptyMap.fromMap(map)`          | Returns `None`                      |
 
 <CreatingInstances/>
 
@@ -83,13 +83,13 @@ no `Option` wrapping needed.
 Cross-type conversions bridge `NonEmptyMap` with `NonEmptySet`, `NonEmptyList`, and the
 standard Java collections.
 
-| Method | Returns | Notes |
-|--------|---------|-------|
-| `keySet()` | `NonEmptySet<K>` | All keys as a non-empty set; head key becomes set head |
-| `values()` | `NonEmptyList<V>` | All values in insertion order; duplicates preserved |
-| `toMap()` | `Map<K, V>` | Unmodifiable `java.util.Map` for standard API interop |
-| `toNonEmptyList()` | `NonEmptyList<Map.Entry<K,V>>` | All entries in insertion order |
-| `fromMap(map)` | `Option<NonEmptyMap<K,V>>` | Safe bridge from a plain `Map`; `None` if empty |
+| Method             | Returns                        | Notes                                                  |
+|--------------------|--------------------------------|--------------------------------------------------------|
+| `keySet()`         | `NonEmptySet<K>`               | All keys as a non-empty set; head key becomes set head |
+| `values()`         | `NonEmptyList<V>`              | All values in insertion order; duplicates preserved    |
+| `toMap()`          | `Map<K, V>`                    | Unmodifiable `java.util.Map` for standard API interop  |
+| `toNonEmptyList()` | `NonEmptyList<Map.Entry<K,V>>` | All entries in insertion order                         |
+| `fromMap(map)`     | `Option<NonEmptyMap<K,V>>`     | Safe bridge from a plain `Map`; `None` if empty        |
 
 <Interop/>
 

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -43,11 +43,11 @@ Use it when:
 
 ## Creating instances
 
-| Factory                                       | When input is empty?          |
-|-----------------------------------------------|-------------------------------|
-| `NonEmptySet.of(head, rest)`                  | N/A — head is always required |
-| `NonEmptySet.singleton(head)`                 | N/A — always one element      |
-| `NonEmptySet.fromSet(set)`                    | Returns `None`                |
+| Factory                       | When input is empty?          |
+|-------------------------------|-------------------------------|
+| `NonEmptySet.of(head, rest)`  | N/A — head is always required |
+| `NonEmptySet.singleton(head)` | N/A — always one element      |
+| `NonEmptySet.fromSet(set)`    | Returns `None`                |
 
 <CreatingInstances/>
 
@@ -88,12 +88,12 @@ not just `NonEmptySet`.
 Cross-type conversions bridge `NonEmptySet` with `NonEmptyMap`, `NonEmptyList`, and the
 standard Java collections.
 
-| Method | Returns | Notes |
-|--------|---------|-------|
-| `toNonEmptyMap(valueMapper)` | `NonEmptyMap<T, V>` | Elements become keys; mapper produces values |
-| `toNonEmptyList()` | `NonEmptyList<T>` | Ordered snapshot; head element preserved |
-| `toSet()` | `Set<T>` | Unmodifiable `java.util.Set` for standard API interop |
-| `fromSet(set)` | `Option<NonEmptySet<T>>` | Safe bridge from a plain `Set`; `None` if empty |
+| Method                       | Returns                  | Notes                                                 |
+|------------------------------|--------------------------|-------------------------------------------------------|
+| `toNonEmptyMap(valueMapper)` | `NonEmptyMap<T, V>`      | Elements become keys; mapper produces values          |
+| `toNonEmptyList()`           | `NonEmptyList<T>`        | Ordered snapshot; head element preserved              |
+| `toSet()`                    | `Set<T>`                 | Unmodifiable `java.util.Set` for standard API interop |
+| `fromSet(set)`               | `Option<NonEmptySet<T>>` | Safe bridge from a plain `Set`; `None` if empty       |
 
 <Interop/>
 

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -188,15 +188,15 @@ Useful for integrating into Stream pipelines without `filter + map`.
 
 ## Interoperability
 
-| Conversion                    | Method                            |
-|-------------------------------|-----------------------------------|
-| `Option` → `Optional`         | `option.toOptional()`             |
-| `Option` → `Result`           | `option.toResult(errorSupplier)`  |
-| `Option` → `Try`              | `option.toTry(exceptionSupplier)` |
-| `Option` → `Either`           | `option.toEither(leftSupplier)`   |
-| `Result` → `Option`           | `result.toOption()`               |
-| `Try` → `Option`              | `tryVal.toOption()`               |
-| `Optional` → `Option`         | `Option.fromOptional(optional)`   |
+| Conversion            | Method                            |
+|-----------------------|-----------------------------------|
+| `Option` → `Optional` | `option.toOptional()`             |
+| `Option` → `Result`   | `option.toResult(errorSupplier)`  |
+| `Option` → `Try`      | `option.toTry(exceptionSupplier)` |
+| `Option` → `Either`   | `option.toEither(leftSupplier)`   |
+| `Result` → `Option`   | `result.toOption()`               |
+| `Try` → `Option`      | `tryVal.toOption()`               |
+| `Optional` → `Option` | `Option.fromOptional(optional)`   |
 
 <InteropConversions/>
 

--- a/site/src/data/guide/performance.mdx
+++ b/site/src/data/guide/performance.mdx
@@ -34,10 +34,10 @@ for use at those boundaries, not inside tight numeric loops.
 
 Two specific operations may show measurable cost under extreme conditions:
 
-| Type / operation                               | Condition                                   | Reason                                                        |
-|------------------------------------------------|---------------------------------------------|---------------------------------------------------------------|
-| `Lazy<T>.get()`                                | Very high concurrent thread contention      | Internal `synchronized` block (double-checked locking)        |
-| `Validated.sequence` / `Validated.traverse`    | Collections larger than ~10 000 elements    | Repeated `NonEmptyList::concat` copies the error list on each merge |
+| Type / operation                            | Condition                                | Reason                                                              |
+|---------------------------------------------|------------------------------------------|---------------------------------------------------------------------|
+| `Lazy<T>.get()`                             | Very high concurrent thread contention   | Internal `synchronized` block (double-checked locking)              |
+| `Validated.sequence` / `Validated.traverse` | Collections larger than ~10 000 elements | Repeated `NonEmptyList::concat` copies the error list on each merge |
 
 **`Lazy<T>` under contention**: the `volatile` read on the happy path (already
 evaluated) is cheap. Cost only appears when many threads race to evaluate the

--- a/site/src/data/guide/pipelines.mdx
+++ b/site/src/data/guide/pipelines.mdx
@@ -11,14 +11,14 @@ All CI/CD is handled by GitHub Actions. The workflows live in `.github/workflows
 
 ## Workflow overview
 
-| Workflow file | Trigger | Purpose |
-|---|---|---|
-| `gradle.yml` | push / PR to `main` (code paths) | Full build, tests, coverage, Javadoc, dependency graph submission |
-| `publish.yml` | push to `main` — stable version only | Publish all modules to Maven Central, create git tag and GitHub Release |
-| `publish-snapshot.yml` | push to `main` — SNAPSHOT version only | Publish SNAPSHOT artifacts to Maven Central |
-| `jackson-compatibility.yaml` | PR touching `jackson/**` | Matrix test against Jackson 2.13.x – 2.21.x |
-| `assertj-compatibility.yaml` | PR touching `assertj/**` | Matrix test against AssertJ 3.21.x – 3.27.x |
-| `pages.yml` | push to `main` | Build and deploy the documentation site to GitHub Pages |
+| Workflow file                | Trigger                                | Purpose                                                                 |
+|------------------------------|----------------------------------------|-------------------------------------------------------------------------|
+| `gradle.yml`                 | push / PR to `main` (code paths)       | Full build, tests, coverage, Javadoc, dependency graph submission       |
+| `publish.yml`                | push to `main` — stable version only   | Publish all modules to Maven Central, create git tag and GitHub Release |
+| `publish-snapshot.yml`       | push to `main` — SNAPSHOT version only | Publish SNAPSHOT artifacts to Maven Central                             |
+| `jackson-compatibility.yaml` | PR touching `jackson/**`               | Matrix test against Jackson 2.13.x – 2.21.x                             |
+| `assertj-compatibility.yaml` | PR touching `assertj/**`               | Matrix test against AssertJ 3.21.x – 3.27.x                             |
+| `pages.yml`                  | push to `main`                         | Build and deploy the documentation site to GitHub Pages                 |
 
 ---
 
@@ -63,13 +63,13 @@ Only stable versions (e.g. `0.0.13`) proceed.
 
 **Secrets required**:
 
-| Secret | Purpose |
-|---|---|
-| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username |
-| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token |
-| `SIGNING_KEY_ID` | GPG key ID (last 8 characters) |
-| `SIGNING_KEY` | GPG private key (armored, base64-encoded) |
-| `SIGNING_KEY_PASSWORD` | Passphrase for the GPG key |
+| Secret                   | Purpose                                   |
+|--------------------------|-------------------------------------------|
+| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username             |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token     |
+| `SIGNING_KEY_ID`         | GPG key ID (last 8 characters)            |
+| `SIGNING_KEY`            | GPG private key (armored, base64-encoded) |
+| `SIGNING_KEY_PASSWORD`   | Passphrase for the GPG key                |
 
 **Local equivalent** (dry-run only — do not publish locally):
 ```bash
@@ -103,16 +103,16 @@ Runs only on pull requests — not on push to `main`.
 **What it does**: runs `:jackson:test` for each Jackson version in the matrix:
 
 | Jackson version | Status |
-|---|---|
-| 2.13.5 | tested |
-| 2.14.3 | tested |
-| 2.15.4 | tested |
-| 2.16.2 | tested |
-| 2.17.3 | tested |
-| 2.18.2 | tested |
-| 2.19.4 | tested |
-| 2.20.2 | tested |
-| 2.21.2 | tested |
+|-----------------|--------|
+| 2.13.5          | tested |
+| 2.14.3          | tested |
+| 2.15.4          | tested |
+| 2.16.2          | tested |
+| 2.17.3          | tested |
+| 2.18.2          | tested |
+| 2.19.4          | tested |
+| 2.20.2          | tested |
+| 2.21.2          | tested |
 
 **Local equivalent**:
 ```bash
@@ -132,14 +132,14 @@ Runs only on pull requests — not on push to `main`.
 **What it does**: runs `:assertj:test` for each AssertJ version in the matrix:
 
 | AssertJ version | Status |
-|---|---|
-| 3.21.0 | tested |
-| 3.22.0 | tested |
-| 3.23.1 | tested |
-| 3.24.2 | tested |
-| 3.25.3 | tested |
-| 3.26.3 | tested |
-| 3.27.7 | tested |
+|-----------------|--------|
+| 3.21.0          | tested |
+| 3.22.0          | tested |
+| 3.23.1          | tested |
+| 3.24.2          | tested |
+| 3.25.3          | tested |
+| 3.26.3          | tested |
+| 3.27.7          | tested |
 
 **Local equivalent**:
 ```bash

--- a/site/src/data/guide/release-process.mdx
+++ b/site/src/data/guide/release-process.mdx
@@ -15,13 +15,13 @@ This page documents the exact steps and what happens at each stage.
 Before any release can be published, these five secrets must be configured in
 **GitHub → Settings → Secrets and variables → Actions**:
 
-| Secret | Purpose |
-|---|---|
-| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username |
-| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token |
-| `SIGNING_KEY_ID` | GPG key ID (last 8 hex characters) |
-| `SIGNING_KEY` | GPG private key — armored, base64-encoded |
-| `SIGNING_KEY_PASSWORD` | Passphrase protecting the GPG key |
+| Secret                   | Purpose                                   |
+|--------------------------|-------------------------------------------|
+| `MAVEN_CENTRAL_USERNAME` | Maven Central portal username             |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central portal password / token     |
+| `SIGNING_KEY_ID`         | GPG key ID (last 8 hex characters)        |
+| `SIGNING_KEY`            | GPG private key — armored, base64-encoded |
+| `SIGNING_KEY_PASSWORD`   | Passphrase protecting the GPG key         |
 
 These secrets are consumed by `publish.yml` and `publish-snapshot.yml`.
 They are never printed in logs.

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -48,12 +48,12 @@ acquire/run/release cycle.
 
 `Resource<T>` follows the same exception-suppression semantics as `try-with-resources`:
 
-| Body     | Release  | Outcome                                                                  |
-|----------|----------|--------------------------------------------------------------------------|
-| Success  | Success  | `Try.success(result)`                                                    |
-| Success  | Throws   | `Try.failure(releaseException)`                                          |
-| Throws   | Success  | `Try.failure(bodyException)`                                             |
-| Throws   | Throws   | `Try.failure(bodyException)` — release exception suppressed onto body    |
+| Body    | Release | Outcome                                                               |
+|---------|---------|-----------------------------------------------------------------------|
+| Success | Success | `Try.success(result)`                                                 |
+| Success | Throws  | `Try.failure(releaseException)`                                       |
+| Throws  | Success | `Try.failure(bodyException)`                                          |
+| Throws  | Throws  | `Try.failure(bodyException)` — release exception suppressed onto body |
 
 <ExceptionContract/>
 
@@ -87,14 +87,14 @@ so you can build resource pipelines without deep nesting.
 
 ## Resource vs try-with-resources
 
-|                          | `try-with-resources`            | `Resource<T>`                             |
-|--------------------------|---------------------------------|-------------------------------------------|
-| Guaranteed release       | Yes                             | Yes                                       |
-| Composable               | Nested blocks only              | `map` / `flatMap` as values               |
-| Result as value          | No — exceptions propagate       | Yes — `Try<R>` or `Result<R,E>` returned  |
-| Multiple resources       | Separate `try` blocks           | `flatMap` chain                           |
-| Reusable                 | No                              | Yes — each `use()` is independent         |
-| Works with non-closeable | No — requires `AutoCloseable`   | Yes — any acquire/release pair            |
+|                          | `try-with-resources`          | `Resource<T>`                            |
+|--------------------------|-------------------------------|------------------------------------------|
+| Guaranteed release       | Yes                           | Yes                                      |
+| Composable               | Nested blocks only            | `map` / `flatMap` as values              |
+| Result as value          | No — exceptions propagate     | Yes — `Try<R>` or `Result<R,E>` returned |
+| Multiple resources       | Separate `try` blocks         | `flatMap` chain                          |
+| Reusable                 | No                            | Yes — each `use()` is independent        |
+| Works with non-closeable | No — requires `AutoCloseable` | Yes — any acquire/release pair           |
 
 Use `Resource<T>` when you need to **compose** multiple resources, reuse the acquire/release
 description across multiple call sites, or integrate with the dmx-fun type system.

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -150,16 +150,16 @@ The downstream variant `groupingBy(classifier, downstream)` applies a
 
 ## Interoperability
 
-| Conversion                          | Method                            |
-|-------------------------------------|-----------------------------------|
-| `Result` → `Option`                 | `result.toOption()`               |
-| `Result` → `Try`                    | `result.toTry(errorMapper)`       |
-| `Result` → `Either`                 | `result.toEither()`               |
-| `Result` → `CompletableFuture`      | `result.toFuture()`               |
-| `Option` → `Result`                 | `option.toResult(errorSupplier)`  |
-| `Try` → `Result`                    | `tryVal.toResult()`               |
-| `Optional` → `Result`               | `Result.fromOptional(optional)`   |
-| `CompletableFuture` → `Result`      | `Result.fromFuture(future)`       |
+| Conversion                     | Method                           |
+|--------------------------------|----------------------------------|
+| `Result` → `Option`            | `result.toOption()`              |
+| `Result` → `Try`               | `result.toTry(errorMapper)`      |
+| `Result` → `Either`            | `result.toEither()`              |
+| `Result` → `CompletableFuture` | `result.toFuture()`              |
+| `Option` → `Result`            | `option.toResult(errorSupplier)` |
+| `Try` → `Result`               | `tryVal.toResult()`              |
+| `Optional` → `Result`          | `Result.fromOptional(optional)`  |
+| `CompletableFuture` → `Result` | `Result.fromFuture(future)`      |
 
 <InteropConversions/>
 
@@ -167,13 +167,13 @@ See the [Combining Types](combining-types) page for the full conversion matrix a
 
 ## Result vs Try vs exceptions
 
-|                             | Exceptions                    | `Try<V>`                         | `Result<V, E>`                          |
-|-----------------------------|-------------------------------|----------------------------------|-----------------------------------------|
-| Error type                  | `Throwable` — implicit        | `Throwable` — explicit value     | Any type — explicit and domain-specific |
-| Forces handling             | Only checked exceptions       | Yes — via API                    | Yes — via API and switch patterns       |
-| Branch on error subtype     | Via `catch` clauses           | Via `instanceof`                 | Via sealed subtype and switch patterns  |
-| Interop with throwing code  | Native                        | Excellent — `Try.of(() -> ...)`  | Indirect — wrap with Try first          |
-| Best for                    | Truly exceptional situations  | Wrapping legacy/third-party code | Domain logic with typed failure modes   |
+|                            | Exceptions                   | `Try<V>`                         | `Result<V, E>`                          |
+|----------------------------|------------------------------|----------------------------------|-----------------------------------------|
+| Error type                 | `Throwable` — implicit       | `Throwable` — explicit value     | Any type — explicit and domain-specific |
+| Forces handling            | Only checked exceptions      | Yes — via API                    | Yes — via API and switch patterns       |
+| Branch on error subtype    | Via `catch` clauses          | Via `instanceof`                 | Via sealed subtype and switch patterns  |
+| Interop with throwing code | Native                       | Excellent — `Try.of(() -> ...)`  | Indirect — wrap with Try first          |
+| Best for                   | Truly exceptional situations | Wrapping legacy/third-party code | Domain logic with typed failure modes   |
 
 ## Common pitfalls
 

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -57,16 +57,16 @@ the compiler enforces that both tracks are handled.
 
 ## Extracting values
 
-| Method                        | When `Failure`                       | Notes                                                            |
-|-------------------------------|--------------------------------------|------------------------------------------------------------------|
-| `get()`                       | Throws `NoSuchElementException`      | Only safe after an `isSuccess()` check; prefer alternatives.     |
-| `getCause()`                  | N/A — throws if `Success`            | Retrieves the exception; unsafe on the success track.            |
-| `getOrElse(fallback)`         | Returns `fallback`                   | Fallback is always evaluated eagerly.                            |
-| `getOrElseGet(supplier)`      | Calls supplier                       | Lazily computed fallback.                                        |
-| `getOrNull()`                 | Returns `null`                       | Ambiguous for `Try<Void>` — avoid when possible.                 |
-| `getOrThrow()`                | Rethrows the original exception      | Rethrows `Exception` as-is; wraps `Error`/`Throwable`.           |
-| `getOrThrow(exMapper)`        | Throws mapped `RuntimeException`     | Maps the cause to a domain exception at the call site.           |
-| `fold(onSuccess, onFailure)`  | Calls `onFailure`                    | The most expressive extractor: forces both tracks to be handled. |
+| Method                       | When `Failure`                   | Notes                                                            |
+|------------------------------|----------------------------------|------------------------------------------------------------------|
+| `get()`                      | Throws `NoSuchElementException`  | Only safe after an `isSuccess()` check; prefer alternatives.     |
+| `getCause()`                 | N/A — throws if `Success`        | Retrieves the exception; unsafe on the success track.            |
+| `getOrElse(fallback)`        | Returns `fallback`               | Fallback is always evaluated eagerly.                            |
+| `getOrElseGet(supplier)`     | Calls supplier                   | Lazily computed fallback.                                        |
+| `getOrNull()`                | Returns `null`                   | Ambiguous for `Try<Void>` — avoid when possible.                 |
+| `getOrThrow()`               | Rethrows the original exception  | Rethrows `Exception` as-is; wraps `Error`/`Throwable`.           |
+| `getOrThrow(exMapper)`       | Throws mapped `RuntimeException` | Maps the cause to a domain exception at the call site.           |
+| `fold(onSuccess, onFailure)` | Calls `onFailure`                | The most expressive extractor: forces both tracks to be handled. |
 
 <ExtractingValues/>
 
@@ -129,15 +129,15 @@ so `null` elements in successful results are preserved.
 
 ## Interoperability
 
-| Conversion                      | Method                              |
-|---------------------------------|-------------------------------------|
-| `Try` → `Option`                | `tryVal.toOption()`                 |
-| `Try` → `Result<V, Throwable>`  | `tryVal.toResult()`                 |
-| `Try` → `Result<V, E>`          | `tryVal.toResult(errorMapper)`      |
-| `Try` → `Either<Throwable, V>`  | `tryVal.toEither()`                 |
-| `Try` → `Stream<V>`             | `tryVal.stream()`                   |
-| `Option` → `Try`                | `option.toTry(exceptionSupplier)`   |
-| `Result` → `Try`                | `result.toTry(errorMapper)`         |
+| Conversion                     | Method                            |
+|--------------------------------|-----------------------------------|
+| `Try` → `Option`               | `tryVal.toOption()`               |
+| `Try` → `Result<V, Throwable>` | `tryVal.toResult()`               |
+| `Try` → `Result<V, E>`         | `tryVal.toResult(errorMapper)`    |
+| `Try` → `Either<Throwable, V>` | `tryVal.toEither()`               |
+| `Try` → `Stream<V>`            | `tryVal.stream()`                 |
+| `Option` → `Try`               | `option.toTry(exceptionSupplier)` |
+| `Result` → `Try`               | `result.toTry(errorMapper)`       |
 
 <InteropConversions/>
 
@@ -145,13 +145,13 @@ See the [Combining Types](combining-types) page for the full conversion matrix a
 
 ## Try vs Result vs checked exceptions
 
-|                              | Checked exceptions             | `Try<V>`                             | `Result<V, E>`                          |
-|------------------------------|--------------------------------|--------------------------------------|-----------------------------------------|
-| Error type                   | Declared `throws` clause       | Always `Throwable`                   | Any domain type                         |
-| Forces handling              | Yes — compile time             | Yes — via API                        | Yes — via API and switch patterns       |
-| Branch on error subtype      | Via `catch` clauses            | Via `instanceof` / `recover(Class)`  | Via sealed subtype and switch patterns  |
-| Interop with throwing code   | Native                         | Excellent — `Try.of(() -> ...)`      | Indirect — wrap with `Try` first        |
-| Best for                     | Internal APIs you control      | Wrapping legacy/third-party code     | Domain logic with typed failure modes   |
+|                            | Checked exceptions        | `Try<V>`                            | `Result<V, E>`                         |
+|----------------------------|---------------------------|-------------------------------------|----------------------------------------|
+| Error type                 | Declared `throws` clause  | Always `Throwable`                  | Any domain type                        |
+| Forces handling            | Yes — compile time        | Yes — via API                       | Yes — via API and switch patterns      |
+| Branch on error subtype    | Via `catch` clauses       | Via `instanceof` / `recover(Class)` | Via sealed subtype and switch patterns |
+| Interop with throwing code | Native                    | Excellent — `Try.of(() -> ...)`     | Indirect — wrap with `Try` first       |
+| Best for                   | Internal APIs you control | Wrapping legacy/third-party code    | Domain logic with typed failure modes  |
 
 ## Time-bounded execution — `Try.withTimeout`
 

--- a/site/src/data/guide/validated.mdx
+++ b/site/src/data/guide/validated.mdx
@@ -55,15 +55,15 @@ Prefer exhaustive switch patterns — the compiler enforces that both tracks are
 
 ## Extracting values
 
-| Method                        | When `Invalid`                      | Notes                                                          |
-|-------------------------------|-------------------------------------|----------------------------------------------------------------|
-| `get()`                       | Throws `NoSuchElementException`     | Only safe after an `isValid()` check; prefer alternatives.     |
-| `getError()`                  | N/A — throws if `Valid`             | Retrieves the error; unsafe on the valid track.                |
-| `getOrElse(fallback)`         | Returns `fallback`                  | Fallback is always evaluated eagerly.                          |
-| `getOrElseGet(supplier)`      | Calls supplier                      | Lazily computed fallback.                                      |
-| `getOrNull()`                 | Returns `null`                      | Bridge to null-expecting APIs.                                 |
-| `getOrThrow(exMapper)`        | Throws mapped `RuntimeException`    | Maps the error to an exception at the call site.               |
-| `fold(onValid, onInvalid)`    | Calls `onInvalid`                   | The most expressive extractor: forces both tracks to be handled. |
+| Method                     | When `Invalid`                   | Notes                                                            |
+|----------------------------|----------------------------------|------------------------------------------------------------------|
+| `get()`                    | Throws `NoSuchElementException`  | Only safe after an `isValid()` check; prefer alternatives.       |
+| `getError()`               | N/A — throws if `Valid`          | Retrieves the error; unsafe on the valid track.                  |
+| `getOrElse(fallback)`      | Returns `fallback`               | Fallback is always evaluated eagerly.                            |
+| `getOrElseGet(supplier)`   | Calls supplier                   | Lazily computed fallback.                                        |
+| `getOrNull()`              | Returns `null`                   | Bridge to null-expecting APIs.                                   |
+| `getOrThrow(exMapper)`     | Throws mapped `RuntimeException` | Maps the error to an exception at the call site.                 |
+| `fold(onValid, onInvalid)` | Calls `onInvalid`                | The most expressive extractor: forces both tracks to be handled. |
 
 <ExtractingValues/>
 
@@ -101,11 +101,11 @@ Use `combine` in most cases.
 For three or four independent fields, `combine3` / `combine4` collapse the chain
 into a single flat call — no intermediate `Tuple2` nesting, no manual unpacking.
 
-| Method | Inputs | Value merger |
-|--------|--------|--------------|
-| `combine(other, errMerge, valueMerge)` | 2 | `BiFunction<A, B, R>` |
-| `Validated.combine3(va, vb, vc, errMerge, valueMerge)` | 3 | `TriFunction<A, B, C, R>` |
-| `Validated.combine4(va, vb, vc, vd, errMerge, valueMerge)` | 4 | `QuadFunction<A, B, C, D, R>` |
+| Method                                                     | Inputs | Value merger                  |
+|------------------------------------------------------------|--------|-------------------------------|
+| `combine(other, errMerge, valueMerge)`                     | 2      | `BiFunction<A, B, R>`         |
+| `Validated.combine3(va, vb, vc, errMerge, valueMerge)`     | 3      | `TriFunction<A, B, C, R>`     |
+| `Validated.combine4(va, vb, vc, vd, errMerge, valueMerge)` | 4      | `QuadFunction<A, B, C, D, R>` |
 
 All inputs are always evaluated — no short-circuit. All errors are accumulated.
 
@@ -132,15 +132,15 @@ streams and the standard `Stream.collect` API.
 
 ## Interoperability
 
-| Conversion                           | Method                                         |
-|--------------------------------------|------------------------------------------------|
-| `Validated` → `Result`               | `v.toResult()`                                 |
-| `Validated` → `Try`                  | `v.toTry(errorMapper)`                         |
-| `Validated` → `Either`               | `v.toEither()`                                 |
-| `Validated` → `Option`               | `v.toOption()`                                 |
-| `Result` → `Validated`               | `Validated.fromResult(result)`                 |
-| `Option` → `Validated`               | `Validated.fromOption(option, errorIfNone)`    |
-| `Try` → `Validated`                  | `Validated.fromTry(t, errorMapper)`            |
+| Conversion             | Method                                      |
+|------------------------|---------------------------------------------|
+| `Validated` → `Result` | `v.toResult()`                              |
+| `Validated` → `Try`    | `v.toTry(errorMapper)`                      |
+| `Validated` → `Either` | `v.toEither()`                              |
+| `Validated` → `Option` | `v.toOption()`                              |
+| `Result` → `Validated` | `Validated.fromResult(result)`              |
+| `Option` → `Validated` | `Validated.fromOption(option, errorIfNone)` |
+| `Try` → `Validated`    | `Validated.fromTry(t, errorMapper)`         |
 
 <InteropConversions/>
 
@@ -148,13 +148,13 @@ See the [Combining Types](combining-types) page for the full conversion matrix.
 
 ## Validated vs Result — when to use each
 
-| Scenario                                         | Use              |
-|--------------------------------------------------|------------------|
-| Stop at the first error; further steps depend on success | `Result`  |
-| Collect all errors; report everything at once    | `Validated`      |
-| Wrap throwing legacy code                        | `Try`            |
-| Independent field validations (form, config)     | `Validated`      |
-| Pipeline where each step feeds the next          | `Result`         |
+| Scenario                                                 | Use         |
+|----------------------------------------------------------|-------------|
+| Stop at the first error; further steps depend on success | `Result`    |
+| Collect all errors; report everything at once            | `Validated` |
+| Wrap throwing legacy code                                | `Try`       |
+| Independent field validations (form, config)             | `Validated` |
+| Pipeline where each step feeds the next                  | `Result`    |
 
 ## Common pitfalls
 

--- a/site/src/pages/guide/index.astro
+++ b/site/src/pages/guide/index.astro
@@ -100,6 +100,14 @@ const types = [
         tag: 'Resource management',
     },
     {
+        name: 'Accumulator<E, A>',
+        href: `${base}guide/accumulator`,
+        summary: 'A value paired with a side-channel accumulation (log, metrics, audit trail). The functional alternative to mutable shared state for cross-cutting concerns.',
+        whenToUse: 'You need to thread log entries, counters, or audit events through a pure computation chain without shared mutable state.',
+        avoidWhen: 'A step can fail — use Result for error handling, or Validated to accumulate validation errors.',
+        tag: 'Tracing',
+    },
+    {
         name: 'Checked interfaces',
         href: `${base}guide/checked-interfaces`,
         summary: 'Checked variants of Function, Supplier, Consumer, Runnable, plus TriFunction/QuadFunction.',


### PR DESCRIPTION
  Implements the Writer monad pattern for threading log entries, metrics, or
  audit events through a pure computation chain without shared mutable state.

  Core API: of, pure, tell factories; map, flatMap (explicit BinaryOperator<E>
  merge), mapAccumulated, hasValue, toTuple2.

  Interoperability: combine (applicative combination of two independent
  accumulators), sequence (fold List into Accumulator<E, List<A>>), toOption,
  liftOption (log present/absent paths), liftTry (log success/failure paths).

  58 tests, runnable AccumulatorSample, Developer Guide (order 12), guide index
  card, and README updated.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #226

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Accumulator<E, A>, a new functional type pairing a computed value with a side‑channel accumulation for audit/logging across computations.

* **Documentation**
  * Added a comprehensive developer guide, multiple how‑to examples, and a real‑world pricing pipeline walkthrough.
  * Updated type overview and reference pages to include Accumulator and navigation links.

* **Tests**
  * Added a comprehensive test suite validating factories, composition, conversions, and accumulation semantics.

* **Samples**
  * Added runnable sample demonstrating common Accumulator workflows and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->