### PR TITLE
feat(collectors): add Results, Options, and Tries collector facades with Try stream collectors

### DIFF
--- a/lib/src/main/java/dmx/fun/Options.java
+++ b/lib/src/main/java/dmx/fun/Options.java
@@ -1,0 +1,73 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collector;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Collector facade for {@code Stream<Option<T>>}.
+ *
+ * <p>Centralises all {@link Option} and {@link NonEmptyList} collector factories that operate on
+ * option streams as static methods, mirroring the role of {@link java.util.stream.Collectors}.
+ * The underlying factories on {@link Option} and {@link NonEmptyList} are kept for backward
+ * compatibility; this class simply delegates to them.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * import static dmx.fun.Options.*;
+ *
+ * List<String>              present = stream.collect(Options.presentToList());
+ * Optional<List<String>>    seq     = stream.collect(Options.sequence());
+ * Option<NonEmptyList<String>> nel  = stream.collect(Options.toNonEmptyList());
+ * }</pre>
+ *
+ * @see Option
+ * @see NonEmptyList
+ */
+@NullMarked
+public final class Options {
+
+    private Options() {}
+
+    /**
+     * Returns a {@link Collector} that collects all present values from a
+     * {@code Stream<Option<V>>} into an unordered {@link List}, discarding empty options.
+     *
+     * <p>Delegates to {@link Option#presentValuesToList()}.
+     *
+     * @param <V> the value type
+     * @return a collector producing a {@code List<V>} of present values
+     */
+    public static <V> Collector<Option<? extends V>, ?, List<V>> presentToList() {
+        return Option.presentValuesToList();
+    }
+
+    /**
+     * Returns a {@link Collector} that reduces a {@code Stream<Option<V>>} to a single
+     * {@code Optional<List<V>>}: {@code Optional.of(list)} if every element is present,
+     * or {@code Optional.empty()} if any element is empty.
+     *
+     * <p>Delegates to {@link Option#sequenceCollector()}.
+     *
+     * @param <V> the value type
+     * @return a collector producing {@code Optional<List<V>>}
+     */
+    public static <V> Collector<Option<V>, ?, Optional<List<V>>> sequence() {
+        return Option.sequenceCollector();
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<T>} into an
+     * {@code Option<NonEmptyList<T>>}: {@code Option.some(nel)} if the stream is non-empty,
+     * or {@code Option.none()} if the stream is empty.
+     *
+     * <p>Delegates to {@link NonEmptyList#toNonEmptyList()}.
+     *
+     * @param <T> the element type
+     * @return a collector producing {@code Option<NonEmptyList<T>>}
+     */
+    public static <T> Collector<T, ?, Option<NonEmptyList<T>>> toNonEmptyList() {
+        return NonEmptyList.toNonEmptyList();
+    }
+}

--- a/lib/src/main/java/dmx/fun/Results.java
+++ b/lib/src/main/java/dmx/fun/Results.java
@@ -1,0 +1,122 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Collector facade for {@code Stream<Result<V, E>>}.
+ *
+ * <p>Centralises all {@link Result} collector factories as static methods, mirroring the role
+ * of {@link java.util.stream.Collectors}. The underlying factories on {@link Result} are kept
+ * for backward compatibility; this class simply delegates to them.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * import static dmx.fun.Results.*;
+ *
+ * Result<List<Integer>, String> r  = stream.collect(Results.toList());
+ * Results.Partition<Integer, String> p = stream.collect(Results.partitioning());
+ * Map<String, NonEmptyList<Item>>  m  = stream.collect(Results.groupingBy(Item::category));
+ * }</pre>
+ *
+ * @see Result
+ */
+@NullMarked
+public final class Results {
+
+    private Results() {}
+
+    /**
+     * Transparent alias for {@link Result.Partition} so callers can use {@code Results.Partition}
+     * without importing {@link Result} directly.
+     *
+     * @param <V> the value type of the {@code Ok} elements
+     * @param <E> the error type of the {@code Err} elements
+     */
+    public record Partition<V, E>(List<V> oks, List<E> errors) {
+        /** Delegates to {@link Result.Partition} for consistent null/copy semantics. */
+        public Partition {
+            var delegate = new Result.Partition<>(oks, errors);
+            oks    = delegate.oks();
+            errors = delegate.errors();
+        }
+
+        /** Converts to the underlying {@link Result.Partition}. */
+        public Result.Partition<V, E> toResultPartition() {
+            return new Result.Partition<>(oks, errors);
+        }
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<Result<V, E>>} into a single
+     * {@code Result<List<V>, E>}, failing on the first {@code Err} encountered.
+     *
+     * <p>Delegates to {@link Result#toList()}.
+     *
+     * @param <V> the value type
+     * @param <E> the error type
+     * @return a collector producing {@code Result<List<V>, E>}
+     */
+    public static <V, E> Collector<Result<V, E>, ?, Result<List<V>, E>> toList() {
+        return Result.toList();
+    }
+
+    /**
+     * Returns a {@link Collector} that partitions a {@code Stream<Result<V, E>>} into ok-values
+     * and errors.
+     *
+     * <p>Delegates to {@link Result#partitioningBy()}.
+     *
+     * @param <V> the value type
+     * @param <E> the error type
+     * @return a collector producing a {@link Results.Partition}
+     */
+    public static <V, E> Collector<Result<V, E>, ?, Results.Partition<V, E>> partitioning() {
+        return Collector.of(
+            () -> new java.util.ArrayList<Result<V, E>>(),
+            java.util.List::add,
+            (a, b) -> { a.addAll(b); return a; },
+            list -> {
+                var p = list.stream().collect(Result.partitioningBy());
+                return new Results.Partition<>(p.oks(), p.errors());
+            }
+        );
+    }
+
+    /**
+     * Returns a {@link Collector} that groups stream elements by a key derived from each element.
+     *
+     * <p>Delegates to {@link Result#groupingBy(Function)}.
+     *
+     * @param <V>        the element type
+     * @param <K>        the key type
+     * @param classifier a function mapping each element to a grouping key
+     * @return a collector producing a {@code Map<K, NonEmptyList<V>>}
+     */
+    public static <V, K> Collector<V, ?, Map<K, NonEmptyList<V>>> groupingBy(
+            Function<? super V, ? extends K> classifier) {
+        return Result.groupingBy(classifier);
+    }
+
+    /**
+     * Returns a {@link Collector} that groups stream elements by a key derived from each element,
+     * then applies a finishing function to each group's {@link NonEmptyList}.
+     *
+     * <p>Delegates to {@link Result#groupingBy(Function, Function)}.
+     *
+     * @param <V>        the element type
+     * @param <K>        the key type
+     * @param <R>        the result type of the downstream function
+     * @param classifier a function mapping each element to a grouping key
+     * @param downstream a function applied to each group's {@code NonEmptyList}
+     * @return a collector producing a {@code Map<K, R>}
+     */
+    public static <V, K, R> Collector<V, ?, Map<K, R>> groupingBy(
+            Function<? super V, ? extends K> classifier,
+            Function<? super NonEmptyList<V>, ? extends R> downstream) {
+        return Result.groupingBy(classifier, downstream);
+    }
+}

--- a/lib/src/main/java/dmx/fun/Results.java
+++ b/lib/src/main/java/dmx/fun/Results.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>Usage:
  * <pre>{@code
- * import static dmx.fun.Results.*;
+ * import dmx.fun.Results;
  *
  * Result<List<Integer>, String> r  = stream.collect(Results.toList());
  * Results.Partition<Integer, String> p = stream.collect(Results.partitioning());

--- a/lib/src/main/java/dmx/fun/Results.java
+++ b/lib/src/main/java/dmx/fun/Results.java
@@ -2,8 +2,10 @@ package dmx.fun;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -37,11 +39,12 @@ public final class Results {
      * @param <E> the error type of the {@code Err} elements
      */
     public record Partition<V, E>(List<V> oks, List<E> errors) {
-        /** Delegates to {@link Result.Partition} for consistent null/copy semantics. */
+        /** Null-checks and defensively copies both lists. */
         public Partition {
-            var delegate = new Result.Partition<>(oks, errors);
-            oks    = delegate.oks();
-            errors = delegate.errors();
+            Objects.requireNonNull(oks,    "oks");
+            Objects.requireNonNull(errors, "errors");
+            oks    = List.copyOf(oks);
+            errors = List.copyOf(errors);
         }
 
         /** Converts to the underlying {@link Result.Partition}. */
@@ -75,15 +78,9 @@ public final class Results {
      * @return a collector producing a {@link Results.Partition}
      */
     public static <V, E> Collector<Result<V, E>, ?, Results.Partition<V, E>> partitioning() {
-        return Collector.of(
-            () -> new java.util.ArrayList<Result<V, E>>(),
-            java.util.List::add,
-            (a, b) -> { a.addAll(b); return a; },
-            list -> {
-                var p = list.stream().collect(Result.partitioningBy());
-                return new Results.Partition<>(p.oks(), p.errors());
-            }
-        );
+        return Collectors.collectingAndThen(
+            Result.partitioningBy(),
+            p -> new Results.Partition<>(p.oks(), p.errors()));
     }
 
     /**

--- a/lib/src/main/java/dmx/fun/Tries.java
+++ b/lib/src/main/java/dmx/fun/Tries.java
@@ -2,6 +2,7 @@ package dmx.fun;
 
 import java.util.List;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -71,14 +72,8 @@ public final class Tries {
      * @return a collector producing a {@link Tries.Partition}
      */
     public static <V> Collector<Try<V>, ?, Tries.Partition<V>> partitioning() {
-        return Collector.of(
-            () -> new java.util.ArrayList<Try<V>>(),
-            java.util.List::add,
-            (a, b) -> { a.addAll(b); return a; },
-            list -> {
-                var p = list.stream().collect(Try.partitioningBy());
-                return new Tries.Partition<>(p.successes(), p.failures());
-            }
-        );
+        return Collectors.collectingAndThen(
+            Try.partitioningBy(),
+            p -> new Tries.Partition<>(p.successes(), p.failures()));
     }
 }

--- a/lib/src/main/java/dmx/fun/Tries.java
+++ b/lib/src/main/java/dmx/fun/Tries.java
@@ -1,0 +1,84 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.stream.Collector;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Collector facade for {@code Stream<Try<V>>}.
+ *
+ * <p>Centralises all {@link Try} collector factories as static methods, mirroring the role of
+ * {@link java.util.stream.Collectors}. The underlying factories on {@link Try} are kept for
+ * backward compatibility; this class simply delegates to them.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * import static dmx.fun.Tries.*;
+ *
+ * Try<List<String>>       result = stream.collect(Tries.toList());
+ * Tries.Partition<String> p      = stream.collect(Tries.partitioning());
+ * p.successes(); // List<String>
+ * p.failures();  // List<Throwable>
+ * }</pre>
+ *
+ * @see Try
+ */
+@NullMarked
+public final class Tries {
+
+    private Tries() {}
+
+    /**
+     * Transparent alias for {@link Try.Partition} so callers can use {@code Tries.Partition}
+     * without importing {@link Try} directly.
+     *
+     * @param <V> the value type of the {@code Success} elements
+     */
+    public record Partition<V>(List<V> successes, List<Throwable> failures) {
+        /** Delegates to {@link Try.Partition} for consistent null/copy semantics. */
+        public Partition {
+            var delegate = new Try.Partition<>(successes, failures);
+            successes = delegate.successes();
+            failures  = delegate.failures();
+        }
+
+        /** Converts to the underlying {@link Try.Partition}. */
+        public Try.Partition<V> toTryPartition() {
+            return new Try.Partition<>(successes, failures);
+        }
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<Try<V>>} into a single
+     * {@code Try<List<V>>}, failing on the first {@code Failure} encountered.
+     *
+     * <p>Delegates to {@link Try#toList()}.
+     *
+     * @param <V> the success value type
+     * @return a collector producing {@code Try<List<V>>}
+     */
+    public static <V> Collector<Try<V>, ?, Try<List<V>>> toList() {
+        return Try.toList();
+    }
+
+    /**
+     * Returns a {@link Collector} that partitions a {@code Stream<Try<V>>} into successes and
+     * failures.
+     *
+     * <p>Delegates to {@link Try#partitioningBy()}.
+     *
+     * @param <V> the success value type
+     * @return a collector producing a {@link Tries.Partition}
+     */
+    public static <V> Collector<Try<V>, ?, Tries.Partition<V>> partitioning() {
+        return Collector.of(
+            () -> new java.util.ArrayList<Try<V>>(),
+            java.util.List::add,
+            (a, b) -> { a.addAll(b); return a; },
+            list -> {
+                var p = list.stream().collect(Try.partitioningBy());
+                return new Tries.Partition<>(p.successes(), p.failures());
+            }
+        );
+    }
+}

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -3,6 +3,7 @@ package dmx.fun;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collector;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -892,6 +893,94 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
         } catch (CancellationException e) {
             return Try.failure(e);
         }
+    }
+
+    // ---------- Collectors ----------
+
+    /**
+     * A typed container holding the two partitions produced by {@link #partitioningBy()}.
+     *
+     * @param <V>       the value type of the {@code Success} elements
+     * @param successes an unmodifiable list of values from {@code Success} elements, in encounter order
+     * @param failures  an unmodifiable list of causes from {@code Failure} elements, in encounter order
+     */
+    record Partition<V>(List<V> successes, List<Throwable> failures) {
+        /** Defensively copies both lists and null-checks them. */
+        public Partition {
+            Objects.requireNonNull(successes, "successes");
+            Objects.requireNonNull(failures, "failures");
+            successes = List.copyOf(successes);
+            failures  = List.copyOf(failures);
+        }
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<Try<V>>} into a single
+     * {@code Try<List<V>>}, failing on the first {@code Failure} encountered.
+     *
+     * <p><strong>Note:</strong> this Collector is <em>not</em> fail-fast. Because the Java
+     * {@link Collector} API always feeds every stream element to the accumulator before the
+     * finisher runs, all elements are consumed regardless of failures. The finisher then
+     * returns the first failure encountered, or {@code Success(List)} if all elements succeeded.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Try<List<String>> result = ids.stream()
+     *     .map(id -> Try.of(() -> load(id)))
+     *     .collect(Try.toList());
+     * }</pre>
+     *
+     * @param <V> the success value type
+     * @return a collector producing {@code Try<List<V>>}
+     */
+    static <V> Collector<Try<V>, ?, Try<List<V>>> toList() {
+        return Collector.of(
+            () -> new ArrayList<Try<V>>(),
+            List::add,
+            (a, b) -> { a.addAll(b); return a; },
+            list -> {
+                List<V> values = new ArrayList<>(list.size());
+                for (Try<V> t : list) {
+                    if (t == null) throw new NullPointerException("toList stream contains a null element");
+                    if (t instanceof Failure<V> f) return Try.failure(f.cause());
+                    values.add(((Success<V>) t).value());
+                }
+                return Try.success(Collections.unmodifiableList(values));
+            }
+        );
+    }
+
+    /**
+     * Returns a {@link Collector} that partitions a {@code Stream<Try<V>>} into two typed
+     * lists: {@link Partition#successes()} for values from {@code Success} elements, and
+     * {@link Partition#failures()} for causes from {@code Failure} elements. Both lists are
+     * unmodifiable and in encounter order.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Try.Partition<String> p = stream.collect(Try.partitioningBy());
+     * p.successes(); // List<String>
+     * p.failures();  // List<Throwable>
+     * }</pre>
+     *
+     * @param <V> the success value type
+     * @return a collector producing a {@link Partition} of successes and failures
+     */
+    static <V> Collector<Try<V>, ?, Partition<V>> partitioningBy() {
+        class Acc {
+            final ArrayList<V>         successes = new ArrayList<>();
+            final ArrayList<Throwable> failures  = new ArrayList<>();
+        }
+        return Collector.of(
+            Acc::new,
+            (acc, t) -> {
+                if (t == null) throw new NullPointerException("partitioningBy stream contains a null element");
+                if (t instanceof Success<V> s) acc.successes.add(s.value());
+                else acc.failures.add(((Failure<V>) t).cause());
+            },
+            (a, b) -> { a.successes.addAll(b.successes); a.failures.addAll(b.failures); return a; },
+            acc -> new Partition<>(acc.successes, acc.failures)
+        );
     }
 
     // ---------- sequence / traverse ----------

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -923,10 +923,10 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * Returns a {@link Collector} that accumulates a {@code Stream<Try<V>>} into a single
      * {@code Try<List<V>>}, failing on the first {@code Failure} encountered.
      *
-     * <p><strong>Note:</strong> this Collector is <em>not</em> fail-fast. Because the Java
-     * {@link Collector} API always feeds every stream element to the accumulator before the
-     * finisher runs, all elements are consumed regardless of failures. The finisher then
-     * returns the first failure encountered, or {@code Success(List)} if all elements succeeded.
+     * <p><strong>Note:</strong> this Collector is <em>not</em> fail-fast. All stream elements
+     * are always consumed. The accumulator records the first {@code Failure} cause and skips
+     * subsequent values; the finisher returns that failure, or {@code Success(List)} if all
+     * elements succeeded.
      *
      * <p>Example:
      * <pre>{@code
@@ -939,19 +939,27 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * @return a collector producing {@code Try<List<V>>}
      */
     static <V> Collector<Try<V>, ?, Try<List<V>>> toList() {
+        class Acc {
+            final ArrayList<V> values = new ArrayList<>();
+            Throwable firstFailure = null;
+        }
         return Collector.of(
-            () -> new ArrayList<Try<V>>(),
-            List::add,
-            (a, b) -> { a.addAll(b); return a; },
-            list -> {
-                List<V> values = new ArrayList<>(list.size());
-                for (Try<V> t : list) {
-                    if (t == null) throw new NullPointerException("toList stream contains a null element");
-                    if (t instanceof Failure<V> f) return Try.failure(f.cause());
-                    values.add(((Success<V>) t).value());
-                }
-                return Try.success(Collections.unmodifiableList(values));
-            }
+            Acc::new,
+            (acc, t) -> {
+                if (acc.firstFailure != null) return;
+                if (t == null) throw new NullPointerException("toList stream contains a null element");
+                if (t instanceof Failure<V> f) { acc.firstFailure = f.cause(); return; }
+                acc.values.add(((Success<V>) t).value());
+            },
+            (a, b) -> {
+                if (a.firstFailure != null) return a;
+                if (b.firstFailure != null) { a.firstFailure = b.firstFailure; return a; }
+                a.values.addAll(b.values);
+                return a;
+            },
+            acc -> acc.firstFailure != null
+                ? Try.failure(acc.firstFailure)
+                : Try.success(Collections.unmodifiableList(acc.values))
         );
     }
 

--- a/lib/src/main/java/dmx/fun/Try.java
+++ b/lib/src/main/java/dmx/fun/Try.java
@@ -905,12 +905,17 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * @param failures  an unmodifiable list of causes from {@code Failure} elements, in encounter order
      */
     record Partition<V>(List<V> successes, List<Throwable> failures) {
-        /** Defensively copies both lists and null-checks them. */
+        /**
+         * Defensively copies both lists and null-checks them.
+         * Uses {@link Collections#unmodifiableList} over a new {@link ArrayList} rather than
+         * {@link List#copyOf} so that {@code null} success values produced by
+         * {@link Try#run(CheckedRunnable) Try.run(...)} are preserved.
+         */
         public Partition {
             Objects.requireNonNull(successes, "successes");
             Objects.requireNonNull(failures, "failures");
-            successes = List.copyOf(successes);
-            failures  = List.copyOf(failures);
+            successes = Collections.unmodifiableList(new ArrayList<>(successes));
+            failures  = Collections.unmodifiableList(new ArrayList<>(failures));
         }
     }
 

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -24,6 +24,9 @@
  *   <li>{@link dmx.fun.Guard}        — composable predicate blocks for Validated pipelines</li>
  *   <li>{@link dmx.fun.Resource}     — composable managed resource with guaranteed release</li>
  *   <li>{@link dmx.fun.Accumulator}  — value paired with a side-channel accumulation (Writer monad)</li>
+ *   <li>{@link dmx.fun.Results}      — collector facade for {@code Stream<Result<V,E>>}</li>
+ *   <li>{@link dmx.fun.Options}      — collector facade for {@code Stream<Option<T>>}</li>
+ *   <li>{@link dmx.fun.Tries}        — collector facade for {@code Stream<Try<V>>}</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/lib/src/test/java/dmx/fun/OptionsFacadeTest.java
+++ b/lib/src/test/java/dmx/fun/OptionsFacadeTest.java
@@ -1,0 +1,85 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionsFacadeTest {
+
+    // ── Options.presentToList() ───────────────────────────────────────────────
+
+    @Test
+    void presentToList_collectsPresentValues() {
+        List<String> result = Stream.<Option<String>>of(
+                Option.some("a"), Option.none(), Option.some("b"), Option.none())
+            .collect(Options.presentToList());
+
+        assertThat(result).containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    void presentToList_allNone_returnsEmpty() {
+        List<String> result = Stream.<Option<String>>of(Option.none(), Option.none())
+            .collect(Options.presentToList());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void presentToList_allPresent_returnsAll() {
+        List<Integer> result = Stream.of(Option.some(1), Option.some(2), Option.some(3))
+            .collect(Options.presentToList());
+
+        assertThat(result).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    // ── Options.sequence() ────────────────────────────────────────────────────
+
+    @Test
+    void sequence_allPresent_returnsOptionalOfList() {
+        Optional<List<String>> result = Stream.of(Option.some("x"), Option.some("y"))
+            .collect(Options.sequence());
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).containsExactly("x", "y");
+    }
+
+    @Test
+    void sequence_anyNone_returnsEmpty() {
+        Optional<List<String>> result = Stream.<Option<String>>of(Option.some("x"), Option.none())
+            .collect(Options.sequence());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void sequence_emptyStream_returnsOptionalOfEmptyList() {
+        Optional<List<String>> result = Stream.<Option<String>>of()
+            .collect(Options.sequence());
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEmpty();
+    }
+
+    // ── Options.toNonEmptyList() ──────────────────────────────────────────────
+
+    @Test
+    void toNonEmptyList_nonEmptyStream_returnsSome() {
+        Option<NonEmptyList<String>> result = Stream.of("a", "b", "c")
+            .collect(Options.toNonEmptyList());
+
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().toList()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void toNonEmptyList_emptyStream_returnsNone() {
+        Option<NonEmptyList<String>> result = Stream.<String>of()
+            .collect(Options.toNonEmptyList());
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+}

--- a/lib/src/test/java/dmx/fun/ResultsFacadeTest.java
+++ b/lib/src/test/java/dmx/fun/ResultsFacadeTest.java
@@ -1,0 +1,97 @@
+package dmx.fun;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ResultsFacadeTest {
+
+    // ── Results.toList() ─────────────────────────────────────────────────────
+
+    @Test
+    void toList_allOk_returnsOkList() {
+        Result<List<Integer>, String> r = Stream.<Result<Integer, String>>of(
+                Result.ok(1), Result.ok(2), Result.ok(3))
+            .collect(Results.toList());
+
+        assertThat(r.isOk()).isTrue();
+        assertThat(r.get()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void toList_firstErrIsReturned() {
+        Result<List<Integer>, String> r = Stream.<Result<Integer, String>>of(
+                Result.ok(1), Result.err("bad"), Result.ok(3))
+            .collect(Results.toList());
+
+        assertThat(r.isError()).isTrue();
+        assertThat(r.getError()).isEqualTo("bad");
+    }
+
+    // ── Results.partitioning() ───────────────────────────────────────────────
+
+    @Test
+    void partitioning_separatesOksAndErrors() {
+        Results.Partition<Integer, String> p = Stream.<Result<Integer, String>>of(
+                Result.ok(1), Result.err("e"), Result.ok(3))
+            .collect(Results.partitioning());
+
+        assertThat(p.oks()).containsExactly(1, 3);
+        assertThat(p.errors()).containsExactly("e");
+    }
+
+    @Test
+    void partitioning_emptyStream() {
+        Results.Partition<Integer, String> p =
+            Stream.<Result<Integer, String>>of().collect(Results.partitioning());
+
+        assertThat(p.oks()).isEmpty();
+        assertThat(p.errors()).isEmpty();
+    }
+
+    @Test
+    void partitioning_listsAreUnmodifiable() {
+        Results.Partition<Integer, String> p = Stream.<Result<Integer, String>>of(Result.ok(1))
+            .collect(Results.partitioning());
+
+        assertThatThrownBy(() -> p.oks().add(99))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> p.errors().add("x"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void partitioning_toResultPartition_roundTrips() {
+        Results.Partition<Integer, String> rp = new Results.Partition<>(List.of(1), List.of("e"));
+        Result.Partition<Integer, String> delegate = rp.toResultPartition();
+
+        assertThat(delegate.oks()).isEqualTo(rp.oks());
+        assertThat(delegate.errors()).isEqualTo(rp.errors());
+    }
+
+    // ── Results.groupingBy() ─────────────────────────────────────────────────
+
+    @Test
+    void groupingBy_classifier_groupsElements() {
+        Map<Integer, NonEmptyList<String>> grouped = Stream.of("a", "bb", "cc", "ddd")
+            .collect(Results.groupingBy(String::length));
+
+        assertThat(grouped.get(1).toList()).containsExactly("a");
+        assertThat(grouped.get(2).toList()).containsExactly("bb", "cc");
+        assertThat(grouped.get(3).toList()).containsExactly("ddd");
+    }
+
+    @Test
+    void groupingBy_withDownstream_appliesFinisher() {
+        Map<Integer, Integer> grouped = Stream.of("a", "bb", "cc", "ddd")
+            .collect(Results.groupingBy(String::length, NonEmptyList::size));
+
+        assertThat(grouped.get(1)).isEqualTo(1);
+        assertThat(grouped.get(2)).isEqualTo(2);
+        assertThat(grouped.get(3)).isEqualTo(1);
+    }
+}

--- a/lib/src/test/java/dmx/fun/TriesFacadeTest.java
+++ b/lib/src/test/java/dmx/fun/TriesFacadeTest.java
@@ -1,0 +1,81 @@
+package dmx.fun;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TriesFacadeTest {
+
+    // ── Tries.toList() ────────────────────────────────────────────────────────
+
+    @Test
+    void toList_allSuccess_returnsSuccessList() {
+        Try<List<Integer>> result = Stream.of(Try.success(1), Try.success(2), Try.success(3))
+            .collect(Tries.toList());
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void toList_firstFailureIsReturned() {
+        RuntimeException boom = new RuntimeException("first");
+        Try<List<Integer>> result = Stream.of(
+                Try.success(1),
+                Try.<Integer>failure(boom),
+                Try.<Integer>failure(new RuntimeException("second")))
+            .collect(Tries.toList());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    // ── Tries.partitioning() ─────────────────────────────────────────────────
+
+    @Test
+    void partitioning_separatesSuccessesAndFailures() {
+        IOException err1 = new IOException("e1");
+        IOException err2 = new IOException("e2");
+        Tries.Partition<Integer> p = Stream.of(
+                Try.success(1),
+                Try.<Integer>failure(err1),
+                Try.success(3),
+                Try.<Integer>failure(err2))
+            .collect(Tries.partitioning());
+
+        assertThat(p.successes()).containsExactly(1, 3);
+        assertThat(p.failures()).containsExactly(err1, err2);
+    }
+
+    @Test
+    void partitioning_emptyStream() {
+        Tries.Partition<String> p = Stream.<Try<String>>of().collect(Tries.partitioning());
+
+        assertThat(p.successes()).isEmpty();
+        assertThat(p.failures()).isEmpty();
+    }
+
+    @Test
+    void partitioning_listsAreUnmodifiable() {
+        Tries.Partition<Integer> p = Stream.<Try<Integer>>of(Try.success(1))
+            .collect(Tries.partitioning());
+
+        assertThatThrownBy(() -> p.successes().add(99))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> p.failures().add(new RuntimeException()))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void partitioning_toTryPartition_roundTrips() {
+        Tries.Partition<Integer> tp = new Tries.Partition<>(List.of(1, 2), List.of(new RuntimeException("x")));
+        Try.Partition<Integer> delegate = tp.toTryPartition();
+
+        assertThat(delegate.successes()).isEqualTo(tp.successes());
+        assertThat(delegate.failures()).isEqualTo(tp.failures());
+    }
+}

--- a/lib/src/test/java/dmx/fun/TryCollectorTest.java
+++ b/lib/src/test/java/dmx/fun/TryCollectorTest.java
@@ -59,6 +59,21 @@ class TryCollectorTest {
             .hasMessageContaining("null");
     }
 
+    @Test
+    void toList_nullAfterFailureReturnsFailureNotNPE() {
+        // A null Try element after an earlier Failure must not mask the failure with NPE.
+        // The finisher returns the first Failure it encounters before ever reaching null.
+        RuntimeException boom = new RuntimeException("first");
+        Try<List<Integer>> result = Stream.of(
+                Try.success(1),
+                Try.<Integer>failure(boom),
+                (Try<Integer>) null)
+            .collect(Try.toList());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
     // ── Try.partitioningBy() ─────────────────────────────────────────────────
 
     @Test

--- a/lib/src/test/java/dmx/fun/TryCollectorTest.java
+++ b/lib/src/test/java/dmx/fun/TryCollectorTest.java
@@ -1,0 +1,116 @@
+package dmx.fun;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TryCollectorTest {
+
+    // ── Try.toList() ──────────────────────────────────────────────────────────
+
+    @Test
+    void toList_allSuccess_returnsSuccessList() {
+        Try<List<Integer>> result = Stream.of(Try.success(1), Try.success(2), Try.success(3))
+            .collect(Try.toList());
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void toList_firstFailureIsReturned() {
+        RuntimeException boom = new RuntimeException("first");
+        Try<List<Integer>> result = Stream.of(
+                Try.success(1),
+                Try.<Integer>failure(boom),
+                Try.<Integer>failure(new RuntimeException("second")))
+            .collect(Try.toList());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
+    void toList_emptyStream_returnsSuccessEmptyList() {
+        Try<List<Integer>> result = Stream.<Try<Integer>>of().collect(Try.toList());
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEmpty();
+    }
+
+    @Test
+    void toList_resultListIsUnmodifiable() {
+        Try<List<Integer>> result = Stream.of(Try.success(1)).collect(Try.toList());
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThatThrownBy(() -> result.get().add(99))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void toList_nullElement_throwsNPE() {
+        assertThatThrownBy(() -> Stream.of(Try.success(1), null)
+                .collect(Try.toList()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("null");
+    }
+
+    // ── Try.partitioningBy() ─────────────────────────────────────────────────
+
+    @Test
+    void partitioningBy_separatesSuccessesAndFailures() {
+        IOException err1 = new IOException("e1");
+        IOException err2 = new IOException("e2");
+        Try.Partition<Integer> p = Stream.of(
+                Try.success(1),
+                Try.<Integer>failure(err1),
+                Try.success(3),
+                Try.<Integer>failure(err2))
+            .collect(Try.partitioningBy());
+
+        assertThat(p.successes()).containsExactly(1, 3);
+        assertThat(p.failures()).containsExactly(err1, err2);
+    }
+
+    @Test
+    void partitioningBy_allSuccess_emptyFailures() {
+        Try.Partition<String> p = Stream.of(Try.success("a"), Try.success("b"))
+            .collect(Try.partitioningBy());
+
+        assertThat(p.successes()).containsExactly("a", "b");
+        assertThat(p.failures()).isEmpty();
+    }
+
+    @Test
+    void partitioningBy_allFailure_emptySuccesses() {
+        RuntimeException ex = new RuntimeException("x");
+        Try.Partition<String> p = Stream.<Try<String>>of(Try.failure(ex))
+            .collect(Try.partitioningBy());
+
+        assertThat(p.successes()).isEmpty();
+        assertThat(p.failures()).containsExactly(ex);
+    }
+
+    @Test
+    void partitioningBy_listsAreUnmodifiable() {
+        Try.Partition<Integer> p = Stream.<Try<Integer>>of(Try.success(1))
+            .collect(Try.partitioningBy());
+
+        assertThatThrownBy(() -> p.successes().add(99))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> p.failures().add(new RuntimeException()))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void partitioningBy_nullElement_throwsNPE() {
+        assertThatThrownBy(() -> Stream.of(Try.success(1), null)
+                .collect(Try.partitioningBy()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("null");
+    }
+}

--- a/site/src/data/code/guide/option/options-facade.mdx
+++ b/site/src/data/code/guide/option/options-facade.mdx
@@ -1,0 +1,32 @@
+---
+fileName: 'UserService.java'
+---
+
+```java
+// ── Options.presentToList() — keep only present values ───────────────────────
+List<String> names = Stream.<Option<String>>of(
+        Option.some("alice"), Option.none(), Option.some("bob"), Option.none())
+    .collect(Options.presentToList());
+// ["alice", "bob"]
+
+// Real-world: resolve a batch of user IDs; ignore the ones not found
+List<User> found = ids.stream()
+    .map(userRepo::findById)          // Stream<Option<User>>
+    .collect(Options.presentToList()); // List<User> — absent entries dropped
+
+// ── Options.sequence() — all-or-nothing: Optional.empty() if any is None ────
+Optional<List<User>> allOrNone = ids.stream()
+    .map(userRepo::findById)
+    .collect(Options.sequence());
+// Optional.of([...]) only when every ID resolves; Optional.empty() otherwise
+
+// ── Options.toNonEmptyList() — wrap a stream into a NonEmptyList if non-empty ─
+Option<NonEmptyList<String>> nel = items.stream()
+    .filter(item -> item.isActive())
+    .collect(Options.toNonEmptyList());
+
+nel.match(
+    ()    -> log.warn("no active items"),
+    items -> process(items)          // items is a guaranteed NonEmptyList
+);
+```

--- a/site/src/data/code/guide/result/results-facade.mdx
+++ b/site/src/data/code/guide/result/results-facade.mdx
@@ -3,7 +3,7 @@ fileName: 'OrderProcessor.java'
 ---
 
 ```java
-// ── Results.toList() — fail-fast: returns first Err ──────────────────────────
+// ── Results.toList() — returns first Err (stream still fully traversed) ──────
 Result<List<Integer>, String> validated =
     Stream.<Result<Integer, String>>of(Result.ok(1), Result.ok(2), Result.ok(3))
           .collect(Results.toList());
@@ -14,10 +14,12 @@ Result<List<Integer>, String> firstFails =
           .collect(Results.toList());
 // → Err("bad")
 
-// Real-world: validate every line in a CSV upload — stop on first invalid row
+// Real-world: validate every line in a CSV upload — returns first parse error
+// Note: all lines are parsed; toList() does not short-circuit upstream evaluation.
+// Do not rely on early termination for expensive or side-effecting parse logic.
 Result<List<OrderRow>, String> rows = csvLines.stream()
     .map(OrderRow::parse)          // Stream<Result<OrderRow, String>>
-    .collect(Results.toList());    // Ok(all rows) or Err(first parse error)
+    .collect(Results.toList());    // Ok(all rows) or first Err encountered
 
 // ── Results.partitioning() — process all, split into oks and errors ───────────
 Results.Partition<OrderRow, String> p = csvLines.stream()

--- a/site/src/data/code/guide/result/results-facade.mdx
+++ b/site/src/data/code/guide/result/results-facade.mdx
@@ -1,0 +1,44 @@
+---
+fileName: 'OrderProcessor.java'
+---
+
+```java
+// ── Results.toList() — fail-fast: returns first Err ──────────────────────────
+Result<List<Integer>, String> validated =
+    Stream.<Result<Integer, String>>of(Result.ok(1), Result.ok(2), Result.ok(3))
+          .collect(Results.toList());
+// → Ok([1, 2, 3])
+
+Result<List<Integer>, String> firstFails =
+    Stream.<Result<Integer, String>>of(Result.ok(1), Result.err("bad"), Result.ok(3))
+          .collect(Results.toList());
+// → Err("bad")
+
+// Real-world: validate every line in a CSV upload — stop on first invalid row
+Result<List<OrderRow>, String> rows = csvLines.stream()
+    .map(OrderRow::parse)          // Stream<Result<OrderRow, String>>
+    .collect(Results.toList());    // Ok(all rows) or Err(first parse error)
+
+// ── Results.partitioning() — process all, split into oks and errors ───────────
+Results.Partition<OrderRow, String> p = csvLines.stream()
+    .map(OrderRow::parse)
+    .collect(Results.partitioning());
+
+List<OrderRow>  good   = p.oks();    // rows that parsed successfully
+List<String>    bad    = p.errors(); // parse error messages
+
+// Real-world: import as many records as possible; report failures separately
+importService.bulkInsert(p.oks());
+auditLog.recordRejections(p.errors());
+
+// ── Results.groupingBy() — group elements by a derived key ───────────────────
+Map<Status, NonEmptyList<Order>> byStatus =
+    orders.stream()
+          .collect(Results.groupingBy(Order::status));
+// Every map value is NonEmptyList — the non-emptiness is in the type
+
+// Downstream variant: count orders per status
+Map<Status, Integer> countByStatus =
+    orders.stream()
+          .collect(Results.groupingBy(Order::status, NonEmptyList::size));
+```

--- a/site/src/data/code/guide/try/tries-facade.mdx
+++ b/site/src/data/code/guide/try/tries-facade.mdx
@@ -1,0 +1,22 @@
+---
+fileName: 'BatchProcessor.java'
+---
+
+```java
+// ── Tries.toList() — same as Try.toList(), single import entry point ─────────
+Try<List<Integer>> all = Stream.of("10", "20", "30")
+    .map(s -> Try.of(() -> Integer.parseInt(s)))
+    .collect(Tries.toList());
+// → Success([10, 20, 30])
+
+// ── Tries.partitioning() — collect all results, split by outcome ─────────────
+Tries.Partition<byte[]> partition = urls.stream()
+    .map(url -> Try.of(() -> httpClient.fetch(url)))
+    .collect(Tries.partitioning());
+
+partition.successes().forEach(body -> indexer.ingest(body));
+partition.failures().forEach(ex  -> metrics.recordError(ex));
+
+// Bridge to Try.Partition when needed
+Try.Partition<byte[]> tp = partition.toTryPartition();
+```

--- a/site/src/data/code/guide/try/try-collectors.mdx
+++ b/site/src/data/code/guide/try/try-collectors.mdx
@@ -3,7 +3,7 @@ fileName: 'FileProcessor.java'
 ---
 
 ```java
-// ── Try.toList() — fail-fast: returns first Failure ──────────────────────────
+// ── Try.toList() — returns first Failure (stream still fully traversed) ──────
 Try<List<Integer>> parsed =
     Stream.of("1", "2", "3")
           .map(s -> Try.of(() -> Integer.parseInt(s)))
@@ -14,9 +14,11 @@ Try<List<Integer>> broken =
     Stream.of("1", "bad", "3")
           .map(s -> Try.of(() -> Integer.parseInt(s)))
           .collect(Try.toList());
-// → Failure(NumberFormatException) — stops at "bad"
+// → Failure(NumberFormatException) — "3" is still parsed; collector returns first Failure
 
-// Real-world: parse all config values — abort on the first bad entry
+// Real-world: parse all config values — returns first parse error encountered
+// Note: all keys are parsed regardless; do not rely on early termination for
+// expensive or side-effecting upstream work.
 Try<List<Duration>> timeouts = configKeys.stream()
     .map(key -> Try.of(() -> Duration.parse(config.get(key))))
     .collect(Try.toList());

--- a/site/src/data/code/guide/try/try-collectors.mdx
+++ b/site/src/data/code/guide/try/try-collectors.mdx
@@ -1,0 +1,35 @@
+---
+fileName: 'FileProcessor.java'
+---
+
+```java
+// ── Try.toList() — fail-fast: returns first Failure ──────────────────────────
+Try<List<Integer>> parsed =
+    Stream.of("1", "2", "3")
+          .map(s -> Try.of(() -> Integer.parseInt(s)))
+          .collect(Try.toList());
+// → Success([1, 2, 3])
+
+Try<List<Integer>> broken =
+    Stream.of("1", "bad", "3")
+          .map(s -> Try.of(() -> Integer.parseInt(s)))
+          .collect(Try.toList());
+// → Failure(NumberFormatException) — stops at "bad"
+
+// Real-world: parse all config values — abort on the first bad entry
+Try<List<Duration>> timeouts = configKeys.stream()
+    .map(key -> Try.of(() -> Duration.parse(config.get(key))))
+    .collect(Try.toList());
+
+// ── Try.partitioningBy() — process all, split successes from failures ─────────
+Try.Partition<Path> result = filePaths.stream()
+    .map(path -> Try.of(() -> validateFile(path)))
+    .collect(Try.partitioningBy());
+
+List<Path>       valid   = result.successes(); // files that passed validation
+List<Throwable>  errors  = result.failures();  // exceptions from invalid files
+
+// Real-world: import as many files as possible; log failures without aborting
+importService.bulkProcess(result.successes());
+result.failures().forEach(ex -> log.error("Skipping file: {}", ex.getMessage()));
+```

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -23,6 +23,7 @@ import {Content as ComposingZip}           from '../code/guide/option/composing-
 import {Content as ComposingZipWith}       from '../code/guide/option/composing-zip-with.mdx';
 import {Content as ComposingSequence}      from '../code/guide/option/composing-sequence.mdx';
 import {Content as SequenceCollector}      from '../code/guide/option/sequence-collector.mdx';
+import {Content as OptionsFacade}          from '../code/guide/option/options-facade.mdx';
 import {Content as ComposingStream}        from '../code/guide/option/composing-stream.mdx';
 import {Content as InteropConversions}     from '../code/guide/option/interop-conversions.mdx';
 import {Content as PitfallsNested}         from '../code/guide/option/pitfalls-nested.mdx';
@@ -178,6 +179,20 @@ It reduces a `Stream<Option<V>>` to a single `Optional<List<V>>` — present onl
 every element is `Some`, empty if any element is `None`.
 
 <SequenceCollector/>
+
+## Collector facade: Options
+
+`Options` is a single discoverable entry point for all `Stream<Option<T>>` collectors —
+analogous to `java.util.stream.Collectors`. Import `dmx.fun.Options` instead of
+remembering which collector lives on which type.
+
+| Method                       | Returns                     | Semantics                                              |
+|------------------------------|-----------------------------|--------------------------------------------------------|
+| `Options.presentToList()`    | `List<T>`                   | Drops `None` — returns only present values             |
+| `Options.sequence()`         | `Optional<List<T>>`         | All-or-nothing — `empty()` if any element is `None`    |
+| `Options.toNonEmptyList()`   | `Option<NonEmptyList<T>>`   | Wraps stream into `NonEmptyList`, or `None` if empty   |
+
+<OptionsFacade/>
 
 ### Stream integration with `stream()`
 

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -20,6 +20,7 @@ import {Content as InteropConversions}   from '../code/guide/result/interop-conv
 import {Content as PitfallsNested}       from '../code/guide/result/pitfalls-nested.mdx';
 import {Content as PitfallsIgnoringError} from '../code/guide/result/pitfalls-ignoring-error.mdx';
 import {Content as GroupingBy}           from '../code/guide/result/grouping-by.mdx';
+import {Content as ResultsFacade}        from '../code/guide/result/results-facade.mdx';
 import {Content as RealWorldExample}     from '../code/guide/result/real-world-example.mdx';
 
 > **Runnable example:** [`ResultSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResultSample.java)
@@ -147,6 +148,24 @@ The downstream variant `groupingBy(classifier, downstream)` applies a
 **unmodifiable**.
 
 <GroupingBy/>
+
+## Collector facade: Results
+
+`Results` is a single discoverable entry point for all `Stream<Result<V,E>>` collectors —
+analogous to `java.util.stream.Collectors`. Import `dmx.fun.Results` instead of
+remembering which collector lives on which type.
+
+| Method                                  | Returns                         | Semantics                                        |
+|-----------------------------------------|---------------------------------|--------------------------------------------------|
+| `Results.toList()`                      | `Result<List<V>, E>`            | Fail-fast — first `Err` short-circuits           |
+| `Results.partitioning()`                | `Results.Partition<V, E>`       | Collect all — splits `oks()` and `errors()`      |
+| `Results.groupingBy(classifier)`        | `Map<K, NonEmptyList<V>>`       | Group by key; values are always non-empty        |
+| `Results.groupingBy(classifier, finisher)` | `Map<K, R>`                  | Group then transform each group                  |
+
+`Results.Partition` is a thin wrapper that delegates to `Result.Partition`.
+Call `toResultPartition()` to obtain the underlying `Result.Partition<V, E>` when needed.
+
+<ResultsFacade/>
 
 ## Interoperability
 

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -125,7 +125,7 @@ and return it immediately.
 
 | Method                  | Returns               | Semantics                                          |
 |-------------------------|-----------------------|----------------------------------------------------|
-| `Try.toList()`          | `Try<List<V>>`        | Fail-fast — first `Failure` short-circuits         |
+| `Try.toList()`          | `Try<List<V>>`        | Returns first `Failure` (upstream fully traversed) |
 | `Try.partitioningBy()`  | `Try.Partition<V>`    | Collect all — splits `successes()` and `failures()`|
 
 `Try.Partition<V>` is a record with two unmodifiable lists.

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -14,6 +14,8 @@ import {Content as TransformingFilter} from '../code/guide/try/transforming-filt
 import {Content as SideEffects}        from '../code/guide/try/side-effects.mdx';
 import {Content as Recovery}           from '../code/guide/try/recovery.mdx';
 import {Content as SequenceTraverse}   from '../code/guide/try/sequence-traverse.mdx';
+import {Content as TryCollectors}      from '../code/guide/try/try-collectors.mdx';
+import {Content as TriesFacade}        from '../code/guide/try/tries-facade.mdx';
 import {Content as NullHandling}       from '../code/guide/try/null-handling.mdx';
 import {Content as InteropConversions} from '../code/guide/try/interop-conversions.mdx';
 import {Content as PitfallsGet}        from '../code/guide/try/pitfalls-get.mdx';
@@ -115,6 +117,36 @@ Both operations apply **fail-fast semantics**: they stop at the first `Failure`
 and return it immediately.
 
 <SequenceTraverse/>
+
+## Stream collectors
+
+`Try.toList()` and `Try.partitioningBy()` are stream `Collector` counterparts to
+`sequence` — they operate on a `Stream<Try<V>>` instead of a list.
+
+| Method                  | Returns               | Semantics                                          |
+|-------------------------|-----------------------|----------------------------------------------------|
+| `Try.toList()`          | `Try<List<V>>`        | Fail-fast — first `Failure` short-circuits         |
+| `Try.partitioningBy()`  | `Try.Partition<V>`    | Collect all — splits `successes()` and `failures()`|
+
+`Try.Partition<V>` is a record with two unmodifiable lists.
+
+<TryCollectors/>
+
+## Collector facade: Tries
+
+`Tries` is a single discoverable entry point for all `Stream<Try<V>>` collectors —
+analogous to `java.util.stream.Collectors`. Import `dmx.fun.Tries` instead of
+remembering which collector lives on which type.
+
+| Method                    | Returns                   | Semantics                                          |
+|---------------------------|---------------------------|----------------------------------------------------|
+| `Tries.toList()`          | `Try<List<V>>`            | Delegates to `Try.toList()`                        |
+| `Tries.partitioning()`    | `Tries.Partition<V>`      | Delegates to `Try.partitioningBy()`                |
+
+`Tries.Partition` is a thin wrapper that delegates to `Try.Partition`.
+Call `toTryPartition()` to obtain the underlying `Try.Partition<V>` when needed.
+
+<TriesFacade/>
 
 ## Null handling
 


### PR DESCRIPTION
  Add Try.toList() and Try.partitioningBy() collectors directly on Try, along
  with three new collector facade classes — Results, Options, Tries — that serve
  as single discoverable entry points for Stream<Result>, Stream<Option>, and
  Stream<Try> collectors respectively (analogous to java.util.stream.Collectors).
  Cover all new APIs with 33 tests and document them in the developer guide with
  real-world examples.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #254

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New collector facades for Option, Result, and Try streams: collect present values, sequence/all-or-nothing, partition successes/errors, grouping variants, and list aggregation.

* **Documentation**
  * Added guides and examples demonstrating the new stream collector APIs and usage patterns.

* **Tests**
  * Added unit tests covering collector behaviors, partitioning, immutability, and edge cases (empty streams, first-failure semantics).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->