### PR TITLE
test(spring): enable fun-assertj fluent assertions in test suite

### DIFF
--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -28,6 +28,13 @@ dependencies {
     testImplementation libs.testcontainers.junit5
     testImplementation libs.testcontainers.postgresql
     testRuntimeOnly    libs.postgresql
+
+    // Fluent assertions for dmx-fun types (ResultAssert, TryAssert, etc.).
+    // compileOnly puts dmx.fun.assertj on compileClasspath so the JPMS module-path
+    // plugin can expose it to compileTestJava; testImplementation covers test runtime.
+    // assertj-core is already on the classpath via dmx-fun.java-base.
+    compileOnly        project(':assertj')
+    testImplementation project(':assertj')
 }
 
 // java.sql is required at both compile and runtime because Spring's transaction
@@ -37,9 +44,15 @@ dependencies {
 // patched into the named dmx.fun.spring module.
 jpmsTest {
     moduleName   = 'dmx.fun.spring'
-    extraModules = ['java.sql']
-    extraReads   = ['java.sql']
+    extraModules = ['java.sql', 'dmx.fun.assertj']
+    extraReads   = ['java.sql', 'dmx.fun.assertj']
     extraOpens   = ['ALL-UNNAMED', 'spring.core', 'spring.beans', 'spring.context']
+}
+
+// assertj-core is on the classpath (unnamed module) at compile time but dmx.fun.assertj
+// is on the module path and requires it. This read allows the compiler to resolve it.
+tasks.named('compileTestJava') {
+    options.compilerArgs += ['--add-reads', 'dmx.fun.assertj=ALL-UNNAMED']
 }
 
 mavenPublishing {

--- a/spring/src/test/java/dmx/fun/spring/TxResultPostgresTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxResultPostgresTest.java
@@ -12,6 +12,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -61,7 +62,7 @@ class TxResultPostgresTest {
             return Result.ok(1);
         });
 
-        assertThat(result.isOk()).isTrue();
+        assertThat(result).isOk();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -72,7 +73,7 @@ class TxResultPostgresTest {
             return Result.err("domain error");
         });
 
-        assertThat(result.isError()).isTrue();
+        assertThat(result).isErr();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -95,7 +96,7 @@ class TxResultPostgresTest {
             return Result.err("rollback");
         });
 
-        assertThat(result.isError()).isTrue();
+        assertThat(result).isErr();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -107,7 +108,7 @@ class TxResultPostgresTest {
             return Result.err("partial");
         });
 
-        assertThat(result.isError()).isTrue();
+        assertThat(result).isErr();
         assertThat(countRows()).isEqualTo(0);
     }
 }

--- a/spring/src/test/java/dmx/fun/spring/TxResultTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxResultTest.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,8 +65,7 @@ class TxResultTest {
             return Result.ok(1);
         });
 
-        assertThat(result.isOk()).isTrue();
-        assertThat(result.get()).isEqualTo(1);
+        assertThat(result).isOk().containsValue(1);
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -76,8 +76,7 @@ class TxResultTest {
             return Result.err("domain error");
         });
 
-        assertThat(result.isError()).isTrue();
-        assertThat(result.getError()).isEqualTo("domain error");
+        assertThat(result).isErr().containsError("domain error");
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -117,7 +116,7 @@ class TxResultTest {
             return Result.ok(4);
         });
 
-        assertThat(result.isOk()).isTrue();
+        assertThat(result).isOk();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -129,7 +128,7 @@ class TxResultTest {
             return Result.err("rollback me");
         });
 
-        assertThat(result.isError()).isTrue();
+        assertThat(result).isErr();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -159,7 +158,7 @@ class TxResultTest {
             return Result.err("partial work");
         });
 
-        assertThat(result.isError()).isTrue();
+        assertThat(result).isErr();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -171,7 +170,7 @@ class TxResultTest {
             return Result.ok(2);
         });
 
-        assertThat(result.isOk()).isTrue();
+        assertThat(result).isOk();
         assertThat(countRows()).isEqualTo(2);
     }
 }

--- a/spring/src/test/java/dmx/fun/spring/TxTryPostgresTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxTryPostgresTest.java
@@ -12,6 +12,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -60,7 +61,7 @@ class TxTryPostgresTest {
             return Try.success(1);
         });
 
-        assertThat(result.isSuccess()).isTrue();
+        assertThat(result).isSuccess();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -72,7 +73,7 @@ class TxTryPostgresTest {
             return Try.failure(ex);
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -95,7 +96,7 @@ class TxTryPostgresTest {
             return Try.failure(new RuntimeException("rollback"));
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -107,7 +108,7 @@ class TxTryPostgresTest {
             return Try.failure(new RuntimeException("partial"));
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(countRows()).isEqualTo(0);
     }
 }

--- a/spring/src/test/java/dmx/fun/spring/TxTryTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxTryTest.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,8 +65,7 @@ class TxTryTest {
             return Try.success(1);
         });
 
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.get()).isEqualTo(1);
+        assertThat(result).isSuccess().containsValue(1);
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -77,7 +77,7 @@ class TxTryTest {
             return Try.failure(ex);
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(result.getCause()).isSameAs(ex);
         assertThat(countRows()).isEqualTo(0);
     }
@@ -118,7 +118,7 @@ class TxTryTest {
             return Try.success(4);
         });
 
-        assertThat(result.isSuccess()).isTrue();
+        assertThat(result).isSuccess();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -130,7 +130,7 @@ class TxTryTest {
             return Try.failure(new RuntimeException("rollback"));
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -160,7 +160,7 @@ class TxTryTest {
             return Try.failure(new RuntimeException("partial work"));
         });
 
-        assertThat(result.isFailure()).isTrue();
+        assertThat(result).isFailure();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -172,7 +172,7 @@ class TxTryTest {
             return Try.success(2);
         });
 
-        assertThat(result.isSuccess()).isTrue();
+        assertThat(result).isSuccess();
         assertThat(countRows()).isEqualTo(2);
     }
 }

--- a/spring/src/test/java/dmx/fun/spring/TxValidatedPostgresTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxValidatedPostgresTest.java
@@ -12,6 +12,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -57,7 +58,7 @@ class TxValidatedPostgresTest {
             return Validated.valid(1);
         });
 
-        assertThat(result.isValid()).isTrue();
+        assertThat(result).isValid();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -68,7 +69,7 @@ class TxValidatedPostgresTest {
             return Validated.invalid("validation error");
         });
 
-        assertThat(result.isInvalid()).isTrue();
+        assertThat(result).isInvalid();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -91,7 +92,7 @@ class TxValidatedPostgresTest {
             return Validated.invalid("rollback");
         });
 
-        assertThat(result.isInvalid()).isTrue();
+        assertThat(result).isInvalid();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -103,7 +104,7 @@ class TxValidatedPostgresTest {
             return Validated.invalid("partial");
         });
 
-        assertThat(result.isInvalid()).isTrue();
+        assertThat(result).isInvalid();
         assertThat(countRows()).isEqualTo(0);
     }
 }

--- a/spring/src/test/java/dmx/fun/spring/TxValidatedTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TxValidatedTest.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -63,8 +64,7 @@ class TxValidatedTest {
             return Validated.valid(1);
         });
 
-        assertThat(result.isValid()).isTrue();
-        assertThat(result.get()).isEqualTo(1);
+        assertThat(result).isValid().containsValue(1);
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -75,8 +75,7 @@ class TxValidatedTest {
             return Validated.invalid("validation failed");
         });
 
-        assertThat(result.isInvalid()).isTrue();
-        assertThat(result.getError()).isEqualTo("validation failed");
+        assertThat(result).isInvalid().hasError("validation failed");
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -116,7 +115,7 @@ class TxValidatedTest {
             return Validated.valid(4);
         });
 
-        assertThat(result.isValid()).isTrue();
+        assertThat(result).isValid();
         assertThat(countRows()).isEqualTo(1);
     }
 
@@ -128,7 +127,7 @@ class TxValidatedTest {
             return Validated.invalid("rollback me");
         });
 
-        assertThat(result.isInvalid()).isTrue();
+        assertThat(result).isInvalid();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -158,7 +157,7 @@ class TxValidatedTest {
             return Validated.invalid("partial work");
         });
 
-        assertThat(result.isInvalid()).isTrue();
+        assertThat(result).isInvalid();
         assertThat(countRows()).isEqualTo(0);
     }
 
@@ -170,7 +169,7 @@ class TxValidatedTest {
             return Validated.valid(2);
         });
 
-        assertThat(result.isValid()).isTrue();
+        assertThat(result).isValid();
         assertThat(countRows()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
  Add dmx.fun.assertj to the :spring test suite so tests read like domain
  assertions instead of raw isTrue()/isEqualTo() checks.

  - Add compileOnly + testImplementation project(':assertj') dependencies
  - Extend jpmsTest with extraModules/extraReads for dmx.fun.assertj
  - Add --add-reads dmx.fun.assertj=ALL-UNNAMED for compileTestJava, since
    assertj-core lives in the unnamed module at compile time
  - Replace assertThat(result.isOk()).isTrue() style with assertThat(result).isOk(),
    isErr(), isSuccess(), isFailure(), isValid(), isInvalid(), containsValue(),
    containsError(), and hasError() across all six test classes

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #249

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test assertion framework with fluent assertion API for improved code clarity and test maintainability across database transaction and validation test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->