### PR TITLE
feature/build/jpms centralization

### DIFF
--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -8,20 +8,8 @@ dependencies {
     testImplementation "org.assertj:assertj-core:${findProperty('assertjVersion') ?: libs.versions.assertj.get()}"
 }
 
-compileTestJava {
-    def mainClassesDirs = sourceSets.main.output.classesDirs
-    def apiDeps = configurations.compileClasspath
-    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
-
-    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
-
-    def modulePath = (mainClassesDirs + apiDeps).asPath
-    options.compilerArgs += [
-        '--module-path', modulePath,
-        '--add-modules', 'dmx.fun.assertj',
-        '--patch-module', "dmx.fun.assertj=${testSrcPath}",
-        '--add-reads', 'dmx.fun.assertj=ALL-UNNAMED',
-    ]
+jpmsTest {
+    moduleName = 'dmx.fun.assertj'
 }
 
 mavenPublishing {
@@ -29,6 +17,6 @@ mavenPublishing {
 
     pom {
         name = 'dmx-fun AssertJ integration'
-        description = 'Optional AssertJ module for dmx-fun: fluent custom assertions for Option, Result, Try, Validated, Either, Tuple2/3/4, and NonEmptyList.'
+        description = 'AssertJ module for dmx-fun: fluent custom assertions for Option, Result, Try, Validated, Either, Tuple2/3/4, and NonEmptyList.'
     }
 }

--- a/assertj/build.gradle
+++ b/assertj/build.gradle
@@ -1,10 +1,20 @@
+// ── AssertJ integration module ────────────────────────────────────────────────
+// Optional module — users must already have AssertJ on their classpath.
+// Provides fluent custom assertions for all dmx-fun types.
 plugins {
     id 'dmx-fun.java-module'
 }
 
 dependencies {
+    // Exposes dmx-fun types to callers; they only need one dependency declaration.
     api project(':lib')
+
+    // AssertJ is an optional peer dependency: declared compileOnly so it is not
+    // pulled in transitively. Users bring their own version.
     compileOnly libs.assertj.core
+
+    // Tests run against the version passed via -PassertjVersion=X.Y.Z (used by
+    // the CI compatibility matrix), falling back to the catalog version locally.
     testImplementation "org.assertj:assertj-core:${findProperty('assertjVersion') ?: libs.versions.assertj.get()}"
 }
 

--- a/build-logic/src/main/groovy/dmx-fun.java-module.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-module.gradle
@@ -60,8 +60,9 @@ mavenPublishing {
 //       moduleName   = 'dmx.fun.spring'       // JPMS module name (required)
 //       extraModules = ['java.sql']            // added to --add-modules
 //       extraReads   = ['java.sql']            // generates --add-reads moduleName=X
-//       extraOpens   = ['ALL-UNNAMED',         // generates --add-opens moduleName/moduleName=X
-//                       'spring.core']
+//       extraOpens   = ['ALL-UNNAMED',         // plain string → --add-opens moduleName/moduleName=target
+//                       'spring.core',         //   (opens the module's root package to that target)
+//                       'dmx.fun.x=spring.tx'] // 'pkg=target' form → --add-opens moduleName/pkg=target
 //   }
 //
 // The plugin wires compileTestJava and test automatically. No hand-written
@@ -114,5 +115,14 @@ tasks.named('test') {
     jvmArgs '--patch-module', "${mod}=${testClassesDirs}"
     jvmArgs '--add-reads',    "${mod}=ALL-UNNAMED"
     jpmsTestCfg.extraReads.each { r -> jvmArgs '--add-reads', "${mod}=${r}" }
-    jpmsTestCfg.extraOpens.each { o -> jvmArgs '--add-opens', "${mod}/${mod}=${o}" }
+    jpmsTestCfg.extraOpens.each { o ->
+        // 'pkg=target' form: opens the named package (within mod) to the target module.
+        // Plain string: opens the module's root package (same name as the module) to the target.
+        if (o.contains('=')) {
+            def parts = o.split('=', 2)
+            jvmArgs '--add-opens', "${mod}/${parts[0]}=${parts[1]}"
+        } else {
+            jvmArgs '--add-opens', "${mod}/${mod}=${o}"
+        }
+    }
 }

--- a/build-logic/src/main/groovy/dmx-fun.java-module.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-module.gradle
@@ -106,9 +106,9 @@ tasks.named('test') {
 
     def allModules      = ([mod] + jpmsTestCfg.extraModules).join(',')
     def mainOut         = project.sourceSets.main.output.classesDirs
-    def apiDeps         = project.configurations.compileClasspath
+    def runtimeDeps     = project.configurations.runtimeClasspath  // includes runtimeOnly deps
     def testClassesDirs = project.sourceSets.test.output.classesDirs.asPath
-    def modulePath      = (mainOut + apiDeps).asPath
+    def modulePath      = (mainOut + runtimeDeps).asPath
 
     jvmArgs '--module-path',  modulePath
     jvmArgs '--add-modules',  allModules
@@ -120,6 +120,12 @@ tasks.named('test') {
         // Plain string: opens the module's root package (same name as the module) to the target.
         if (o.contains('=')) {
             def parts = o.split('=', 2)
+            if (parts[0].isEmpty() || parts[1].isEmpty()) {
+                throw new GradleException(
+                    "jpmsTest.extraOpens entry '${o}' is malformed — " +
+                    "expected 'package=target' with non-empty package and target"
+                )
+            }
             jvmArgs '--add-opens', "${mod}/${parts[0]}=${parts[1]}"
         } else {
             jvmArgs '--add-opens', "${mod}/${mod}=${o}"

--- a/build-logic/src/main/groovy/dmx-fun.java-module.gradle
+++ b/build-logic/src/main/groovy/dmx-fun.java-module.gradle
@@ -51,3 +51,68 @@ mavenPublishing {
         }
     }
 }
+
+// ── JPMS test configuration ───────────────────────────────────────────────────
+//
+// Each subproject declares its JPMS test needs once:
+//
+//   jpmsTest {
+//       moduleName   = 'dmx.fun.spring'       // JPMS module name (required)
+//       extraModules = ['java.sql']            // added to --add-modules
+//       extraReads   = ['java.sql']            // generates --add-reads moduleName=X
+//       extraOpens   = ['ALL-UNNAMED',         // generates --add-opens moduleName/moduleName=X
+//                       'spring.core']
+//   }
+//
+// The plugin wires compileTestJava and test automatically. No hand-written
+// compileTestJava or test JPMS blocks are needed in module build files.
+
+class JpmsTestExtension {
+    String       moduleName   = null
+    List<String> extraModules = []
+    List<String> extraReads   = []
+    List<String> extraOpens   = []
+}
+
+def jpmsTestCfg = extensions.create('jpmsTest', JpmsTestExtension)
+
+// tasks.named() is lazy: the configuration action runs when the task is first
+// resolved (after all project evaluation), so jpmsTestCfg is fully populated.
+
+tasks.named('compileTestJava') {
+    def mod = jpmsTestCfg.moduleName
+    if (!mod) return
+
+    def allModules   = ([mod] + jpmsTestCfg.extraModules).join(',')
+    def mainOut      = project.sourceSets.main.output.classesDirs
+    def apiDeps      = project.configurations.compileClasspath
+    def testSrcPath  = project.files(project.sourceSets.test.java.srcDirs).asPath
+    def modulePath   = (mainOut + apiDeps).asPath
+
+    // Move main output + api deps to the module-path to avoid split-package errors.
+    classpath = classpath.filter { f -> !mainOut.contains(f) && !apiDeps.contains(f) }
+
+    options.compilerArgs += ['--module-path',  modulePath]
+    options.compilerArgs += ['--add-modules',  allModules]
+    options.compilerArgs += ['--patch-module', "${mod}=${testSrcPath}"]
+    options.compilerArgs += ['--add-reads',    "${mod}=ALL-UNNAMED"]
+    jpmsTestCfg.extraReads.each { r -> options.compilerArgs += ['--add-reads', "${mod}=${r}"] }
+}
+
+tasks.named('test') {
+    def mod = jpmsTestCfg.moduleName
+    if (!mod) return
+
+    def allModules      = ([mod] + jpmsTestCfg.extraModules).join(',')
+    def mainOut         = project.sourceSets.main.output.classesDirs
+    def apiDeps         = project.configurations.compileClasspath
+    def testClassesDirs = project.sourceSets.test.output.classesDirs.asPath
+    def modulePath      = (mainOut + apiDeps).asPath
+
+    jvmArgs '--module-path',  modulePath
+    jvmArgs '--add-modules',  allModules
+    jvmArgs '--patch-module', "${mod}=${testClassesDirs}"
+    jvmArgs '--add-reads',    "${mod}=ALL-UNNAMED"
+    jpmsTestCfg.extraReads.each { r -> jvmArgs '--add-reads', "${mod}=${r}" }
+    jpmsTestCfg.extraOpens.each { o -> jvmArgs '--add-opens', "${mod}/${mod}=${o}" }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,17 @@ tasks.register('aggregateJavadoc', Exec) {
     // own module-path during javadoc generation).
     def internalDirs = moduleMap.keySet().collect { project(it).projectDir.absolutePath }
 
-    // Resolved compile classpaths — provide the external dependencies (e.g.
-    // JSpecify, Spring TX) that javadoc needs on the module-path.
-    def externalDepsConfigs = moduleMap.keySet().collect { project(it).configurations.compileClasspath }
+    // Resolved external module-path: all compile-classpath jars across submodules,
+    // filtered to exclude the submodules' own project directories (those come via
+    // --module-source-path), uniqued, and joined into a path string.
+    // Resolved here at configuration time so doFirst never touches Configuration
+    // objects — required for Gradle configuration-cache compliance.
+    def externalModulePath = moduleMap.keySet()
+        .collectMany { project(it).configurations.compileClasspath.files }
+        .findAll { f -> !internalDirs.any { dir -> f.absolutePath.startsWith(dir) } }
+        .collect { it.absolutePath }
+        .unique()
+        .join(File.pathSeparator)
 
     // jpmsName → absolute source directory, used for --module-source-path args.
     def sourceMap = moduleMap.collectEntries { proj, jpmsName ->
@@ -86,30 +94,18 @@ tasks.register('aggregateJavadoc', Exec) {
     // Comma-separated list of JPMS module names for the --module flag.
     def jpmsModules = moduleMap.values().join(',')
 
-    // Declare source directories as task inputs so Gradle detects changes and
-    // re-runs javadoc when sources are modified.
-    sourceMap.each { _, srcPath -> inputs.files fileTree(srcPath) }
+    // Declare Java source files as task inputs so Gradle detects changes and
+    // re-runs javadoc when sources are modified. Only *.java files are tracked
+    // to avoid spurious re-runs when non-source files change.
+    sourceMap.each { _, srcPath -> inputs.files fileTree(srcPath) { include '**/*.java' } }
     outputs.dir destDir
 
     // ── Execution ─────────────────────────────────────────────────────────────
     doFirst {
-        def sep = File.pathSeparator
-
-        // Build the external module-path: all compile-classpath jars that do NOT
-        // belong to one of the documented submodules (those come via --module-source-path).
-        def modulePath = externalDepsConfigs
-            .collectMany { cfg ->
-                cfg.files.findAll { f ->
-                    !internalDirs.any { dir -> f.absolutePath.startsWith(dir) }
-                }*.absolutePath
-            }
-            .unique()
-            .join(sep)
-
         destDir.mkdirs()
 
         executable javadocToolProvider.get().executablePath.asFile.absolutePath
-        args '--module-path', modulePath
+        args '--module-path', externalModulePath
 
         // One --module-source-path per module: tells javadoc where to find the
         // sources for each JPMS module instead of relying on compiled artifacts.

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,16 @@
 plugins {
     id 'dmx-fun.java-base'
-    id 'test-report-aggregation'
-    id 'jacoco-report-aggregation'
+    id 'test-report-aggregation'   // aggregates JUnit XML reports across subprojects
+    id 'jacoco-report-aggregation' // aggregates JaCoCo coverage data across subprojects
 }
 
+// ── Module registry ───────────────────────────────────────────────────────────
 // Single source of truth: Gradle project path → JPMS module name.
-// Add a new entry here to include a module in report aggregation and Javadoc.
+//
+// Adding a new submodule here automatically includes it in:
+//   • test and coverage report aggregation  (dependencies block below)
+//   • ./gradlew check                       (testAggregateTestReport + testCodeCoverageReport)
+//   • ./gradlew aggregateJavadoc            (--module-source-path + --module args)
 def moduleMap = [
     ':lib'     : 'dmx.fun',
     ':assertj' : 'dmx.fun.assertj',
@@ -13,6 +18,9 @@ def moduleMap = [
     ':spring'  : 'dmx.fun.spring',
 ]
 
+// ── Report aggregation ────────────────────────────────────────────────────────
+// Pulls test results and coverage data from every registered submodule so that
+// the root-level reports cover the whole codebase in one pass.
 dependencies {
     moduleMap.keySet().each {
         testReportAggregation project(it)
@@ -30,15 +38,25 @@ reporting {
     }
 }
 
+// Wire aggregate reports into the standard lifecycle check task so that
+// `./gradlew check` always produces a unified HTML report and coverage summary.
 tasks.named('check') {
     dependsOn tasks.named('testAggregateTestReport')
     dependsOn tasks.named('testCodeCoverageReport')
 }
 
+// ── Aggregate Javadoc ─────────────────────────────────────────────────────────
+// Invokes the javadoc tool directly (via Exec) rather than Gradle's built-in
+// javadoc task so that we can pass --module-source-path for true multi-module
+// Javadoc generation. Each module's sources are discovered from moduleMap.
+//
+// Run with:  ./gradlew aggregateJavadoc
+// Output:    build/reports/javadoc/index.html
 tasks.register('aggregateJavadoc', Exec) {
-    group = 'documentation'
+    group       = 'documentation'
     description = 'Generates aggregated multi-module Javadoc for all dmx-fun modules.'
 
+    // Ensure every module is compiled before javadoc runs.
     dependsOn moduleMap.keySet().collect { "${it}:compileJava" }
 
     def javadocToolProvider = javaToolchains.javadocToolFor {
@@ -46,20 +64,39 @@ tasks.register('aggregateJavadoc', Exec) {
     }
     def destDir = file('build/reports/javadoc')
 
-    // Capture all project-relative values at configuration time (config-cache safe).
-    def internalDirs      = moduleMap.keySet().collect { project(it).projectDir.absolutePath }
+    // ── Configuration-time captures (config-cache safe) ───────────────────────
+    // All values that reference other projects must be resolved here, not inside
+    // doFirst, because the configuration cache forbids calling project() at
+    // execution time.
+
+    // Absolute paths of subproject root dirs — used to exclude internal artifacts
+    // from the external module-path (avoids putting a submodule's own jar on its
+    // own module-path during javadoc generation).
+    def internalDirs = moduleMap.keySet().collect { project(it).projectDir.absolutePath }
+
+    // Resolved compile classpaths — provide the external dependencies (e.g.
+    // JSpecify, Spring TX) that javadoc needs on the module-path.
     def externalDepsConfigs = moduleMap.keySet().collect { project(it).configurations.compileClasspath }
-    def sourceMap         = moduleMap.collectEntries { proj, jpmsName ->
+
+    // jpmsName → absolute source directory, used for --module-source-path args.
+    def sourceMap = moduleMap.collectEntries { proj, jpmsName ->
         [(jpmsName): project(proj).file('src/main/java').absolutePath]
     }
-    def jpmsModules       = moduleMap.values().join(',')
 
+    // Comma-separated list of JPMS module names for the --module flag.
+    def jpmsModules = moduleMap.values().join(',')
+
+    // Declare source directories as task inputs so Gradle detects changes and
+    // re-runs javadoc when sources are modified.
     sourceMap.each { _, srcPath -> inputs.files fileTree(srcPath) }
     outputs.dir destDir
 
+    // ── Execution ─────────────────────────────────────────────────────────────
     doFirst {
         def sep = File.pathSeparator
 
+        // Build the external module-path: all compile-classpath jars that do NOT
+        // belong to one of the documented submodules (those come via --module-source-path).
         def modulePath = externalDepsConfigs
             .collectMany { cfg ->
                 cfg.files.findAll { f ->
@@ -73,11 +110,17 @@ tasks.register('aggregateJavadoc', Exec) {
 
         executable javadocToolProvider.get().executablePath.asFile.absolutePath
         args '--module-path', modulePath
-        sourceMap.each { jpmsName, srcPath -> args '--module-source-path', "${jpmsName}=${srcPath}" }
-        args '--module',      jpmsModules
-        args '-d',            destDir.absolutePath
-        args '-doctitle',     'dmx-fun API'
-        args '-windowtitle',  'dmx-fun API'
+
+        // One --module-source-path per module: tells javadoc where to find the
+        // sources for each JPMS module instead of relying on compiled artifacts.
+        sourceMap.each { jpmsName, srcPath ->
+            args '--module-source-path', "${jpmsName}=${srcPath}"
+        }
+
+        args '--module',     jpmsModules      // which modules to document
+        args '-d',           destDir.absolutePath
+        args '-doctitle',    'dmx-fun API'
+        args '-windowtitle', 'dmx-fun API'
         args '-quiet'
         args '-notimestamp'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,17 @@ plugins {
     id 'jacoco-report-aggregation'
 }
 
-dependencies {
-    def modules = [
-        ':lib',
-        ':assertj',
-        ':jackson',
-        ':spring',
-    ]
+// Single source of truth: Gradle project path → JPMS module name.
+// Add a new entry here to include a module in report aggregation and Javadoc.
+def moduleMap = [
+    ':lib'     : 'dmx.fun',
+    ':assertj' : 'dmx.fun.assertj',
+    ':jackson' : 'dmx.fun.jackson',
+    ':spring'  : 'dmx.fun.spring',
+]
 
-    modules.each {
+dependencies {
+    moduleMap.keySet().each {
         testReportAggregation project(it)
         jacocoAggregation project(it)
     }
@@ -35,56 +37,26 @@ tasks.named('check') {
 
 tasks.register('aggregateJavadoc', Exec) {
     group = 'documentation'
-    description = 'Generates aggregated multi-module Javadoc covering dmx.fun, dmx.fun.assertj, and dmx.fun.jackson.'
+    description = 'Generates aggregated multi-module Javadoc for all dmx-fun modules.'
 
-    dependsOn ':lib:compileJava', ':assertj:compileJava', ':jackson:compileJava'
+    dependsOn moduleMap.keySet().collect { "${it}:compileJava" }
 
-    // Capture all project-relative values at configuration time
     def javadocToolProvider = javaToolchains.javadocToolFor {
         languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get().toInteger()))
     }
-    def modules = [
-        ':lib',
-        ':assertj',
-        ':jackson',
-        ':spring',
-    ]
-    def moduleSources = modules.collect {
-        [
-            name:it,
-            location: project(it).file('src/main/java')
-        ]
+    def destDir = file('build/reports/javadoc')
+
+    // Capture all project-relative values at configuration time (config-cache safe).
+    def internalDirs      = moduleMap.keySet().collect { project(it).projectDir.absolutePath }
+    def externalDepsConfigs = moduleMap.keySet().collect { project(it).configurations.compileClasspath }
+    def sourceMap         = moduleMap.collectEntries { proj, jpmsName ->
+        [(jpmsName): project(proj).file('src/main/java').absolutePath]
     }
-    def libSrc     = project(':lib').file('src/main/java')
-    def assertjSrc = project(':assertj').file('src/main/java')
-    def jacksonSrc = project(':jackson').file('src/main/java')
-    def springSrc = project(':spring').file('src/main/java')
-    def destDir    = file('build/reports/javadoc')
-    // Only external dependencies on the module-path; the three documented modules
-    // are found via --module-source-path so their artifacts must NOT appear here.
-    def internalDirs = modules.collect {
-        project(it).projectDir.absolutePath
-    }
-//    def internalDirs = [
-//        project(':lib').projectDir.absolutePath,
-//        project(':assertj').projectDir.absolutePath,
-//        project(':jackson').projectDir.absolutePath,
-//    ]
-//    def externalDepsConfigs = [
-//        project(':lib').configurations.compileClasspath,
-//        project(':assertj').configurations.compileClasspath,
-//        project(':jackson').configurations.compileClasspath,
-//    ]
-    def externalDepsConfigs = modules.collect {
-        project(it).configurations.compileClasspath
-    }
-    modules.each {
-        inputs.files fileTree(it)
-    }
-    //inputs.files fileTree(libSrc), fileTree(assertjSrc), fileTree(jacksonSrc)
+    def jpmsModules       = moduleMap.values().join(',')
+
+    sourceMap.each { _, srcPath -> inputs.files fileTree(srcPath) }
     outputs.dir destDir
 
-    // Build the command at execution time (configs are not yet resolved at configuration time)
     doFirst {
         def sep = File.pathSeparator
 
@@ -100,20 +72,12 @@ tasks.register('aggregateJavadoc', Exec) {
         destDir.mkdirs()
 
         executable javadocToolProvider.get().executablePath.asFile.absolutePath
-        args '--module-path',        modulePath
-        args '--module-source-path', "dmx.fun=${libSrc.absolutePath}"
-        args '--module-source-path', "dmx.fun.assertj=${assertjSrc.absolutePath}"
-        args '--module-source-path', "dmx.fun.jackson=${jacksonSrc.absolutePath}"
-        args '--module-source-path', "dmx.fun.spring=${springSrc.absolutePath}"
-        args '--module',             'dmx.fun,dmx.fun.assertj,dmx.fun.jackson,dmx.fun.spring'
-
-//        moduleSources.each {
-//            args '--module-source-path', "dmx.${it.name}=${it.location.absolutePath}"
-//        }
-
-        args '-d',                   destDir.absolutePath
-        args '-doctitle',            'dmx-fun API'
-        args '-windowtitle',         'dmx-fun API'
+        args '--module-path', modulePath
+        sourceMap.each { jpmsName, srcPath -> args '--module-source-path', "${jpmsName}=${srcPath}" }
+        args '--module',      jpmsModules
+        args '-d',            destDir.absolutePath
+        args '-doctitle',     'dmx-fun API'
+        args '-windowtitle',  'dmx-fun API'
         args '-quiet'
         args '-notimestamp'
     }

--- a/jackson/build.gradle
+++ b/jackson/build.gradle
@@ -1,10 +1,20 @@
+// ── Jackson integration module ────────────────────────────────────────────────
+// Optional module — users must already have Jackson on their classpath.
+// Provides serializers and deserializers for all dmx-fun types.
 plugins {
     id 'dmx-fun.java-module'
 }
 
 dependencies {
+    // Exposes dmx-fun types to callers; they only need one dependency declaration.
     api project(':lib')
+
+    // Jackson is an optional peer dependency: declared compileOnly so it is not
+    // pulled in transitively. Users bring their own version.
     compileOnly libs.jackson.databind
+
+    // Tests run against the version passed via -PjacksonVersion=X.Y.Z (used by
+    // the CI compatibility matrix), falling back to the catalog version locally.
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${findProperty('jacksonVersion') ?: libs.versions.jackson.get()}"
 }
 

--- a/jackson/build.gradle
+++ b/jackson/build.gradle
@@ -8,26 +8,14 @@ dependencies {
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${findProperty('jacksonVersion') ?: libs.versions.jackson.get()}"
 }
 
-compileTestJava {
-    def mainClassesDirs = sourceSets.main.output.classesDirs
-    def apiDeps = configurations.compileClasspath
-    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
-
-    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
-
-    def modulePath = (mainClassesDirs + apiDeps).asPath
-    options.compilerArgs += [
-        '--module-path', modulePath,
-        '--add-modules', 'dmx.fun.jackson',
-        '--patch-module', "dmx.fun.jackson=${testSrcPath}",
-        '--add-reads', 'dmx.fun.jackson=ALL-UNNAMED',
-    ]
+jpmsTest {
+    moduleName = 'dmx.fun.jackson'
 }
 
 mavenPublishing {
     coordinates("codes.domix", "fun-jackson", "${project.version}")
     pom {
         name = 'dmx-fun Jackson integration'
-        description = 'Optional Jackson module for dmx-fun: serializers and deserializers for Option, Result, Try, Validated, Either, Lazy, Tuple2/3/4, and NonEmptyList.'
+        description = 'Jackson module for dmx-fun: serializers and deserializers for Option, Result, Try, Validated, Either, Lazy, Tuple2/3/4, and NonEmptyList.'
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,22 +7,10 @@ dependencies {
     api libs.jspecify
 }
 
-compileTestJava {
-    def mainClassesDirs = sourceSets.main.output.classesDirs
-    def apiDeps = configurations.compileClasspath   // api-scoped deps (jspecify)
-    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
-
-    // Move main output + api deps off the classpath → module-path to avoid split-package conflict
-    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
-
-    def modulePath = (mainClassesDirs + apiDeps).asPath
-    options.compilerArgs += [
-        '--module-path', modulePath,
-        '--add-modules', 'dmx.fun,java.net.http',
-        '--patch-module', "dmx.fun=${testSrcPath}",
-        '--add-reads', 'dmx.fun=ALL-UNNAMED',
-        '--add-reads', 'dmx.fun=java.net.http'
-    ]
+jpmsTest {
+    moduleName   = 'dmx.fun'
+    extraModules = ['java.net.http']
+    extraReads   = ['java.net.http']
 }
 
 mavenPublishing {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,12 +1,19 @@
+// ── Core library module ───────────────────────────────────────────────────────
+// The dmx.fun module is the only artifact that end users must always declare.
+// All other modules (assertj, jackson, spring, …) depend on it via `api project(':lib')`.
 plugins {
     id 'dmx-fun.java-module'
 }
 
 dependencies {
-    // Null-safety annotations (part of the public API)
+    // JSpecify null-safety annotations (@NullMarked, @Nullable) are part of the
+    // public API contract — callers need them on their compile classpath.
     api libs.jspecify
 }
 
+// java.net.http is used in tests that exercise Try/Result with HttpClient.
+// extraModules makes it visible to the patched test module at both compile and
+// runtime; extraReads grants the module permission to read java.net.http types.
 jpmsTest {
     moduleName   = 'dmx.fun'
     extraModules = ['java.net.http']

--- a/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
+++ b/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
@@ -9,16 +9,22 @@ plugins {
 
 dependencies {
     api project(':lib')
-    compileOnly libs.spring.context          // optional peer dependency
-    testImplementation libs.spring.context   // or property-driven version
+    compileOnly libs.spring.context                              // optional peer dep
+    testImplementation "org.springframework:spring-context:${findProperty('springVersion') ?: libs.versions.spring.get()}"
+}
+
+// Wire JPMS test flags automatically via the convention plugin DSL.
+// moduleName is required; extraModules/extraReads/extraOpens are optional.
+jpmsTest {
+    moduleName = 'dmx.fun.newmod'
 }
 
 mavenPublishing {
-    coordinates("codes.domix", "fun-spring", "${project.version}")
+    coordinates("codes.domix", "fun-newmod", "${project.version}")
 
     pom {
-        name = 'dmx-fun Spring integration'
-        description = 'Optional Spring module for dmx-fun: ...'
+        name = 'dmx-fun Newmod integration'
+        description = 'Optional Newmod module for dmx-fun: ...'
     }
 }
 ```

--- a/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
+++ b/site/src/data/code/guide/module-conventions/new-module-build-gradle.mdx
@@ -24,7 +24,7 @@ mavenPublishing {
 
     pom {
         name = 'dmx-fun Newmod integration'
-        description = 'Optional Newmod module for dmx-fun: ...'
+        description = 'Newmod module for dmx-fun: ...'
     }
 }
 ```

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -115,6 +115,111 @@ docs/guide/adding-validated-examples
 
 All PRs run the full CI pipeline (`gradle.yml`) automatically.
 
+## CI pipelines
+
+All pipelines live in `.github/workflows/`. The table below is a quick reference; the sections
+that follow explain each one in detail.
+
+| File                              | Trigger                             | Purpose                                     |
+|-----------------------------------|-------------------------------------|---------------------------------------------|
+| `gradle.yml`                      | push to `main`, any PR              | Full build, tests, coverage                 |
+| `publish.yml`                     | push to `main` (stable version)     | Publish to Maven Central + create GH tag    |
+| `publish-snapshot.yml`            | push to `main` (SNAPSHOT version)   | Publish SNAPSHOT to Maven Central           |
+| `pages.yml`                       | push to `main`, manual dispatch     | Build Javadoc + Astro site → GitHub Pages   |
+| `assertj-compatibility.yaml`      | PR touching `assertj/**`            | Matrix: AssertJ 3.21 – 3.27                 |
+| `jackson-compatibility.yaml`      | PR touching `jackson/**`            | Matrix: Jackson 2.13 – 2.21                 |
+| `spring-compatibility.yaml`       | PR touching `spring/**`             | Matrix: Spring 6.0 – 7.0                   |
+
+### `gradle.yml` — Main CI
+
+Runs on every push to `main` and on every pull request against `main`.
+For pushes, a `dorny/paths-filter` step skips the build job when none of the source directories
+have changed (avoids redundant runs for docs-only commits). For PRs, the build always runs.
+
+```
+./gradlew build
+```
+
+This compiles all modules, runs all tests, generates the aggregated test report and JaCoCo
+coverage report. A `madrapps/jacoco-report` step then posts coverage deltas as a PR comment.
+
+A separate `dependency-submission` job (push-only) submits the dependency graph to GitHub so
+Dependabot can raise alerts for vulnerable transitive dependencies.
+
+### `publish.yml` — Stable release
+
+Triggered on push to `main` when the changed paths include source or build files. The workflow
+reads `version` from `gradle.properties` and skips entirely if:
+- the version ends with `-SNAPSHOT`, or
+- the tag `v{version}` already exists in the remote.
+
+When both checks pass it runs the full test suite, publishes all modules to Maven Central, pushes
+the release tag, and creates a GitHub Release with auto-generated release notes.
+
+The required repository secrets are:
+
+| Secret                         | Used for                     |
+|--------------------------------|------------------------------|
+| `MAVEN_CENTRAL_USERNAME`       | Maven Central auth           |
+| `MAVEN_CENTRAL_PASSWORD`       | Maven Central auth           |
+| `SIGNING_KEY_ID`               | In-memory PGP key ID         |
+| `SIGNING_KEY`                  | In-memory PGP key (armored)  |
+| `SIGNING_KEY_PASSWORD`         | PGP key passphrase           |
+
+To trigger a stable release: set `version=X.Y.Z` (no `-SNAPSHOT`) in `gradle.properties` and
+push to `main`.
+
+### `publish-snapshot.yml` — SNAPSHOT publish
+
+Mirrors `publish.yml` but fires when `version` ends with `-SNAPSHOT`. It runs tests then
+publishes to Maven Central's snapshot repository. No tag is created.
+
+To trigger: ensure `version=X.Y.Z-SNAPSHOT` in `gradle.properties` and push to `main`.
+
+### `pages.yml` — GitHub Pages deploy
+
+Triggered on push to `main` when `site/**`, any `build.gradle`, or source files under
+`lib/src/main/`, `assertj/src/main/`, or `jackson/src/main/` change. Also supports
+`workflow_dispatch` for manual deploys.
+
+Steps:
+1. `./gradlew aggregateJavadoc` — builds multi-module Javadoc into `build/reports/javadoc/`
+2. `npm run build` (in `site/`) — copies the Javadoc into `site/public/` and produces `site/dist/`
+3. Uploads `site/dist/` as a Pages artifact and deploys via `actions/deploy-pages`
+
+To preview the site locally without triggering CI:
+
+```bash
+./gradlew aggregateJavadoc
+cd site && npm run dev
+```
+
+### Compatibility matrix workflows
+
+Each optional-dependency module has its own matrix workflow that runs on PRs touching that
+module's directory. The matrix version is passed as a Gradle property; the build falls back to
+the version catalog entry when the property is absent (safe for local development).
+
+| Workflow                         | Gradle property      | Tested range            |
+|----------------------------------|----------------------|-------------------------|
+| `assertj-compatibility.yaml`     | `-PassertjVersion`   | `3.21.0` – `3.27.7`    |
+| `jackson-compatibility.yaml`     | `-PjacksonVersion`   | `2.13.5` – `2.21.2`    |
+| `spring-compatibility.yaml`      | `-PspringVersion`    | `6.0.23` – `7.0.6`     |
+
+To run a specific version locally:
+
+```bash
+./gradlew :assertj:test -PassertjVersion=3.25.3
+./gradlew :jackson:test -PjacksonVersion=2.17.3
+./gradlew :spring:test  -PspringVersion=6.1.21
+```
+
+When you add a new module with an optional peer dependency, create
+`.github/workflows/{module}-compatibility.yaml` following this same pattern.
+See step 6 of the [Adding a New Module](./module-conventions) guide for details.
+
+---
+
 ## Note on `lib/src/test/resources/`
 
 This directory is intentionally untracked (it appears in `git status` as untracked).

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -40,20 +40,54 @@ Key rules:
 include('fun-spring')
 ```
 
-### 3. Add to the root `build.gradle` aggregation
+### 3. Register in the root `moduleMap`
 
-The root `build.gradle` aggregates test reports and Javadoc. Add the new module to both:
+The root `build.gradle` uses a `moduleMap` as the single source of truth for all submodules.
+Adding one entry here automatically wires the module into test-report aggregation, JaCoCo
+coverage aggregation, and the `aggregateJavadoc` task — no other changes to the root build file
+are needed.
 
 ```groovy
-dependencies {
-    testReportAggregation project(':fun-spring')
-    jacocoAggregation      project(':fun-spring')
+// build.gradle (root)
+def moduleMap = [
+    ':lib'          : 'dmx.fun',
+    ':assertj'      : 'dmx.fun.assertj',
+    ':jackson'      : 'dmx.fun.jackson',
+    ':spring'       : 'dmx.fun.spring',
+    ':fun-newmod'   : 'dmx.fun.newmod',   // ← add this line
+]
+```
+
+### 4. Configure JPMS tests
+
+The `dmx-fun.java-module` convention plugin exposes a `jpmsTest` DSL block that wires
+`--module-path`, `--patch-module`, and `--add-modules` into `compileTestJava` and `test`
+automatically. Add it to the module's `build.gradle`:
+
+```groovy
+// Minimal — only moduleName is required
+jpmsTest {
+    moduleName = 'dmx.fun.newmod'
+}
+
+// Extended — for modules with extra JPMS requirements
+jpmsTest {
+    moduleName   = 'dmx.fun.newmod'
+    extraModules = ['java.sql']            // added to --add-modules
+    extraReads   = ['java.sql']            // generates --add-reads moduleName=X
+    extraOpens   = ['ALL-UNNAMED',         // generates --add-opens moduleName/moduleName=X
+                    'spring.core']
 }
 ```
 
-And add its source directory to the `aggregateJavadoc` task's `--module-source-path` arguments.
+| Property      | Type           | Required | Description                                                  |
+|---------------|----------------|----------|--------------------------------------------------------------|
+| `moduleName`  | `String`       | yes      | JPMS module name (`dmx.fun.*`)                               |
+| `extraModules`| `List<String>` | no       | Extra `--add-modules` entries needed at test compile/runtime |
+| `extraReads`  | `List<String>` | no       | Extra `--add-reads moduleName=X` entries                     |
+| `extraOpens`  | `List<String>` | no       | Extra `--add-opens moduleName/moduleName=X` entries          |
 
-### 4. Expand CI path triggers
+### 5. Expand CI path triggers
 
 Four workflow files reference module paths — update all of them:
 
@@ -63,7 +97,7 @@ Four workflow files reference module paths — update all of them:
 | `.github/workflows/publish.yml`          | `paths:` block                                         |
 | `.github/workflows/publish-snapshot.yml` | `paths:` block                                         |
 
-### 5. Add a compatibility matrix workflow
+### 6. Add a compatibility matrix workflow
 
 If the module has an optional peer dependency, create `.github/workflows/{module}-compatibility.yaml`
 following the pattern of `jackson-compatibility.yaml`:
@@ -72,19 +106,19 @@ following the pattern of `jackson-compatibility.yaml`:
 - Matrix: one entry per supported version of the peer dependency
 - Run: `./gradlew :{module}:test -P{module}Version={version}`
 
-### 6. Write a `README.md` in the module root
+### 7. Write a `README.md` in the module root
 
 Cover: what the module does, Maven/Gradle coordinates, usage snippet, version compatibility table.
 See `jackson/README.md` or `assertj/README.md` for the expected format.
 
-### 7. Add a guide page
+### 8. Add a guide page
 
 Create `site/src/data/guide/{module-name}.mdx` following the established guide style:
 - `order` should be the next available integer after the last module guide
 - Externalize all code snippets into `site/src/data/code/guide/{module-name}/`
 - Include a version compatibility table matching the CI matrix
 
-### 8. Register in the guide index
+### 9. Register in the guide index
 
 Add a card to the `modules` array in `site/src/pages/guide/index.astro`:
 

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -84,9 +84,14 @@ jpmsTest {
 | Property      | Type           | Required | Description                                                  |
 |---------------|----------------|----------|--------------------------------------------------------------|
 | `moduleName`  | `String`       | yes      | JPMS module name (`dmx.fun.*`)                               |
-| `extraModules`| `List<String>` | no       | Extra `--add-modules` entries needed at test compile/runtime |
+| `extraModules`| `List<String>` | no       | Extra `--add-modules` entries added at both compile and runtime |
 | `extraReads`  | `List<String>` | no       | Extra `--add-reads moduleName=X` entries                     |
-| `extraOpens`  | `List<String>` | no       | Plain string: `--add-opens moduleName/moduleName=target` (root package only). `'pkg=target'` form: `--add-opens moduleName/pkg=target` (named subpackage) |
+| `extraOpens`  | `List<String>` | no       | Plain string: `--add-opens moduleName/moduleName=target` (root package only). `'pkg=target'` form: `--add-opens moduleName/pkg=target` (named subpackage). Malformed `'pkg=target'` entries (empty package or target) throw a `GradleException` at configuration time. |
+
+> **`testRuntimeOnly` dependencies**: the `test` task builds the module-path from
+> `runtimeClasspath`, so `testRuntimeOnly` entries (e.g. a JDBC driver declared as
+> `testRuntimeOnly libs.postgresql`) are correctly visible to the JVM at test time.
+> No extra `jpmsTest` configuration is needed for runtime-only dependencies.
 
 ### 5. Expand CI path triggers
 

--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -75,8 +75,9 @@ jpmsTest {
     moduleName   = 'dmx.fun.newmod'
     extraModules = ['java.sql']            // added to --add-modules
     extraReads   = ['java.sql']            // generates --add-reads moduleName=X
-    extraOpens   = ['ALL-UNNAMED',         // generates --add-opens moduleName/moduleName=X
-                    'spring.core']
+    extraOpens   = ['ALL-UNNAMED',         // plain string → opens module's root package to target
+                    'spring.core',         //   (--add-opens moduleName/moduleName=target)
+                    'dmx.fun.x=spring.tx'] // 'pkg=target' form → opens pkg to target
 }
 ```
 
@@ -85,7 +86,7 @@ jpmsTest {
 | `moduleName`  | `String`       | yes      | JPMS module name (`dmx.fun.*`)                               |
 | `extraModules`| `List<String>` | no       | Extra `--add-modules` entries needed at test compile/runtime |
 | `extraReads`  | `List<String>` | no       | Extra `--add-reads moduleName=X` entries                     |
-| `extraOpens`  | `List<String>` | no       | Extra `--add-opens moduleName/moduleName=X` entries          |
+| `extraOpens`  | `List<String>` | no       | Plain string: `--add-opens moduleName/moduleName=target` (root package only). `'pkg=target'` form: `--add-opens moduleName/pkg=target` (named subpackage) |
 
 ### 5. Expand CI path triggers
 

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -1,20 +1,40 @@
+// ── Spring integration module ─────────────────────────────────────────────────
+// Optional module — users must already have Spring Framework on their classpath.
+// Provides transaction-aware wrappers (TxResult, TxTry, TxValidated) that execute
+// actions inside a Spring-managed transaction and return dmx-fun types instead of
+// throwing exceptions.
 plugins {
     id 'dmx-fun.java-module'
 }
 
 dependencies {
+    // Exposes dmx-fun types to callers; they only need one dependency declaration.
     api project(':lib')
-    compileOnly libs.spring.tx
-    compileOnly libs.spring.context
+
+    // Spring is an optional peer dependency: declared compileOnly so it is not
+    // pulled in transitively. Users bring their own Spring version.
+    compileOnly libs.spring.tx       // PlatformTransactionManager, TransactionTemplate
+    compileOnly libs.spring.context  // @Component for TxResult / TxTry / TxValidated
+
+    // Tests run against the version passed via -PspringVersion=X.Y.Z (used by
+    // the CI compatibility matrix), falling back to the catalog version locally.
     testImplementation "org.springframework:spring-tx:${findProperty('springVersion') ?: libs.versions.spring.get()}"
     testImplementation "org.springframework:spring-context:${findProperty('springVersion') ?: libs.versions.spring.get()}"
     testImplementation "org.springframework:spring-jdbc:${findProperty('springVersion') ?: libs.versions.spring.get()}"
+
+    // Integration tests use H2 for lightweight unit tests and Testcontainers +
+    // PostgreSQL to verify real rollback/commit behaviour across isolation levels.
     testImplementation libs.h2
     testImplementation libs.testcontainers.junit5
     testImplementation libs.testcontainers.postgresql
-    testRuntimeOnly libs.postgresql
+    testRuntimeOnly    libs.postgresql
 }
 
+// java.sql is required at both compile and runtime because Spring's transaction
+// infrastructure uses JDBC types (Connection, DataSource) that live in java.sql.
+// extraOpens allows Spring's reflection-heavy internals (spring.core, spring.beans,
+// spring.context) and JUnit's unnamed module to access test classes that are
+// patched into the named dmx.fun.spring module.
 jpmsTest {
     moduleName   = 'dmx.fun.spring'
     extraModules = ['java.sql']

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -15,37 +15,11 @@ dependencies {
     testRuntimeOnly libs.postgresql
 }
 
-compileTestJava {
-    def mainClassesDirs = sourceSets.main.output.classesDirs
-    def apiDeps = configurations.compileClasspath
-    def testSrcPath = files(sourceSets.test.java.srcDirs).asPath
-
-    classpath = classpath.filter { f -> !mainClassesDirs.contains(f) && !apiDeps.contains(f) }
-
-    def modulePath = (mainClassesDirs + apiDeps).asPath
-    options.compilerArgs += [
-        '--module-path', modulePath,
-        '--add-modules', 'dmx.fun.spring,java.sql',
-        '--patch-module', "dmx.fun.spring=${testSrcPath}",
-        '--add-reads', 'dmx.fun.spring=ALL-UNNAMED',
-        '--add-reads', 'dmx.fun.spring=java.sql',
-    ]
-}
-
-test {
-    def mainClassesDirs = sourceSets.main.output.classesDirs
-    def apiDeps = configurations.compileClasspath
-    def testClassesDirs = sourceSets.test.output.classesDirs.asPath
-    def modulePath = (mainClassesDirs + apiDeps).asPath
-
-    jvmArgs += [
-        '--module-path', modulePath,
-        '--add-modules', 'dmx.fun.spring,java.sql',
-        '--patch-module', "dmx.fun.spring=${testClassesDirs}",
-        '--add-reads', 'dmx.fun.spring=ALL-UNNAMED',
-        '--add-reads', 'dmx.fun.spring=java.sql',
-        '--add-opens', 'dmx.fun.spring/dmx.fun.spring=ALL-UNNAMED',
-    ]
+jpmsTest {
+    moduleName   = 'dmx.fun.spring'
+    extraModules = ['java.sql']
+    extraReads   = ['java.sql']
+    extraOpens   = ['ALL-UNNAMED', 'spring.core', 'spring.beans', 'spring.context']
 }
 
 mavenPublishing {


### PR DESCRIPTION
- **build: extract JPMS test-patching boilerplate into dmx-fun.java-module plugin**
- **build: eliminate duplication in root build.gradle via moduleMap**
- **docs(build): add inline documentation to root build.gradle**
- **docs(guide): document moduleMap, jpmsTest DSL, and CI pipelines**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #248

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CI pipelines guide for GitHub Actions and updated module conventions with JPMS test configuration examples.

* **Chores**
  * Centralized module registration for aggregation and Javadoc generation.
  * Standardized JPMS test configuration across modules (new jpmsTest DSL).
  * Cleaned up Gradle build and dependency declarations and updated Maven POM descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->