### PR TITLE
build(ci): add Gradle build cache to pages and compatibility matrix workflows

### DIFF
--- a/.github/workflows/assertj-compatibility.yaml
+++ b/.github/workflows/assertj-compatibility.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v6
       # Pass the matrix version as a Gradle property; the build falls back to
       # the catalog version when the property is absent (local development).
       - run: ./gradlew :assertj:test -PassertjVersion=${{ matrix.assertj-version }}

--- a/.github/workflows/jackson-compatibility.yaml
+++ b/.github/workflows/jackson-compatibility.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v6
       # Pass the matrix version as a Gradle property; the build falls back to
       # the catalog version when the property is absent (local development).
       - run: ./gradlew :jackson:test -PjacksonVersion=${{ matrix.jackson-version }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,6 +49,9 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
       - name: Install
         run: npm ci
         working-directory: site

--- a/.github/workflows/spring-compatibility.yaml
+++ b/.github/workflows/spring-compatibility.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v6
       # Pass the matrix version as a Gradle property; the build falls back to
       # the catalog version when the property is absent (local development).
       - run: ./gradlew :spring:test -PspringVersion=${{ matrix.spring-version }}


### PR DESCRIPTION
  pages.yml, assertj-compatibility.yaml, jackson-compatibility.yaml, and
  spring-compatibility.yaml were missing gradle/actions/setup-gradle, causing
  every run to re-download the Gradle wrapper and all dependencies from scratch.
  Add the setup-gradle@v6 step after setup-java in each workflow so that the
  Gradle home cache is shared across runs and matrix jobs.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
