### PR TITLE
test(jackson): enable fun-assertj fluent assertions in test suite

### DIFF
--- a/assertj/README.md
+++ b/assertj/README.md
@@ -38,6 +38,20 @@ the argument types differ.
 
 ## Assertions reference
 
+### `Either<L, R>`
+
+| Method                     | Description                                                  |
+|----------------------------|--------------------------------------------------------------|
+| `isRight()`                | Asserts the either is a Right                                |
+| `isLeft()`                 | Asserts the either is a Left                                 |
+| `containsRight(expected)`  | Asserts the either is Right and contains the given value     |
+| `containsLeft(expected)`   | Asserts the either is Left and contains the given value      |
+
+```java
+assertThat(Either.right(42)).isRight().containsRight(42);
+assertThat(Either.left("oops")).isLeft().containsLeft("oops");
+```
+
 ### `Option<T>`
 
 | Method                         | Description                                                               |
@@ -108,6 +122,52 @@ assertThat(Validated.invalid("bad")).isInvalid().hasError("bad");
 assertThat(new Tuple2<>("Alice", 30)).hasFirst("Alice").hasSecond(30);
 assertThat(Tuple3.of("Alice", 30, true)).hasFirst("Alice").hasSecond(30).hasThird(true);
 assertThat(Tuple4.of("Alice", 30, true, 1.75)).hasFirst("Alice").hasFourth(1.75);
+```
+
+### `Resource<T>`
+
+| Method                       | Description                                                          |
+|------------------------------|----------------------------------------------------------------------|
+| `succeedsWith(expected)`     | Asserts the resource lifecycle completes and yields the given value  |
+| `failsWith(exceptionType)`   | Asserts the lifecycle fails with an exception of the given type      |
+| `failsWithMessage(message)`  | Asserts the lifecycle fails with an exception containing the message |
+
+The lifecycle (acquire → use → release) runs exactly once and is cached — all
+chained assertions on the same instance reuse the same result.
+
+```java
+assertThat(Resource.of(() -> "conn", c -> {})).succeedsWith("conn");
+assertThat(Resource.of(() -> { throw new IOException("timeout"); }, c -> {}))
+    .failsWith(IOException.class);
+```
+
+### `Guard<T>`
+
+| Method                                   | Description                                                       |
+|------------------------------------------|-------------------------------------------------------------------|
+| `accepts(value)`                         | Asserts the guard passes for the given value                      |
+| `rejects(value)`                         | Asserts the guard fails for the given value                       |
+| `rejectsWithMessage(value, message)`     | Asserts the guard fails with the exact given message              |
+| `rejectsWithMessages(value, messages…)`  | Asserts the guard fails with all of the given messages            |
+
+```java
+Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+assertThat(notBlank).accepts("alice").rejects("  ");
+assertThat(notBlank).rejectsWithMessage("", "must not be blank");
+```
+
+### `Accumulator<E, A>`
+
+| Method                          | Description                                                              |
+|---------------------------------|--------------------------------------------------------------------------|
+| `hasValue(expected)`            | Asserts the primary value equals the expected value                      |
+| `hasAccumulation(expected)`     | Asserts the side-channel accumulation equals the expected value          |
+| `accumulationContains(element)` | Asserts the accumulation (a `Collection`) contains the given element     |
+| `accumulationHasSize(size)`     | Asserts the accumulation (a `Collection`) has the given size             |
+
+```java
+Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("step1", "step2"));
+assertThat(acc).hasValue(42).accumulationContains("step1").accumulationHasSize(2);
 ```
 
 ## AssertJ version compatibility

--- a/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
+++ b/assertj/src/main/java/dmx/fun/assertj/DmxFunAssertions.java
@@ -1,6 +1,7 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Accumulator;
+import dmx.fun.Either;
 import dmx.fun.Guard;
 import dmx.fun.Option;
 import dmx.fun.Resource;
@@ -42,6 +43,18 @@ public final class DmxFunAssertions {
      */
     public static <V> OptionAssert<V> assertThat(Option<V> actual) {
         return new OptionAssert<>(actual);
+    }
+
+    /**
+     * Creates an assertion for an {@link Either}.
+     *
+     * @param <L>    the left value type
+     * @param <R>    the right value type
+     * @param actual the Either to assert on
+     * @return a new {@link EitherAssert}
+     */
+    public static <L, R> EitherAssert<L, R> assertThat(Either<L, R> actual) {
+        return new EitherAssert<>(actual);
     }
 
     /**

--- a/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
@@ -75,7 +75,7 @@ public final class EitherAssert<L, R> extends AbstractAssert<EitherAssert<L, R>,
     }
 
     private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
+        String message = String.format(template, args);
         String description = info.descriptionText();
         return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }

--- a/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
@@ -1,0 +1,82 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Either;
+import java.util.Objects;
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * AssertJ assertions for {@link Either}.
+ *
+ * <p>Obtain instances via {@link DmxFunAssertions#assertThat(Either)}.
+ *
+ * @param <L> the left value type
+ * @param <R> the right value type
+ */
+@NullMarked
+public final class EitherAssert<L, R> extends AbstractAssert<EitherAssert<L, R>, Either<L, R>> {
+
+    EitherAssert(Either<L, R> actual) {
+        super(actual, EitherAssert.class);
+    }
+
+    /**
+     * Verifies that the {@code Either} is a {@code Right}.
+     *
+     * @return this assertion for chaining
+     */
+    public EitherAssert<L, R> isRight() {
+        isNotNull();
+        if (!actual.isRight()) {
+            throw buildError("Expected Either to be Right but was Left<%s>", actual.getLeft());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Either} is a {@code Left}.
+     *
+     * @return this assertion for chaining
+     */
+    public EitherAssert<L, R> isLeft() {
+        isNotNull();
+        if (!actual.isLeft()) {
+            throw buildError("Expected Either to be Left but was Right<%s>", actual.getRight());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Either} is a {@code Right} containing the given value.
+     *
+     * @param expected the expected right value
+     * @return this assertion for chaining
+     */
+    public EitherAssert<L, R> containsRight(R expected) {
+        isRight();
+        if (!Objects.equals(actual.getRight(), expected)) {
+            throw buildError("Expected Either to contain right <%s> but contained <%s>", expected, actual.getRight());
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that the {@code Either} is a {@code Left} containing the given value.
+     *
+     * @param expected the expected left value
+     * @return this assertion for chaining
+     */
+    public EitherAssert<L, R> containsLeft(L expected) {
+        isLeft();
+        if (!Objects.equals(actual.getLeft(), expected)) {
+            throw buildError("Expected Either to contain left <%s> but contained <%s>", expected, actual.getLeft());
+        }
+        return this;
+    }
+
+    private AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    }
+}

--- a/assertj/src/main/java/module-info.java
+++ b/assertj/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 /**
  * AssertJ custom assertions for dmx-fun types.
  *
- * <p>Provides fluent, self-documenting assertions for {@code Option}, {@code Result},
- * {@code Try}, {@code Validated}, {@code Tuple2}, {@code Tuple3}, {@code Tuple4},
- * {@code Resource}, {@code Guard}, and {@code Accumulator}.
+ * <p>Provides fluent, self-documenting assertions for {@code Either}, {@code Option},
+ * {@code Result}, {@code Try}, {@code Validated}, {@code Tuple2}, {@code Tuple3},
+ * {@code Tuple4}, {@code Resource}, {@code Guard}, and {@code Accumulator}.
  *
  * <p>Entry point: {@link dmx.fun.assertj.DmxFunAssertions#assertThat}.
  */

--- a/assertj/src/test/java/dmx/fun/assertj/EitherAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/EitherAssertTest.java
@@ -1,0 +1,112 @@
+package dmx.fun.assertj;
+
+import dmx.fun.Either;
+import org.junit.jupiter.api.Test;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EitherAssertTest {
+
+    // ── isRight() ─────────────────────────────────────────────────────────────
+
+    @Test
+    void isRight_shouldPass_forRight() {
+        assertThat(Either.<String, Integer>right(1)).isRight();
+    }
+
+    @Test
+    void isRight_shouldFail_forLeft() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>left("oops")).isRight())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Right")
+            .hasMessageContaining("oops");
+    }
+
+    @Test
+    void isRight_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() ->
+            assertThat(Either.<String, Integer>left("err")).as("payment result").isRight())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[payment result]");
+    }
+
+    // ── isLeft() ──────────────────────────────────────────────────────────────
+
+    @Test
+    void isLeft_shouldPass_forLeft() {
+        assertThat(Either.<String, Integer>left("err")).isLeft();
+    }
+
+    @Test
+    void isLeft_shouldFail_forRight() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>right(42)).isLeft())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Left")
+            .hasMessageContaining("42");
+    }
+
+    @Test
+    void isLeft_shouldIncludeDescription_inFailureMessage() {
+        assertThatThrownBy(() ->
+            assertThat(Either.<String, Integer>right(1)).as("routing result").isLeft())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("[routing result]");
+    }
+
+    // ── containsRight() ───────────────────────────────────────────────────────
+
+    @Test
+    void containsRight_shouldPass_whenValueMatches() {
+        assertThat(Either.<String, Integer>right(42)).containsRight(42);
+    }
+
+    @Test
+    void containsRight_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>right(42)).containsRight(99))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99")
+            .hasMessageContaining("42");
+    }
+
+    @Test
+    void containsRight_shouldFail_forLeft() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>left("e")).containsRight(1))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Right");
+    }
+
+    // ── containsLeft() ────────────────────────────────────────────────────────
+
+    @Test
+    void containsLeft_shouldPass_whenValueMatches() {
+        assertThat(Either.<String, Integer>left("error")).containsLeft("error");
+    }
+
+    @Test
+    void containsLeft_shouldFail_whenValueDiffers() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>left("error")).containsLeft("other"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("other")
+            .hasMessageContaining("error");
+    }
+
+    @Test
+    void containsLeft_shouldFail_forRight() {
+        assertThatThrownBy(() -> assertThat(Either.<String, Integer>right(1)).containsLeft("e"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Left");
+    }
+
+    // ── Chaining ──────────────────────────────────────────────────────────────
+
+    @Test
+    void isFluent_shouldChain_isRight_containsRight() {
+        assertThat(Either.<String, Integer>right(5)).isRight().containsRight(5);
+    }
+
+    @Test
+    void isFluent_shouldChain_isLeft_containsLeft() {
+        assertThat(Either.<String, Integer>left("e")).isLeft().containsLeft("e");
+    }
+}

--- a/jackson/build.gradle
+++ b/jackson/build.gradle
@@ -16,10 +16,25 @@ dependencies {
     // Tests run against the version passed via -PjacksonVersion=X.Y.Z (used by
     // the CI compatibility matrix), falling back to the catalog version locally.
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${findProperty('jacksonVersion') ?: libs.versions.jackson.get()}"
+
+    // Fluent assertions for dmx-fun types (ResultAssert, TryAssert, etc.).
+    // compileOnly puts dmx.fun.assertj on compileClasspath so the JPMS module-path
+    // plugin can expose it to compileTestJava; testImplementation covers test runtime.
+    // assertj-core is already on the classpath via dmx-fun.java-base.
+    compileOnly        project(':assertj')
+    testImplementation project(':assertj')
 }
 
 jpmsTest {
-    moduleName = 'dmx.fun.jackson'
+    moduleName   = 'dmx.fun.jackson'
+    extraModules = ['dmx.fun.assertj']
+    extraReads   = ['dmx.fun.assertj']
+}
+
+// assertj-core is on the classpath (unnamed module) at compile time but dmx.fun.assertj
+// is on the module path and requires it. This read allows the compiler to resolve it.
+tasks.named('compileTestJava') {
+    options.compilerArgs += ['--add-reads', 'dmx.fun.assertj=ALL-UNNAMED']
 }
 
 mavenPublishing {

--- a/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
+++ b/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
@@ -349,8 +349,7 @@ class DmxFunModuleTest {
             Either<String, Integer> original = Either.right(5);
             String json = mapper.writeValueAsString(original);
             Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
-            assertThat(deserialized.isRight()).isTrue();
-            assertThat(deserialized.getRight()).isEqualTo(5);
+            assertThat(deserialized).isRight().containsRight(5);
         }
 
         @Test
@@ -358,24 +357,21 @@ class DmxFunModuleTest {
             Either<String, Integer> original = Either.left("left value");
             String json = mapper.writeValueAsString(original);
             Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
-            assertThat(deserialized.isLeft()).isTrue();
-            assertThat(deserialized.getLeft()).isEqualTo("left value");
+            assertThat(deserialized).isLeft().containsLeft("left value");
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeRight_rawType_coversNullRightTypePath() throws Exception {
-            Either<?, ?> result = mapper.readValue("{\"right\":5}", Either.class);
-            assertThat(result.isRight()).isTrue();
-            assertThat(result.getRight()).isEqualTo(5);
+            Either<Object, Object> result = (Either<Object, Object>) mapper.readValue("{\"right\":5}", Either.class);
+            assertThat(result).isRight().containsRight(5);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeLeft_rawType_coversNullLeftTypePath() throws Exception {
-            Either<?, ?> result = mapper.readValue("{\"left\":\"e\"}", Either.class);
-            assertThat(result.isLeft()).isTrue();
-            assertThat(result.getLeft()).isEqualTo("e");
+            Either<Object, Object> result = (Either<Object, Object>) mapper.readValue("{\"left\":\"e\"}", Either.class);
+            assertThat(result).isLeft().containsLeft("e");
         }
 
         @Test

--- a/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
+++ b/jackson/src/test/java/dmx/fun/jackson/DmxFunModuleTest.java
@@ -20,7 +20,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DmxFunModuleTest {
 
@@ -42,27 +45,26 @@ class DmxFunModuleTest {
         void serializeSome() throws Exception {
             Option<String> some = Option.some("hello");
             String json = mapper.writeValueAsString(some);
-            assertEquals("\"hello\"", json);
+            assertThat(json).isEqualTo("\"hello\"");
         }
 
         @Test
         void serializeNone() throws Exception {
             Option<String> none = Option.none();
             String json = mapper.writeValueAsString(none);
-            assertEquals("null", json);
+            assertThat(json).isEqualTo("null");
         }
 
         @Test
         void deserializeSome() throws Exception {
             Option<String> result = mapper.readValue("\"world\"", new TypeReference<Option<String>>() {});
-            assertTrue(result.isDefined());
-            assertEquals("world", result.get());
+            assertThat(result).isSome().containsValue("world");
         }
 
         @Test
         void deserializeNone() throws Exception {
             Option<String> result = mapper.readValue("null", new TypeReference<Option<String>>() {});
-            assertTrue(result.isEmpty());
+            assertThat(result).isNone();
         }
 
         @Test
@@ -70,8 +72,7 @@ class DmxFunModuleTest {
             Option<Integer> original = Option.some(42);
             String json = mapper.writeValueAsString(original);
             Option<Integer> deserialized = mapper.readValue(json, new TypeReference<Option<Integer>>() {});
-            assertTrue(deserialized.isDefined());
-            assertEquals(42, deserialized.get());
+            assertThat(deserialized).isSome().containsValue(42);
         }
 
         @Test
@@ -79,7 +80,7 @@ class DmxFunModuleTest {
             Option<Integer> original = Option.none();
             String json = mapper.writeValueAsString(original);
             Option<Integer> deserialized = mapper.readValue(json, new TypeReference<Option<Integer>>() {});
-            assertTrue(deserialized.isEmpty());
+            assertThat(deserialized).isNone();
         }
 
         @Test
@@ -88,8 +89,8 @@ class DmxFunModuleTest {
             // No TypeReference → createContextual returns `this` (no type params),
             // deserialize falls back to p.readValueAs(Object.class)
             Option<?> result = mapper.readValue("\"raw\"", Option.class);
-            assertTrue(result.isDefined());
-            assertEquals("raw", result.get());
+            assertThat(result).isSome();
+            assertThat(result.get()).isEqualTo("raw");
         }
     }
 
@@ -104,14 +105,14 @@ class DmxFunModuleTest {
         void serializeOk() throws Exception {
             Result<String, Integer> ok = Result.ok("success");
             String json = mapper.writeValueAsString(ok);
-            assertEquals("{\"ok\":\"success\"}", json);
+            assertThat(json).isEqualTo("{\"ok\":\"success\"}");
         }
 
         @Test
         void serializeErr() throws Exception {
             Result<String, Integer> err = Result.err(404);
             String json = mapper.writeValueAsString(err);
-            assertEquals("{\"err\":404}", json);
+            assertThat(json).isEqualTo("{\"err\":404}");
         }
 
         @Test
@@ -119,8 +120,7 @@ class DmxFunModuleTest {
             Result<String, Integer> original = Result.ok("hello");
             String json = mapper.writeValueAsString(original);
             Result<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
-            assertTrue(deserialized.isOk());
-            assertEquals("hello", deserialized.get());
+            assertThat(deserialized).isOk().containsValue("hello");
         }
 
         @Test
@@ -128,31 +128,30 @@ class DmxFunModuleTest {
             Result<String, Integer> original = Result.err(500);
             String json = mapper.writeValueAsString(original);
             Result<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
-            assertTrue(deserialized.isError());
-            assertEquals(500, deserialized.getError());
+            assertThat(deserialized).isErr().containsError(500);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeOk_rawType_coversNullValueTypePath() throws Exception {
             Result<?, ?> result = mapper.readValue("{\"ok\":99}", Result.class);
-            assertTrue(result.isOk());
-            assertEquals(99, result.get());
+            assertThat(result).isOk();
+            assertThat(result.get()).isEqualTo(99);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeErr_rawType_coversNullErrorTypePath() throws Exception {
             Result<?, ?> result = mapper.readValue("{\"err\":\"oops\"}", Result.class);
-            assertTrue(result.isError());
-            assertEquals("oops", result.getError());
+            assertThat(result).isErr();
+            assertThat(result.getError()).isEqualTo("oops");
         }
 
         @Test
         void deserializeUnknownField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Result<Integer, String>>() {}));
-            assertTrue(ex.getMessage().contains("unknown"));
+            assertThat(ex.getMessage()).contains("unknown");
         }
 
         @Test
@@ -171,7 +170,7 @@ class DmxFunModuleTest {
         void deserializeExtraField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"ok\":1,\"extra\":2}", new TypeReference<Result<Integer, String>>() {}));
-            assertTrue(ex.getMessage().contains("extra"));
+            assertThat(ex.getMessage()).contains("extra");
         }
     }
 
@@ -186,14 +185,14 @@ class DmxFunModuleTest {
         void serializeSuccess() throws Exception {
             Try<String> success = Try.success("ok");
             String json = mapper.writeValueAsString(success);
-            assertEquals("\"ok\"", json);
+            assertThat(json).isEqualTo("\"ok\"");
         }
 
         @Test
         void serializeFailure() throws Exception {
             Try<String> failure = Try.failure(new RuntimeException("boom"));
             String json = mapper.writeValueAsString(failure);
-            assertEquals("{\"error\":\"boom\"}", json);
+            assertThat(json).isEqualTo("{\"error\":\"boom\"}");
         }
 
         @Test
@@ -201,8 +200,7 @@ class DmxFunModuleTest {
             Try<Integer> original = Try.success(99);
             String json = mapper.writeValueAsString(original);
             Try<Integer> deserialized = mapper.readValue(json, new TypeReference<Try<Integer>>() {});
-            assertTrue(deserialized.isSuccess());
-            assertEquals(99, deserialized.get());
+            assertThat(deserialized).isSuccess().containsValue(99);
         }
 
         @Test
@@ -210,8 +208,8 @@ class DmxFunModuleTest {
             Try<Integer> original = Try.failure(new RuntimeException("error message"));
             String json = mapper.writeValueAsString(original);
             Try<Integer> deserialized = mapper.readValue(json, new TypeReference<Try<Integer>>() {});
-            assertTrue(deserialized.isFailure());
-            assertEquals("error message", deserialized.getCause().getMessage());
+            assertThat(deserialized).isFailure();
+            assertThat(deserialized.getCause().getMessage()).isEqualTo("error message");
         }
 
         @Test
@@ -221,8 +219,8 @@ class DmxFunModuleTest {
             String json = "{\"name\":\"alice\"}";
             Try<Map<String, Object>> result = mapper.readValue(json,
                 new TypeReference<Try<Map<String, Object>>>() {});
-            assertTrue(result.isSuccess());
-            assertEquals("alice", result.get().get("name"));
+            assertThat(result).isSuccess();
+            assertThat(result.get().get("name")).isEqualTo("alice");
         }
 
         @Test
@@ -230,9 +228,9 @@ class DmxFunModuleTest {
         void deserializeSuccessObject_rawType_coversNodeReturnPath() throws Exception {
             // START_OBJECT, no "error" key, valueType == null → returns Try.success(node)
             Try<?> result = mapper.readValue("{\"key\":\"v\"}", Try.class);
-            assertTrue(result.isSuccess());
+            assertThat(result).isSuccess();
             assertInstanceOf(JsonNode.class, result.get());
-            assertEquals("v", ((JsonNode) result.get()).get("key").asText());
+            assertThat(((JsonNode) result.get()).get("key").asText()).isEqualTo("v");
         }
 
         @Test
@@ -240,8 +238,8 @@ class DmxFunModuleTest {
         void deserializeSuccess_rawType_coversPrimitiveNullTypePath() throws Exception {
             // Non-object token, valueType == null → p.readValueAs(Object.class)
             Try<?> result = mapper.readValue("42", Try.class);
-            assertTrue(result.isSuccess());
-            assertEquals(42, result.get());
+            assertThat(result).isSuccess();
+            assertThat(result.get()).isEqualTo(42);
         }
     }
 
@@ -256,14 +254,14 @@ class DmxFunModuleTest {
         void serializeValid() throws Exception {
             Validated<String, Integer> valid = Validated.valid(42);
             String json = mapper.writeValueAsString(valid);
-            assertEquals("{\"valid\":42}", json);
+            assertThat(json).isEqualTo("{\"valid\":42}");
         }
 
         @Test
         void serializeInvalid() throws Exception {
             Validated<String, Integer> invalid = Validated.invalid("error");
             String json = mapper.writeValueAsString(invalid);
-            assertEquals("{\"invalid\":\"error\"}", json);
+            assertThat(json).isEqualTo("{\"invalid\":\"error\"}");
         }
 
         @Test
@@ -271,8 +269,7 @@ class DmxFunModuleTest {
             Validated<String, Integer> original = Validated.valid(7);
             String json = mapper.writeValueAsString(original);
             Validated<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Validated<String, Integer>>() {});
-            assertTrue(deserialized.isValid());
-            assertEquals(7, deserialized.get());
+            assertThat(deserialized).isValid().containsValue(7);
         }
 
         @Test
@@ -280,31 +277,30 @@ class DmxFunModuleTest {
             Validated<String, Integer> original = Validated.invalid("bad input");
             String json = mapper.writeValueAsString(original);
             Validated<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Validated<String, Integer>>() {});
-            assertTrue(deserialized.isInvalid());
-            assertEquals("bad input", deserialized.getError());
+            assertThat(deserialized).isInvalid().hasError("bad input");
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeValid_rawType_coversNullValueTypePath() throws Exception {
             Validated<?, ?> result = mapper.readValue("{\"valid\":7}", Validated.class);
-            assertTrue(result.isValid());
-            assertEquals(7, result.get());
+            assertThat(result).isValid();
+            assertThat(result.get()).isEqualTo(7);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeInvalid_rawType_coversNullErrorTypePath() throws Exception {
             Validated<?, ?> result = mapper.readValue("{\"invalid\":\"e\"}", Validated.class);
-            assertTrue(result.isInvalid());
-            assertEquals("e", result.getError());
+            assertThat(result).isInvalid();
+            assertThat(result.getError()).isEqualTo("e");
         }
 
         @Test
         void deserializeUnknownField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Validated<String, Integer>>() {}));
-            assertTrue(ex.getMessage().contains("unknown"));
+            assertThat(ex.getMessage()).contains("unknown");
         }
 
         @Test
@@ -323,7 +319,7 @@ class DmxFunModuleTest {
         void deserializeExtraField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"valid\":1,\"extra\":2}", new TypeReference<Validated<String, Integer>>() {}));
-            assertTrue(ex.getMessage().contains("extra"));
+            assertThat(ex.getMessage()).contains("extra");
         }
     }
 
@@ -338,14 +334,14 @@ class DmxFunModuleTest {
         void serializeRight() throws Exception {
             Either<String, Integer> right = Either.right(1);
             String json = mapper.writeValueAsString(right);
-            assertEquals("{\"right\":1}", json);
+            assertThat(json).isEqualTo("{\"right\":1}");
         }
 
         @Test
         void serializeLeft() throws Exception {
             Either<String, Integer> left = Either.left("oops");
             String json = mapper.writeValueAsString(left);
-            assertEquals("{\"left\":\"oops\"}", json);
+            assertThat(json).isEqualTo("{\"left\":\"oops\"}");
         }
 
         @Test
@@ -353,8 +349,8 @@ class DmxFunModuleTest {
             Either<String, Integer> original = Either.right(5);
             String json = mapper.writeValueAsString(original);
             Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
-            assertTrue(deserialized.isRight());
-            assertEquals(5, deserialized.getRight());
+            assertThat(deserialized.isRight()).isTrue();
+            assertThat(deserialized.getRight()).isEqualTo(5);
         }
 
         @Test
@@ -362,31 +358,31 @@ class DmxFunModuleTest {
             Either<String, Integer> original = Either.left("left value");
             String json = mapper.writeValueAsString(original);
             Either<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Either<String, Integer>>() {});
-            assertTrue(deserialized.isLeft());
-            assertEquals("left value", deserialized.getLeft());
+            assertThat(deserialized.isLeft()).isTrue();
+            assertThat(deserialized.getLeft()).isEqualTo("left value");
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeRight_rawType_coversNullRightTypePath() throws Exception {
             Either<?, ?> result = mapper.readValue("{\"right\":5}", Either.class);
-            assertTrue(result.isRight());
-            assertEquals(5, result.getRight());
+            assertThat(result.isRight()).isTrue();
+            assertThat(result.getRight()).isEqualTo(5);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeLeft_rawType_coversNullLeftTypePath() throws Exception {
             Either<?, ?> result = mapper.readValue("{\"left\":\"e\"}", Either.class);
-            assertTrue(result.isLeft());
-            assertEquals("e", result.getLeft());
+            assertThat(result.isLeft()).isTrue();
+            assertThat(result.getLeft()).isEqualTo("e");
         }
 
         @Test
         void deserializeUnknownField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"unknown\":42}", new TypeReference<Either<String, Integer>>() {}));
-            assertTrue(ex.getMessage().contains("unknown"));
+            assertThat(ex.getMessage()).contains("unknown");
         }
 
         @Test
@@ -405,7 +401,7 @@ class DmxFunModuleTest {
         void deserializeExtraField_throws() {
             JsonMappingException ex = assertThrows(JsonMappingException.class, () ->
                 mapper.readValue("{\"right\":1,\"extra\":2}", new TypeReference<Either<String, Integer>>() {}));
-            assertTrue(ex.getMessage().contains("extra"));
+            assertThat(ex.getMessage()).contains("extra");
         }
     }
 
@@ -420,7 +416,7 @@ class DmxFunModuleTest {
         void serialize() throws Exception {
             Tuple2<String, Integer> t = new Tuple2<>("a", 1);
             String json = mapper.writeValueAsString(t);
-            assertEquals("[\"a\",1]", json);
+            assertThat(json).isEqualTo("[\"a\",1]");
         }
 
         @Test
@@ -428,16 +424,16 @@ class DmxFunModuleTest {
             Tuple2<String, Integer> original = new Tuple2<>("hello", 42);
             String json = mapper.writeValueAsString(original);
             Tuple2<String, Integer> deserialized = mapper.readValue(json, new TypeReference<Tuple2<String, Integer>>() {});
-            assertEquals("hello", deserialized._1());
-            assertEquals(42, deserialized._2());
+            assertThat(deserialized._1()).isEqualTo("hello");
+            assertThat(deserialized._2()).isEqualTo(42);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeRawType_coversNullTypePaths() throws Exception {
             Tuple2<?, ?> result = mapper.readValue("[\"a\",1]", Tuple2.class);
-            assertEquals("a", result._1());
-            assertEquals(1, result._2());
+            assertThat(result._1()).isEqualTo("a");
+            assertThat(result._2()).isEqualTo(1);
         }
 
         @Test
@@ -476,7 +472,7 @@ class DmxFunModuleTest {
         void serialize() throws Exception {
             Tuple3<String, Integer, Boolean> t = Tuple3.of("a", 1, true);
             String json = mapper.writeValueAsString(t);
-            assertEquals("[\"a\",1,true]", json);
+            assertThat(json).isEqualTo("[\"a\",1,true]");
         }
 
         @Test
@@ -484,18 +480,18 @@ class DmxFunModuleTest {
             Tuple3<String, Integer, Boolean> original = Tuple3.of("x", 10, false);
             String json = mapper.writeValueAsString(original);
             Tuple3<String, Integer, Boolean> deserialized = mapper.readValue(json, new TypeReference<Tuple3<String, Integer, Boolean>>() {});
-            assertEquals("x", deserialized._1());
-            assertEquals(10, deserialized._2());
-            assertEquals(false, deserialized._3());
+            assertThat(deserialized._1()).isEqualTo("x");
+            assertThat(deserialized._2()).isEqualTo(10);
+            assertThat(deserialized._3()).isEqualTo(false);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeRawType_coversNullTypePaths() throws Exception {
             Tuple3<?, ?, ?> result = mapper.readValue("[\"a\",1,true]", Tuple3.class);
-            assertEquals("a", result._1());
-            assertEquals(1, result._2());
-            assertEquals(true, result._3());
+            assertThat(result._1()).isEqualTo("a");
+            assertThat(result._2()).isEqualTo(1);
+            assertThat(result._3()).isEqualTo(true);
         }
 
         @Test
@@ -540,7 +536,7 @@ class DmxFunModuleTest {
         void serialize() throws Exception {
             Tuple4<String, Integer, Boolean, Double> t = Tuple4.of("a", 1, true, 3.14);
             String json = mapper.writeValueAsString(t);
-            assertEquals("[\"a\",1,true,3.14]", json);
+            assertThat(json).isEqualTo("[\"a\",1,true,3.14]");
         }
 
         @Test
@@ -548,20 +544,20 @@ class DmxFunModuleTest {
             Tuple4<String, Integer, Boolean, Double> original = Tuple4.of("z", 7, true, 2.71);
             String json = mapper.writeValueAsString(original);
             Tuple4<String, Integer, Boolean, Double> deserialized = mapper.readValue(json, new TypeReference<Tuple4<String, Integer, Boolean, Double>>() {});
-            assertEquals("z", deserialized._1());
-            assertEquals(7, deserialized._2());
-            assertEquals(true, deserialized._3());
-            assertEquals(2.71, deserialized._4(), 0.001);
+            assertThat(deserialized._1()).isEqualTo("z");
+            assertThat(deserialized._2()).isEqualTo(7);
+            assertThat(deserialized._3()).isEqualTo(true);
+            assertThat(deserialized._4()).isEqualTo(2.71);
         }
 
         @Test
         @SuppressWarnings("unchecked")
         void deserializeRawType_coversNullTypePaths() throws Exception {
             Tuple4<?, ?, ?, ?> result = mapper.readValue("[\"a\",1,true,3.14]", Tuple4.class);
-            assertEquals("a", result._1());
-            assertEquals(1, result._2());
-            assertEquals(true, result._3());
-            assertEquals(3.14, (double) result._4(), 0.001);
+            assertThat(result._1()).isEqualTo("a");
+            assertThat(result._2()).isEqualTo(1);
+            assertThat(result._3()).isEqualTo(true);
+            assertThat((double) result._4()).isEqualTo(3.14);
         }
 
         @Test
@@ -612,14 +608,14 @@ class DmxFunModuleTest {
         void serializeSingleElement() throws Exception {
             NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of());
             String json = mapper.writeValueAsString(nel);
-            assertEquals("[1]", json);
+            assertThat(json).isEqualTo("[1]");
         }
 
         @Test
         void serializeMultipleElements() throws Exception {
             NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
             String json = mapper.writeValueAsString(nel);
-            assertEquals("[1,2,3]", json);
+            assertThat(json).isEqualTo("[1,2,3]");
         }
 
         @Test
@@ -627,8 +623,8 @@ class DmxFunModuleTest {
             NonEmptyList<Integer> original = NonEmptyList.of(1, List.of(2, 3));
             String json = mapper.writeValueAsString(original);
             NonEmptyList<Integer> deserialized = mapper.readValue(json, new TypeReference<NonEmptyList<Integer>>() {});
-            assertEquals(1, deserialized.head());
-            assertEquals(List.of(2, 3), deserialized.tail());
+            assertThat(deserialized.head()).isEqualTo(1);
+            assertThat(deserialized.tail()).isEqualTo(List.of(2, 3));
         }
 
         @Test
@@ -641,8 +637,8 @@ class DmxFunModuleTest {
         @SuppressWarnings("unchecked")
         void deserializeRawType_coversNullElementTypePath() throws Exception {
             NonEmptyList<?> result = mapper.readValue("[1,2,3]", NonEmptyList.class);
-            assertEquals(1, result.head());
-            assertEquals(List.of(2, 3), result.tail());
+            assertThat(result.head()).isEqualTo(1);
+            assertThat(result.tail()).isEqualTo(List.of(2, 3));
         }
 
         @Test
@@ -664,11 +660,10 @@ class DmxFunModuleTest {
             ObjectMapper autoMapper = new ObjectMapper().findAndRegisterModules();
             Option<String> some = Option.some("auto");
             String json = autoMapper.writeValueAsString(some);
-            assertEquals("\"auto\"", json);
+            assertThat(json).isEqualTo("\"auto\"");
 
             Option<String> deserialized = autoMapper.readValue("\"auto\"", new TypeReference<Option<String>>() {});
-            assertTrue(deserialized.isDefined());
-            assertEquals("auto", deserialized.get());
+            assertThat(deserialized).isSome().containsValue("auto");
         }
 
         @Test
@@ -676,11 +671,10 @@ class DmxFunModuleTest {
             ObjectMapper autoMapper = new ObjectMapper().findAndRegisterModules();
             Result<String, Integer> ok = Result.ok("found");
             String json = autoMapper.writeValueAsString(ok);
-            assertEquals("{\"ok\":\"found\"}", json);
+            assertThat(json).isEqualTo("{\"ok\":\"found\"}");
 
             Result<String, Integer> deserialized = autoMapper.readValue(json, new TypeReference<Result<String, Integer>>() {});
-            assertTrue(deserialized.isOk());
-            assertEquals("found", deserialized.get());
+            assertThat(deserialized).isOk().containsValue("found");
         }
     }
 }

--- a/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
+++ b/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
@@ -1,6 +1,7 @@
 package dmx.fun.samples;
 
 import dmx.fun.Accumulator;
+import dmx.fun.Either;
 import dmx.fun.Guard;
 import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
@@ -22,6 +23,39 @@ import static dmx.fun.assertj.DmxFunAssertions.assertThat;
  * org.assertj.core.api.Assertions.assertThat without naming conflicts.
  */
 class AssertJSampleTest {
+
+    // ── Either<L, R> ─────────────────────────────────────────────────────────
+
+    @Test
+    void either_rightContainsValue() {
+        // Models a computation that produces the success track (Right).
+        Either<String, Integer> parsed = Either.right(42);
+
+        assertThat(parsed)
+            .isRight()
+            .containsRight(42);
+    }
+
+    @Test
+    void either_leftContainsError() {
+        // Models a computation that ended on the error track (Left).
+        Either<String, Integer> failed = Either.left("invalid input");
+
+        assertThat(failed)
+            .isLeft()
+            .containsLeft("invalid input");
+    }
+
+    @Test
+    void either_isRight_afterSwap() {
+        // swap() exchanges left and right — a Left becomes a Right.
+        Either<String, Integer> original = Either.left("msg");
+        Either<Integer, String> swapped  = original.swap();
+
+        assertThat(swapped)
+            .isRight()
+            .containsRight("msg");
+    }
 
     // ── Option<T> ────────────────────────────────────────────────────────────
 

--- a/site/src/data/code/guide/assertj/either-assertions.mdx
+++ b/site/src/data/code/guide/assertj/either-assertions.mdx
@@ -1,0 +1,21 @@
+---
+fileName: 'EitherTest.java'
+---
+
+```java
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+
+// Assert Right and its value — chainable in one expression
+assertThat(Either.<String, Integer>right(42))
+    .isRight()
+    .containsRight(42);
+
+// Assert Left and its value — chainable in one expression
+assertThat(Either.<String, Integer>left("oops"))
+    .isLeft()
+    .containsLeft("oops");
+
+// isRight() / isLeft() alone when the value does not matter
+assertThat(Either.right("ok")).isRight();
+assertThat(Either.left("err")).isLeft();
+```

--- a/site/src/data/guide/assertj.mdx
+++ b/site/src/data/guide/assertj.mdx
@@ -1,11 +1,12 @@
 ---
 title: "AssertJ Integration — Developer Guide"
-description: "How to use the optional fun-assertj module: fluent assertions for Option, Result, Try, Validated, Tuple, Resource, Guard, and Accumulator types via DmxFunAssertions.assertThat."
+description: "How to use the optional fun-assertj module: fluent assertions for Either, Option, Result, Try, Validated, Tuple, Resource, Guard, and Accumulator types via DmxFunAssertions.assertThat."
 order: 15
 h1: "AssertJ Integration"
 ---
 
 import {Content as Dependency}           from '../code/guide/assertj/dependency.mdx';
+import {Content as EitherAssertions}     from '../code/guide/assertj/either-assertions.mdx';
 import {Content as OptionAssertions}     from '../code/guide/assertj/option-assertions.mdx';
 import {Content as ResultAssertions}     from '../code/guide/assertj/result-assertions.mdx';
 import {Content as TryAssertions}        from '../code/guide/assertj/try-assertions.mdx';
@@ -49,6 +50,7 @@ in the same test class without naming conflict, because the argument types diffe
 
 | Type                 | Methods                                                                                                                  |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `Either<L, R>`       | `isRight()`, `isLeft()`, `containsRight(expected)`, `containsLeft(expected)`                                             |
 | `Option<T>`          | `isSome()`, `isNone()`, `containsValue(expected)`, `hasValueSatisfying(consumer)`                                        |
 | `Result<V, E>`       | `isOk()`, `isErr()`, `containsValue(expected)`, `containsError(expected)`                                                |
 | `Try<V>`             | `isSuccess()`, `isFailure()`, `containsValue(expected)`, `failsWith(exceptionType)`                                      |
@@ -59,6 +61,10 @@ in the same test class without naming conflict, because the argument types diffe
 | `Resource<T>`        | `succeedsWith(expected)`, `failsWith(exceptionType)`, `failsWithMessage(message)`                                        |
 | `Guard<T>`           | `accepts(value)`, `rejects(value)`, `rejectsWithMessage(value, message)`, `rejectsWithMessages(value, messages...)`      |
 | `Accumulator<E, A>`  | `hasValue(expected)`, `hasAccumulation(expected)`, `accumulationContains(element)`, `accumulationHasSize(size)`          |
+
+## `Either<L, R>` assertions
+
+<EitherAssertions/>
 
 ## `Option<T>` assertions
 


### PR DESCRIPTION
  Add dmx.fun.assertj as a compileOnly/testImplementation dependency and
  configure jpmsTest (extraModules, extraReads) and the --add-reads compiler
  arg so DmxFunModuleTest can use DmxFunAssertions. Replace assertTrue /
  assertEquals on dmx-fun types with fluent assertThat chains (isOk,
  isErr, isSome, isNone, isSuccess, isFailure, isValid, isInvalid and
  their containsValue / containsError / hasError counterparts). Follows
  the same pattern applied in #249 for the spring module. Closes #257.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #257

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fluent AssertJ support for Either with new assertion methods and sample usage; documentation and guide updated.

* **Tests**
  * Replaced many JUnit assertions with AssertJ fluent assertions, added unit tests covering Either assertions and sample tests.

* **Chores**
  * Updated build/test configuration so assertions are available at test compile and runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->