### PR TITLE
feature/assertj/resource guard accumulator

### DIFF
--- a/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
@@ -1,0 +1,105 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Accumulator;
+import java.util.Collection;
+import java.util.Objects;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * AssertJ assertions for {@link Accumulator}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Accumulator)}.
+ *
+ * @param <E> the accumulated side-channel type
+ * @param <A> the primary value type
+ */
+@NullMarked
+public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAssert<E, A>, Accumulator<E, A>> {
+
+    AccumulatorAssert(Accumulator<E, A> actual) {
+        super(actual, AccumulatorAssert.class);
+    }
+
+    /**
+     * Verifies that the accumulator's primary value equals the given expected value.
+     *
+     * @param expected the expected value (may be {@code null})
+     * @return this assertion for chaining
+     */
+    public AccumulatorAssert<E, A> hasValue(@Nullable A expected) {
+        isNotNull();
+        if (!Objects.equals(actual.value(), expected)) {
+            throw buildError("Expected Accumulator to have value <%s> but had <%s>",
+                expected, actual.value());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the accumulator's side-channel equals the given expected accumulation.
+     *
+     * @param expected the expected accumulated value
+     * @return this assertion for chaining
+     */
+    public AccumulatorAssert<E, A> hasAccumulation(E expected) {
+        isNotNull();
+        if (!Objects.equals(actual.accumulated(), expected)) {
+            throw buildError("Expected Accumulator to have accumulation <%s> but had <%s>",
+                expected, actual.accumulated());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the accumulator's side-channel (which must be a {@link Collection})
+     * contains the given element.
+     *
+     * @param element the element expected to be present in the accumulation
+     * @return this assertion for chaining
+     * @throws AssertionError if the accumulated value is not a {@link Collection}
+     */
+    public AccumulatorAssert<E, A> accumulationContains(Object element) {
+        isNotNull();
+        E accumulated = actual.accumulated();
+        if (!(accumulated instanceof Collection<?> col)) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for accumulationContains, but was <%s>",
+                accumulated.getClass().getName());
+        }
+        if (!col.contains(element)) {
+            throw buildError("Expected accumulation <%s> to contain <%s>", accumulated, element);
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the accumulator's side-channel (which must be a {@link Collection})
+     * has the given size.
+     *
+     * @param expected the expected number of elements in the accumulation
+     * @return this assertion for chaining
+     * @throws AssertionError if the accumulated value is not a {@link Collection}
+     */
+    public AccumulatorAssert<E, A> accumulationHasSize(int expected) {
+        isNotNull();
+        E accumulated = actual.accumulated();
+        if (!(accumulated instanceof Collection<?> col)) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for accumulationHasSize, but was <%s>",
+                accumulated.getClass().getName());
+        }
+        if (col.size() != expected) {
+            throw buildError("Expected accumulation to have size <%s> but had <%s>",
+                expected, col.size());
+        }
+        return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
@@ -63,6 +63,10 @@ public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAss
     public AccumulatorAssert<E, A> accumulationContains(Object element) {
         isNotNull();
         E accumulated = actual.accumulated();
+        if (accumulated == null) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for accumulationContains, but was <null>");
+        }
         if (!(accumulated instanceof Collection<?> col)) {
             throw buildError(
                 "Expected accumulated value to be a Collection for accumulationContains, but was <%s>",
@@ -85,6 +89,10 @@ public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAss
     public AccumulatorAssert<E, A> accumulationHasSize(int expected) {
         isNotNull();
         E accumulated = actual.accumulated();
+        if (accumulated == null) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for accumulationHasSize, but was <null>");
+        }
         if (!(accumulated instanceof Collection<?> col)) {
             throw buildError(
                 "Expected accumulated value to be a Collection for accumulationHasSize, but was <%s>",

--- a/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
+++ b/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
@@ -1,6 +1,9 @@
 package dmx.fun.assertj;
 
+import dmx.fun.Accumulator;
+import dmx.fun.Guard;
 import dmx.fun.Option;
+import dmx.fun.Resource;
 import dmx.fun.Result;
 import dmx.fun.Try;
 import dmx.fun.Tuple2;
@@ -20,6 +23,9 @@ import org.jspecify.annotations.NullMarked;
  * assertThat(Result.ok("hello")).isOk().containsValue("hello");
  * assertThat(Try.success(1)).isSuccess().containsValue(1);
  * assertThat(Validated.valid("ok")).isValid().containsValue("ok");
+ * assertThat(resource).succeedsWith("value");
+ * assertThat(guard).accepts("alice").rejects("!!");
+ * assertThat(accumulator).hasValue(42).accumulationContains("step1");
  * }</pre>
  */
 @NullMarked
@@ -110,5 +116,39 @@ public final class DmxFunAssertions {
      */
     public static <A, B, C, D> Tuple4Assert<A, B, C, D> assertThat(Tuple4<A, B, C, D> actual) {
         return new Tuple4Assert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Resource}.
+     *
+     * @param <T>    the resource value type
+     * @param actual the Resource to assert on
+     * @return a new {@link ResourceAssert}
+     */
+    public static <T> ResourceAssert<T> assertThat(Resource<T> actual) {
+        return new ResourceAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for a {@link Guard}.
+     *
+     * @param <T>    the type of value the guard validates
+     * @param actual the Guard to assert on
+     * @return a new {@link GuardAssert}
+     */
+    public static <T> GuardAssert<T> assertThat(Guard<T> actual) {
+        return new GuardAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for an {@link Accumulator}.
+     *
+     * @param <E>    the accumulated side-channel type
+     * @param <A>    the primary value type
+     * @param actual the Accumulator to assert on
+     * @return a new {@link AccumulatorAssert}
+     */
+    public static <E, A> AccumulatorAssert<E, A> assertThat(Accumulator<E, A> actual) {
+        return new AccumulatorAssert<>(actual);
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
@@ -60,8 +60,12 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      * @return this assertion for chaining
      */
     public GuardAssert<T> rejectsWithMessage(T value, String message) {
-        rejects(value);
-        NonEmptyList<String> errors = actual.check(value).getError();
+        isNotNull();
+        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        if (!result.isInvalid()) {
+            throw buildError("Expected Guard to reject <%s> but accepted it", value);
+        }
+        NonEmptyList<String> errors = result.getError();
         if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
             throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
         }
@@ -77,8 +81,12 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      * @return this assertion for chaining
      */
     public GuardAssert<T> rejectsWithMessages(T value, String... messages) {
-        rejects(value);
-        NonEmptyList<String> errors = actual.check(value).getError();
+        isNotNull();
+        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        if (!result.isInvalid()) {
+            throw buildError("Expected Guard to reject <%s> but accepted it", value);
+        }
+        NonEmptyList<String> errors = result.getError();
         for (String message : messages) {
             if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
                 throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);

--- a/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
@@ -1,0 +1,95 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Guard;
+import dmx.fun.NonEmptyList;
+import dmx.fun.Validated;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * AssertJ assertions for {@link Guard}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Guard)}.
+ *
+ * @param <T> the type of value the guard validates
+ */
+@NullMarked
+public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T>> {
+
+    GuardAssert(Guard<T> actual) {
+        super(actual, GuardAssert.class);
+    }
+
+    /**
+     * Verifies that the guard accepts (validates successfully) the given value.
+     *
+     * @param value the value to check
+     * @return this assertion for chaining
+     */
+    public GuardAssert<T> accepts(T value) {
+        isNotNull();
+        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        if (!result.isValid()) {
+            throw buildError("Expected Guard to accept <%s> but rejected it with <%s>",
+                value, result.getError());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the guard rejects (fails validation of) the given value.
+     *
+     * @param value the value to check
+     * @return this assertion for chaining
+     */
+    public GuardAssert<T> rejects(T value) {
+        isNotNull();
+        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        if (!result.isInvalid()) {
+            throw buildError("Expected Guard to reject <%s> but accepted it", value);
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the guard rejects the given value and that at least one rejection
+     * message contains the expected string.
+     *
+     * @param value   the value to check
+     * @param message the string expected to appear in at least one rejection message
+     * @return this assertion for chaining
+     */
+    public GuardAssert<T> rejectsWithMessage(T value, String message) {
+        rejects(value);
+        NonEmptyList<String> errors = actual.check(value).getError();
+        if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
+            throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the guard rejects the given value and that for each expected message,
+     * at least one rejection message contains it.
+     *
+     * @param value    the value to check
+     * @param messages the strings each expected to appear in at least one rejection message
+     * @return this assertion for chaining
+     */
+    public GuardAssert<T> rejectsWithMessages(T value, String... messages) {
+        rejects(value);
+        NonEmptyList<String> errors = actual.check(value).getError();
+        for (String message : messages) {
+            if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
+                throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
+            }
+        }
+        return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
@@ -1,0 +1,95 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Resource;
+import dmx.fun.Try;
+import java.util.Objects;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * AssertJ assertions for {@link Resource}.
+ *
+ * <p>Each assertion method exercises the resource's full acquire-use-release cycle
+ * by calling {@link Resource#use(dmx.fun.CheckedFunction) use(v -> v)} (identity body)
+ * and inspecting the resulting {@link Try}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Resource)}.
+ *
+ * @param <T> the resource value type
+ */
+@NullMarked
+public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, Resource<T>> {
+
+    ResourceAssert(Resource<T> actual) {
+        super(actual, ResourceAssert.class);
+    }
+
+    /**
+     * Verifies that the resource's acquire-use-release cycle succeeds and the acquired
+     * value equals {@code expected}.
+     *
+     * @param expected the expected value produced by the resource
+     * @return this assertion for chaining
+     */
+    public ResourceAssert<T> succeedsWith(T expected) {
+        isNotNull();
+        Try<T> result = actual.use(v -> v);
+        if (result.isFailure()) {
+            throw buildError("Expected Resource to succeed with <%s> but failed with <%s>",
+                expected, result.getCause());
+        }
+        if (!Objects.equals(result.get(), expected)) {
+            throw buildError("Expected Resource to succeed with <%s> but succeeded with <%s>",
+                expected, result.get());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the resource's acquire-use-release cycle fails with an exception of
+     * the given type (or a subtype).
+     *
+     * @param exceptionType the expected exception type
+     * @return this assertion for chaining
+     */
+    public ResourceAssert<T> failsWith(Class<? extends Throwable> exceptionType) {
+        isNotNull();
+        Try<T> result = actual.use(v -> v);
+        if (result.isSuccess()) {
+            throw buildError("Expected Resource to fail with <%s> but succeeded with <%s>",
+                exceptionType.getName(), result.get());
+        }
+        if (!exceptionType.isInstance(result.getCause())) {
+            throw buildError("Expected Resource to fail with <%s> but failed with <%s>",
+                exceptionType.getName(), result.getCause().getClass().getName());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the resource's acquire-use-release cycle fails with an exception whose
+     * message contains the given string.
+     *
+     * @param message the string expected to be contained in the failure message
+     * @return this assertion for chaining
+     */
+    public ResourceAssert<T> failsWithMessage(String message) {
+        isNotNull();
+        Try<T> result = actual.use(v -> v);
+        if (result.isSuccess()) {
+            throw buildError("Expected Resource to fail but succeeded with <%s>", result.get());
+        }
+        String causeMessage = result.getCause().getMessage();
+        if (causeMessage == null || !causeMessage.contains(message)) {
+            throw buildError("Expected Resource failure message to contain <%s> but was <%s>",
+                message, causeMessage);
+        }
+        return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
@@ -5,6 +5,7 @@ import dmx.fun.Try;
 import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * AssertJ assertions for {@link Resource}.
@@ -20,8 +21,18 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, Resource<T>> {
 
+    private @Nullable Try<T> cachedResult;
+
     ResourceAssert(Resource<T> actual) {
         super(actual, ResourceAssert.class);
+    }
+
+    private Try<T> evaluate() {
+        isNotNull();
+        if (cachedResult == null) {
+            cachedResult = actual.use(v -> v);
+        }
+        return cachedResult;
     }
 
     /**
@@ -32,8 +43,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> succeedsWith(T expected) {
-        isNotNull();
-        Try<T> result = actual.use(v -> v);
+        Try<T> result = evaluate();
         if (result.isFailure()) {
             throw buildError("Expected Resource to succeed with <%s> but failed with <%s>",
                 expected, result.getCause());
@@ -53,8 +63,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> failsWith(Class<? extends Throwable> exceptionType) {
-        isNotNull();
-        Try<T> result = actual.use(v -> v);
+        Try<T> result = evaluate();
         if (result.isSuccess()) {
             throw buildError("Expected Resource to fail with <%s> but succeeded with <%s>",
                 exceptionType.getName(), result.get());
@@ -74,8 +83,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> failsWithMessage(String message) {
-        isNotNull();
-        Try<T> result = actual.use(v -> v);
+        Try<T> result = evaluate();
         if (result.isSuccess()) {
             throw buildError("Expected Resource to fail but succeeded with <%s>", result.get());
         }

--- a/assertj/src/main/java/module-info.java
+++ b/assertj/src/main/java/module-info.java
@@ -2,7 +2,8 @@
  * AssertJ custom assertions for dmx-fun types.
  *
  * <p>Provides fluent, self-documenting assertions for {@code Option}, {@code Result},
- * {@code Try}, {@code Validated}, {@code Tuple2}, {@code Tuple3}, and {@code Tuple4}.
+ * {@code Try}, {@code Validated}, {@code Tuple2}, {@code Tuple3}, {@code Tuple4},
+ * {@code Resource}, {@code Guard}, and {@code Accumulator}.
  *
  * <p>Entry point: {@link dmx.fun.assertj.DmxFunAssertions#assertThat}.
  */

--- a/assertj/src/test/java/dmx/fun/assertj/AccumulatorAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/AccumulatorAssertTest.java
@@ -1,0 +1,111 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Accumulator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AccumulatorAssertTest {
+
+    private static final Accumulator<List<String>, Integer> ACC =
+        Accumulator.of(42, List.of("step1", "step2"));
+
+    // ── hasValue ──────────────────────────────────────────────────────────────
+
+    @Test
+    void hasValue_shouldPass_whenValueMatches() {
+        assertThat(ACC).hasValue(42);
+    }
+
+    @Test
+    void hasValue_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(ACC).hasValue(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99");
+    }
+
+    @Test
+    void hasValue_shouldPass_forNullValue() {
+        // tell() creates an Accumulator whose value is null (no primary result, only log)
+        var acc = Accumulator.tell(List.of("log"));
+        assertThat(acc).hasValue(null);
+    }
+
+    // ── hasAccumulation ───────────────────────────────────────────────────────
+
+    @Test
+    void hasAccumulation_shouldPass_whenAccumulationMatches() {
+        assertThat(ACC).hasAccumulation(List.of("step1", "step2"));
+    }
+
+    @Test
+    void hasAccumulation_shouldFail_whenAccumulationDiffers() {
+        assertThatThrownBy(() -> assertThat(ACC).hasAccumulation(List.of("other")))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("other");
+    }
+
+    // ── accumulationContains ──────────────────────────────────────────────────
+
+    @Test
+    void accumulationContains_shouldPass_whenElementPresent() {
+        assertThat(ACC).accumulationContains("step1");
+    }
+
+    @Test
+    void accumulationContains_shouldFail_whenElementAbsent() {
+        assertThatThrownBy(() -> assertThat(ACC).accumulationContains("step3"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("step3");
+    }
+
+    @Test
+    void accumulationContains_shouldFail_whenAccumulationIsNotCollection() {
+        var acc = Accumulator.of(1, "not-a-collection");
+        assertThatThrownBy(() -> assertThat(acc).accumulationContains("x"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Collection");
+    }
+
+    // ── accumulationHasSize ───────────────────────────────────────────────────
+
+    @Test
+    void accumulationHasSize_shouldPass_whenSizeMatches() {
+        assertThat(ACC).accumulationHasSize(2);
+    }
+
+    @Test
+    void accumulationHasSize_shouldFail_whenSizeDiffers() {
+        assertThatThrownBy(() -> assertThat(ACC).accumulationHasSize(3))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("3");
+    }
+
+    @Test
+    void accumulationHasSize_shouldFail_whenAccumulationIsNotCollection() {
+        var acc = Accumulator.of(1, "not-a-collection");
+        assertThatThrownBy(() -> assertThat(acc).accumulationHasSize(1))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Collection");
+    }
+
+    // ── fluency and description ───────────────────────────────────────────────
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(ACC)
+            .hasValue(42)
+            .hasAccumulation(List.of("step1", "step2"))
+            .accumulationContains("step1")
+            .accumulationHasSize(2);
+    }
+
+    @Test
+    void shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(ACC).as("my acc").hasValue(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my acc]");
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
@@ -1,0 +1,103 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Guard;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GuardAssertTest {
+
+    private static final Guard<String> ALPHANUMERIC =
+        Guard.of(s -> s.matches("[a-zA-Z0-9]+"), "must be alphanumeric");
+
+    private static final Guard<String> LENGTH =
+        Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+
+    private static final Guard<String> BOTH = ALPHANUMERIC.and(LENGTH);
+
+    // ── accepts ───────────────────────────────────────────────────────────────
+
+    @Test
+    void accepts_shouldPass_forValidValue() {
+        assertThat(ALPHANUMERIC).accepts("alice123");
+    }
+
+    @Test
+    void accepts_shouldFail_forInvalidValue() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).accepts("!!"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("!!");
+    }
+
+    // ── rejects ───────────────────────────────────────────────────────────────
+
+    @Test
+    void rejects_shouldPass_forInvalidValue() {
+        assertThat(ALPHANUMERIC).rejects("!!");
+    }
+
+    @Test
+    void rejects_shouldFail_forValidValue() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).rejects("alice"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("alice");
+    }
+
+    // ── rejectsWithMessage ────────────────────────────────────────────────────
+
+    @Test
+    void rejectsWithMessage_shouldPass_whenMessagePresent() {
+        assertThat(ALPHANUMERIC).rejectsWithMessage("!!", "alphanumeric");
+    }
+
+    @Test
+    void rejectsWithMessage_shouldPass_withPartialMatch() {
+        assertThat(ALPHANUMERIC).rejectsWithMessage("!!", "must be");
+    }
+
+    @Test
+    void rejectsWithMessage_shouldFail_whenMessageAbsent() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).rejectsWithMessage("!!", "database error"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("database error");
+    }
+
+    @Test
+    void rejectsWithMessage_shouldFail_forValidValue() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).rejectsWithMessage("alice", "alphanumeric"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    // ── rejectsWithMessages ───────────────────────────────────────────────────
+
+    @Test
+    void rejectsWithMessages_shouldPass_whenAllMessagesPresent() {
+        assertThat(BOTH).rejectsWithMessages("!!", "alphanumeric", "at least 3 chars");
+    }
+
+    @Test
+    void rejectsWithMessages_shouldFail_whenOneMessageAbsent() {
+        assertThatThrownBy(() ->
+            assertThat(BOTH).rejectsWithMessages("!!", "alphanumeric", "does not exist"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("does not exist");
+    }
+
+    // ── fluency and description ───────────────────────────────────────────────
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(ALPHANUMERIC)
+            .accepts("alice")
+            .rejects("!!")
+            .rejectsWithMessage("!!", "alphanumeric");
+    }
+
+    @Test
+    void shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).as("my guard").accepts("!!"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my guard]");
+    }
+}

--- a/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
@@ -1,10 +1,12 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Resource;
+import dmx.fun.Try;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ResourceAssertTest {
@@ -12,6 +14,13 @@ class ResourceAssertTest {
     private static final Resource<Integer> SUCCESSFUL = Resource.of(() -> 42, v -> {});
     private static final Resource<Integer> FAILING    = Resource.of(
         () -> { throw new IOException("file not found"); }, v -> {});
+    // Body succeeds, but release throws — the release exception surfaces as the failure.
+    private static final Resource<Integer> RELEASE_FAILS = Resource.of(
+        () -> 42, v -> { throw new IOException("release failed"); });
+    // Acquire succeeds; used with a throwing body in tests so that both body and
+    // release throw — body exception is the primary failure, release is suppressed.
+    private static final Resource<Integer> BODY_AND_RELEASE_FAIL = Resource.of(
+        () -> 99, v -> { throw new IOException("release failed"); });
 
     // ── succeedsWith ──────────────────────────────────────────────────────────
 
@@ -83,6 +92,46 @@ class ResourceAssertTest {
     void failsWithMessage_shouldFail_whenResourceSucceeds() {
         assertThatThrownBy(() -> assertThat(SUCCESSFUL).failsWithMessage("anything"))
             .isInstanceOf(AssertionError.class);
+    }
+
+    // ── RELEASE_FAILS: body succeeds, release throws ──────────────────────────
+
+    @Test
+    void releaseFails_surfacesReleaseException() {
+        assertThat(RELEASE_FAILS)
+            .failsWith(IOException.class)
+            .failsWithMessage("release failed");
+    }
+
+    @Test
+    void releaseFails_shouldFail_succeedsWith() {
+        assertThatThrownBy(() -> assertThat(RELEASE_FAILS).succeedsWith(42))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("42");
+    }
+
+    // ── BODY_AND_RELEASE_FAIL: body throws, release also throws ──────────────
+
+    @Test
+    void bodyAndReleaseFail_bodyExceptionIsPrimary_releaseIsSuppressed() {
+        // ResourceAssert always uses the identity body (v -> v), so to test the
+        // suppression path we drive the lifecycle directly with a throwing body —
+        // CheckedFunction allows throwing checked exceptions.
+        Try<Integer> result = BODY_AND_RELEASE_FAIL.use(v -> {
+            throw new IOException("body failed");
+        });
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause())
+            .isInstanceOf(IOException.class)
+            .hasMessage("body failed");
+        assertThat(result.getCause().getSuppressed())
+            .hasSize(1)
+            .satisfies(suppressed -> {
+                assertThat(suppressed[0])
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("release failed");
+            });
     }
 
     // ── fluency and description ───────────────────────────────────────────────

--- a/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
@@ -1,0 +1,103 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Resource;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResourceAssertTest {
+
+    private static final Resource<Integer> SUCCESSFUL = Resource.of(() -> 42, v -> {});
+    private static final Resource<Integer> FAILING    = Resource.of(
+        () -> { throw new IOException("file not found"); }, v -> {});
+
+    // ── succeedsWith ──────────────────────────────────────────────────────────
+
+    @Test
+    void succeedsWith_shouldPass_whenValueMatches() {
+        assertThat(SUCCESSFUL).succeedsWith(42);
+    }
+
+    @Test
+    void succeedsWith_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(SUCCESSFUL).succeedsWith(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99");
+    }
+
+    @Test
+    void succeedsWith_shouldFail_whenResourceFails() {
+        assertThatThrownBy(() -> assertThat(FAILING).succeedsWith(42))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("42");
+    }
+
+    // ── failsWith ─────────────────────────────────────────────────────────────
+
+    @Test
+    void failsWith_shouldPass_whenExceptionTypeMatches() {
+        assertThat(FAILING).failsWith(IOException.class);
+    }
+
+    @Test
+    void failsWith_shouldPass_forSupertype() {
+        assertThat(FAILING).failsWith(Exception.class);
+    }
+
+    @Test
+    void failsWith_shouldFail_whenExceptionTypeDiffers() {
+        assertThatThrownBy(() -> assertThat(FAILING).failsWith(IllegalArgumentException.class))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("IllegalArgumentException");
+    }
+
+    @Test
+    void failsWith_shouldFail_whenResourceSucceeds() {
+        assertThatThrownBy(() -> assertThat(SUCCESSFUL).failsWith(IOException.class))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("IOException");
+    }
+
+    // ── failsWithMessage ──────────────────────────────────────────────────────
+
+    @Test
+    void failsWithMessage_shouldPass_whenMessageContained() {
+        assertThat(FAILING).failsWithMessage("file not found");
+    }
+
+    @Test
+    void failsWithMessage_shouldPass_whenPartialMatch() {
+        assertThat(FAILING).failsWithMessage("not found");
+    }
+
+    @Test
+    void failsWithMessage_shouldFail_whenMessageNotContained() {
+        assertThatThrownBy(() -> assertThat(FAILING).failsWithMessage("database error"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("database error");
+    }
+
+    @Test
+    void failsWithMessage_shouldFail_whenResourceSucceeds() {
+        assertThatThrownBy(() -> assertThat(SUCCESSFUL).failsWithMessage("anything"))
+            .isInstanceOf(AssertionError.class);
+    }
+
+    // ── fluency and description ───────────────────────────────────────────────
+
+    @Test
+    void isFluent_shouldChain() {
+        assertThat(FAILING)
+            .failsWith(IOException.class)
+            .failsWithMessage("file not found");
+    }
+
+    @Test
+    void shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() -> assertThat(FAILING).as("my resource").succeedsWith(42))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[my resource]");
+    }
+}

--- a/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
+++ b/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
@@ -1,13 +1,18 @@
 package dmx.fun.samples;
 
+import dmx.fun.Accumulator;
+import dmx.fun.Guard;
 import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
+import dmx.fun.Resource;
 import dmx.fun.Result;
 import dmx.fun.Try;
 import dmx.fun.Tuple2;
 import dmx.fun.Tuple3;
 import dmx.fun.Validated;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 
@@ -134,5 +139,136 @@ class AssertJSampleTest {
             .hasFirst("Alice")
             .hasSecond(30)
             .hasThird(true);
+    }
+
+    // ── Resource<T> ──────────────────────────────────────────────────────────
+
+    @Test
+    void resource_succeedsWith_whenAcquireAndReleaseComplete() {
+        // Simulates acquiring a database connection string and releasing it safely.
+        // succeedsWith checks that use(v -> v) returns the acquired value unchanged.
+        Resource<String> connectionString = Resource.of(
+            () -> "jdbc:postgresql://localhost/mydb",
+            conn -> { /* release: return to pool */ }
+        );
+
+        assertThat(connectionString).succeedsWith("jdbc:postgresql://localhost/mydb");
+    }
+
+    @Test
+    void resource_failsWith_whenAcquireThrows() {
+        // A resource whose acquisition always fails — e.g. cannot open the file.
+        Resource<String> unavailable = Resource.of(
+            () -> { throw new java.io.IOException("file not found"); },
+            s  -> { /* release never called */ }
+        );
+
+        assertThat(unavailable).failsWith(java.io.IOException.class);
+    }
+
+    @Test
+    void resource_failsWithMessage_whenAcquireThrowsWithKnownMessage() {
+        // The acquire step fails with a predictable message — useful for asserting
+        // that the correct error propagates through the resource lifecycle.
+        Resource<String> unavailable = Resource.of(
+            () -> { throw new IllegalStateException("config file missing: app.yml"); },
+            s  -> {}
+        );
+
+        assertThat(unavailable).failsWithMessage("config file missing: app.yml");
+    }
+
+    // ── Guard<T> ─────────────────────────────────────────────────────────────
+
+    @Test
+    void guard_accepts_whenPredicatePasses() {
+        // A username must be 3–20 characters and contain only alphanumerics.
+        Guard<String> usernameGuard = Guard.of(
+            s -> s.length() >= 3 && s.length() <= 20 && s.matches("[A-Za-z0-9]+"),
+            "username must be 3–20 alphanumeric characters"
+        );
+
+        assertThat(usernameGuard).accepts("alice99");
+    }
+
+    @Test
+    void guard_rejects_whenPredicateFails() {
+        Guard<String> usernameGuard = Guard.of(
+            s -> s.length() >= 3 && s.length() <= 20 && s.matches("[A-Za-z0-9]+"),
+            "username must be 3–20 alphanumeric characters"
+        );
+
+        assertThat(usernameGuard).rejects("a!");
+    }
+
+    @Test
+    void guard_rejectsWithMessage_includesContextualError() {
+        Guard<Integer> positiveAmount = Guard.of(
+            n -> n > 0,
+            n -> "amount must be positive, got: " + n
+        );
+
+        assertThat(positiveAmount).rejectsWithMessage(-5, "amount must be positive, got: -5");
+    }
+
+    @Test
+    void guard_rejectsWithMessages_whenMultipleRulesApplied() {
+        // Compose two guards: minimum length and no whitespace.
+        Guard<String> minLength  = Guard.of(s -> s.length() >= 8, "must be at least 8 characters");
+        Guard<String> noSpaces   = Guard.of(s -> !s.contains(" "), "must not contain spaces");
+        Guard<String> passwordGuard = minLength.and(noSpaces);
+
+        // "hi pw" has 5 chars (fails minLength) and a space (fails noSpaces) — both errors accumulated
+        assertThat(passwordGuard)
+            .rejectsWithMessages("hi pw", "must be at least 8 characters", "must not contain spaces");
+    }
+
+    // ── Accumulator<E, A> ────────────────────────────────────────────────────
+
+    @Test
+    void accumulator_hasValue_whenPrimaryValuePresent() {
+        // Models a pipeline step that produces a result and logs a message.
+        Accumulator<List<String>, Integer> step =
+            Accumulator.of(42, List.of("computed answer"));
+
+        assertThat(step).hasValue(42);
+    }
+
+    @Test
+    void accumulator_hasAccumulation_matchesLogEntries() {
+        Accumulator<List<String>, String> step =
+            Accumulator.of("Alice", List.of("fetched user", "applied discount"));
+
+        assertThat(step).hasAccumulation(List.of("fetched user", "applied discount"));
+    }
+
+    @Test
+    void accumulator_accumulationContains_singleAuditEntry() {
+        Accumulator<List<String>, Integer> result =
+            Accumulator.of(100, List.of("order created", "stock reserved"));
+
+        assertThat(result)
+            .accumulationContains("order created")
+            .accumulationContains("stock reserved");
+    }
+
+    @Test
+    void accumulator_accumulationHasSize_tracksStepCount() {
+        // A multi-step pipeline that accumulates one log entry per step.
+        Accumulator<List<String>, String> pipeline =
+            Accumulator.of("done", List.of("step1", "step2", "step3"));
+
+        assertThat(pipeline).accumulationHasSize(3);
+    }
+
+    @Test
+    void accumulator_tell_sideEffectOnly() {
+        // tell() creates an accumulator with no primary value — useful for pure logging steps.
+        Accumulator<List<String>, Void> log =
+            Accumulator.tell(List.of("audit: payment initiated"));
+
+        assertThat(log)
+            .hasValue(null)
+            .accumulationContains("audit: payment initiated");
     }
 }

--- a/site/src/data/code/guide/assertj/accumulator-assertions.mdx
+++ b/site/src/data/code/guide/assertj/accumulator-assertions.mdx
@@ -1,0 +1,40 @@
+---
+fileName: 'AccumulatorTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+BinaryOperator<List<String>> concat = (a, b) -> {
+    var merged = new ArrayList<>(a);
+    merged.addAll(b);
+    return merged;
+};
+
+Accumulator<List<String>, Integer> result =
+    Accumulator.of(10, List.of("loaded base value"))
+        .flatMap(v -> Accumulator.of(v * 2, List.of("doubled")), concat)
+        .flatMap(v -> Accumulator.of(v + 5, List.of("added 5")), concat);
+
+// Assert the primary computed value
+assertThat(result).hasValue(25);
+
+// Assert individual log entries are present
+assertThat(result)
+    .accumulationContains("loaded base value")
+    .accumulationContains("doubled")
+    .accumulationContains("added 5");
+
+// Assert total number of log entries
+assertThat(result).accumulationHasSize(3);
+
+// Assert the exact accumulation
+assertThat(result)
+    .hasAccumulation(List.of("loaded base value", "doubled", "added 5"));
+
+// Fluent chain
+assertThat(result)
+    .hasValue(25)
+    .accumulationContains("loaded base value")
+    .accumulationHasSize(3);
+```

--- a/site/src/data/code/guide/assertj/guard-assertions.mdx
+++ b/site/src/data/code/guide/assertj/guard-assertions.mdx
@@ -1,0 +1,31 @@
+---
+fileName: 'GuardTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+Guard<String> alphanumeric = Guard.of(
+    s -> s.matches("[a-zA-Z0-9]+"), "must be alphanumeric");
+
+// Assert acceptance
+assertThat(alphanumeric).accepts("alice123");
+
+// Assert rejection (any invalid value)
+assertThat(alphanumeric).rejects("!!");
+
+// Assert a specific rejection message is present
+assertThat(alphanumeric).rejectsWithMessage("!!", "alphanumeric");
+
+// Combined guard: assert all expected messages appear
+Guard<String> minLength = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+Guard<String> username  = alphanumeric.and(minLength);
+
+assertThat(username).rejectsWithMessages("!!", "alphanumeric", "at least 3 chars");
+
+// Fluent chain
+assertThat(username)
+    .accepts("alice")
+    .rejects("!!")
+    .rejectsWithMessage("ab", "at least 3 chars");
+```

--- a/site/src/data/code/guide/assertj/resource-assertions.mdx
+++ b/site/src/data/code/guide/assertj/resource-assertions.mdx
@@ -1,0 +1,35 @@
+---
+fileName: 'ResourceTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Successful acquire + use + release
+Resource<String> file = Resource.of(
+    () -> "file-content",   // acquire
+    content -> { });        // release
+
+assertThat(file).succeedsWith("file-content");
+
+// Acquisition failure — verify exception type
+Resource<String> broken = Resource.of(
+    () -> { throw new IOException("file not found"); },
+    content -> { });
+
+assertThat(broken).failsWith(IOException.class);
+
+// Acquisition failure — verify exception message
+assertThat(broken).failsWithMessage("file not found");
+
+// Chain both failure checks
+assertThat(broken)
+    .failsWith(IOException.class)
+    .failsWithMessage("not found");
+
+// AutoCloseable shorthand
+Resource<BufferedReader> reader = Resource.fromAutoCloseable(
+    () -> new BufferedReader(new FileReader("data.txt")));
+
+assertThat(reader).failsWith(FileNotFoundException.class);
+```

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -82,11 +82,12 @@ in the same test class without naming conflict, because the argument types diffe
 
 ## `Resource<T>` assertions
 
-Each assertion method exercises the full acquire-use-release cycle by calling
-`use(v -> v)` (identity body) and inspecting the resulting `Try`. Use
-`succeedsWith` to verify that acquisition and release complete without error;
-use `failsWith` / `failsWithMessage` to verify that the cycle fails in the
-expected way.
+The first assertion called on a `ResourceAssert` runs the full acquire-use-release
+cycle once (via `use(v -> v)`) and caches the result. All subsequent chained
+assertions on the same instance reuse that cached `Try` — the lifecycle is never
+triggered more than once. Use `succeedsWith` to verify that acquisition and
+release complete without error; use `failsWith` / `failsWithMessage` to verify
+that the cycle fails in the expected way.
 
 <ResourceAssertions/>
 
@@ -101,9 +102,10 @@ messages you expect to find in the rejection error list.
 ## `Accumulator<E, A>` assertions
 
 `accumulationContains` and `accumulationHasSize` require the accumulated
-side-channel (`E`) to be a `java.util.Collection`. If it is not, the assertion
-fails with a descriptive error. Use `hasAccumulation` for equality checks on
-any accumulation type.
+side-channel (`E`) to be a non-null `java.util.Collection`. If it is `null` or
+not a `Collection`, the assertion fails with a descriptive error. Use
+`hasAccumulation` for equality checks on any accumulation type, including
+non-collection and nullable values.
 
 <AccumulatorAssertions/>
 

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AssertJ Integration — Developer Guide"
-description: "How to use the optional fun-assertj module: fluent assertions for Option, Result, Try, Validated, and Tuple types via DmxFunAssertions.assertThat."
+description: "How to use the optional fun-assertj module: fluent assertions for Option, Result, Try, Validated, Tuple, Resource, Guard, and Accumulator types via DmxFunAssertions.assertThat."
 order: 15
 h1: "AssertJ Integration"
 ---
@@ -10,7 +10,10 @@ import {Content as OptionAssertions}     from '../code/guide/assertj/option-asse
 import {Content as ResultAssertions}     from '../code/guide/assertj/result-assertions.mdx';
 import {Content as TryAssertions}        from '../code/guide/assertj/try-assertions.mdx';
 import {Content as ValidatedAssertions}  from '../code/guide/assertj/validated-assertions.mdx';
-import {Content as TupleAssertions}      from '../code/guide/assertj/tuple-assertions.mdx';
+import {Content as TupleAssertions}        from '../code/guide/assertj/tuple-assertions.mdx';
+import {Content as ResourceAssertions}    from '../code/guide/assertj/resource-assertions.mdx';
+import {Content as GuardAssertions}       from '../code/guide/assertj/guard-assertions.mdx';
+import {Content as AccumulatorAssertions} from '../code/guide/assertj/accumulator-assertions.mdx';
 
 > **Runnable example:** [`AssertJSampleTest.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java)
 
@@ -44,15 +47,18 @@ in the same test class without naming conflict, because the argument types diffe
 
 ## Assertions reference
 
-| Type                 | Methods                                                                                  |
-|----------------------|------------------------------------------------------------------------------------------|
-| `Option<T>`          | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)`        |
-| `Result<V, E>`       | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)`                |
-| `Try<V>`             | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)`      |
-| `Validated<E, A>`    | `isValid()`, `isInvalid()`, `containsValue(expected)`, `hasError(expected)`              |
-| `Tuple2<A, B>`       | `hasFirst(expected)`, `hasSecond(expected)`                                              |
-| `Tuple3<A, B, C>`    | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`                        |
-| `Tuple4<A, B, C, D>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`, `hasFourth(expected)` |
+| Type                 | Methods                                                                                                                  |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `Option<T>`          | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)`                                        |
+| `Result<V, E>`       | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)`                                                |
+| `Try<V>`             | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)`                                      |
+| `Validated<E, A>`    | `isValid()`, `isInvalid()`, `containsValue(expected)`, `hasError(expected)`                                              |
+| `Tuple2<A, B>`       | `hasFirst(expected)`, `hasSecond(expected)`                                                                              |
+| `Tuple3<A, B, C>`    | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`                                                        |
+| `Tuple4<A, B, C, D>` | `hasFirst(expected)`, `hasSecond(expected)`, `hasThird(expected)`, `hasFourth(expected)`                                 |
+| `Resource<T>`        | `succeedsWith(expected)`, `failsWith(exceptionType)`, `failsWithMessage(message)`                                        |
+| `Guard<T>`           | `accepts(value)`, `rejects(value)`, `rejectsWithMessage(value, message)`, `rejectsWithMessages(value, messages...)`      |
+| `Accumulator<E, A>`  | `hasValue(expected)`, `hasAccumulation(expected)`, `accumulationContains(element)`, `accumulationHasSize(size)`          |
 
 ## `Option<T>` assertions
 
@@ -73,6 +79,33 @@ in the same test class without naming conflict, because the argument types diffe
 ## `Tuple2/3/4` assertions
 
 <TupleAssertions/>
+
+## `Resource<T>` assertions
+
+Each assertion method exercises the full acquire-use-release cycle by calling
+`use(v -> v)` (identity body) and inspecting the resulting `Try`. Use
+`succeedsWith` to verify that acquisition and release complete without error;
+use `failsWith` / `failsWithMessage` to verify that the cycle fails in the
+expected way.
+
+<ResourceAssertions/>
+
+## `Guard<T>` assertions
+
+`Guard.check(value)` returns `Validated<NonEmptyList<String>, T>`. The assertion
+methods call `check` internally — you only supply the value to validate and the
+messages you expect to find in the rejection error list.
+
+<GuardAssertions/>
+
+## `Accumulator<E, A>` assertions
+
+`accumulationContains` and `accumulationHasSize` require the accumulated
+side-channel (`E`) to be a `java.util.Collection`. If it is not, the assertion
+fails with a descriptive error. Use `hasAccumulation` for equality checks on
+any accumulation type.
+
+<AccumulatorAssertions/>
 
 ## Version compatibility
 


### PR DESCRIPTION
- **feat(assertj): add fluent assertions for Resource, Guard, and Accumulator (#252)**
- **test(samples): add real-world examples for Resource, Guard, and Accumulator assertions**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #252

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fluent AssertJ assertions for Resource, Guard, and Accumulator types, enabling streamlined testing of resource lifecycle behavior, guard validation logic, and accumulator state.

* **Documentation**
  * Added comprehensive guides and examples demonstrating assertion usage for the three newly supported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->