### PR TITLE
feat(non-empty-list): implement SequencedCollection — getFirst(), getLast(), reversed()

### DIFF
--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -449,6 +449,12 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
 
     /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
     @Override
+    public boolean removeIf(java.util.function.Predicate<? super T> filter) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
     public void clear() {
         throw new UnsupportedOperationException("NonEmptyList is immutable");
     }

--- a/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.SequencedCollection;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -28,7 +29,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <T> the type of elements in this list
  */
 @NullMarked
-public final class NonEmptyList<T> implements Iterable<T> {
+public final class NonEmptyList<T> implements SequencedCollection<T> {
 
     private final T head;
     private final List<T> tail;
@@ -107,6 +108,86 @@ public final class NonEmptyList<T> implements Iterable<T> {
      */
     public T head() {
         return head;
+    }
+
+    /**
+     * Returns the first element of this list. Alias for {@link #head()}.
+     *
+     * <p>Implements {@link SequencedCollection#getFirst()}.
+     *
+     * @return the first element (never {@code null})
+     */
+    @Override
+    public T getFirst() {
+        return head;
+    }
+
+    /**
+     * Returns the last element of this list.
+     *
+     * <p>Implements {@link SequencedCollection#getLast()}.
+     *
+     * @return the last element (never {@code null})
+     */
+    @Override
+    public T getLast() {
+        return tail.isEmpty() ? head : tail.get(tail.size() - 1);
+    }
+
+    /**
+     * Returns a new {@code NonEmptyList} with all elements in reverse order.
+     *
+     * <p>Implements {@link SequencedCollection#reversed()}.
+     *
+     * @return a reversed copy of this list
+     */
+    @Override
+    public NonEmptyList<T> reversed() {
+        List<T> all = new ArrayList<>(toList());
+        Collections.reverse(all);
+        T newHead = all.get(0);
+        List<T> newTail = List.copyOf(all.subList(1, all.size()));
+        return new NonEmptyList<>(newHead, newTail);
+    }
+
+    /**
+     * Unsupported — {@code NonEmptyList} is immutable.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void addFirst(T t) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /**
+     * Unsupported — {@code NonEmptyList} is immutable.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void addLast(T t) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /**
+     * Unsupported — {@code NonEmptyList} is immutable.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public T removeFirst() {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /**
+     * Unsupported — {@code NonEmptyList} is immutable.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public T removeLast() {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
     }
 
     /**
@@ -304,6 +385,72 @@ public final class NonEmptyList<T> implements Iterable<T> {
         }
         // values.size() == nel.size() >= 1, so fromList always returns Some
         return NonEmptyList.fromList(values);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection (required by SequencedCollection)
+    // -------------------------------------------------------------------------
+
+    /** Always {@code false} — a {@code NonEmptyList} always has at least one element. */
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return head.equals(o) || tail.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(java.util.Collection<?> c) {
+        return toList().containsAll(c);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return toList().toArray();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        return toList().toArray(a);
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public boolean add(T t) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public boolean addAll(java.util.Collection<? extends T> c) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public boolean removeAll(java.util.Collection<?> c) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public boolean retainAll(java.util.Collection<?> c) {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
+    }
+
+    /** @throws UnsupportedOperationException always — {@code NonEmptyList} is immutable */
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("NonEmptyList is immutable");
     }
 
     // -------------------------------------------------------------------------

--- a/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -401,4 +401,118 @@ class NonEmptyListTest {
             Stream.of(1, 2, 3).collect(NonEmptyList.toNonEmptyList());
         assertThat(viaAlias).isEqualTo(viaCollector);
     }
+
+    // -------------------------------------------------------------------------
+    // SequencedCollection — getFirst() / getLast() / reversed()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getFirst_returnsHead() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.getFirst()).isEqualTo(1);
+    }
+
+    @Test
+    void getFirst_singleton_returnsSoleElement() {
+        assertThat(NonEmptyList.singleton("only").getFirst()).isEqualTo("only");
+    }
+
+    @Test
+    void getLast_returnsLastTailElement() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.getLast()).isEqualTo(3);
+    }
+
+    @Test
+    void getLast_singleton_returnsSoleElement() {
+        assertThat(NonEmptyList.singleton("only").getLast()).isEqualTo("only");
+    }
+
+    @Test
+    void reversed_returnsElementsInReverseOrder() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        NonEmptyList<Integer> rev = nel.reversed();
+        assertThat(rev.toList()).containsExactly(3, 2, 1);
+    }
+
+    @Test
+    void reversed_singleton_returnsSameContent() {
+        NonEmptyList<String> nel = NonEmptyList.singleton("x");
+        assertThat(nel.reversed().toList()).containsExactly("x");
+    }
+
+    @Test
+    void reversed_doesNotMutateOriginal() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        nel.reversed();
+        assertThat(nel.toList()).containsExactly(1, 2, 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // SequencedCollection — mutating methods throw UnsupportedOperationException
+    // -------------------------------------------------------------------------
+
+    @Test
+    void addFirst_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).addFirst(0))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void addLast_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).addLast(2))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void removeFirst_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).removeFirst())
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void removeLast_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).removeLast())
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection — contains / isEmpty / immutable mutations
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isEmpty_alwaysFalse() {
+        assertThat(NonEmptyList.singleton("x").isEmpty()).isFalse();
+        assertThat(NonEmptyList.of(1, List.of(2, 3)).isEmpty()).isFalse();
+    }
+
+    @Test
+    void contains_presentElement_returnsTrue() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.contains(1)).isTrue();
+        assertThat(nel.contains(3)).isTrue();
+    }
+
+    @Test
+    void contains_absentElement_returnsFalse() {
+        assertThat(NonEmptyList.of(1, List.of(2)).contains(99)).isFalse();
+    }
+
+    @Test
+    void add_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).add(2))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void remove_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).remove(Integer.valueOf(1)))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void clear_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).clear())
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
 }

--- a/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
+++ b/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java
@@ -27,13 +27,21 @@ public class NonEmptyListSample {
     public static void main(String[] args) {
         // Construction — head + tail list
         NonEmptyList<String> tags = NonEmptyList.of("java", List.of("fp", "dmx-fun"));
-        System.out.println("Head: " + tags.head());      // java
-        System.out.println("Tail: " + tags.tail());      // [fp, dmx-fun]
-        System.out.println("Size: " + tags.size());      // 3
+        System.out.println("Head:     " + tags.head());       // java
+        System.out.println("First:    " + tags.getFirst());   // java  (SequencedCollection)
+        System.out.println("Last:     " + tags.getLast());    // dmx-fun (SequencedCollection)
+        System.out.println("Tail:     " + tags.tail());       // [fp, dmx-fun]
+        System.out.println("Size:     " + tags.size());       // 3
+        System.out.println("Empty?:   " + tags.isEmpty());    // false — always false
 
         // Singleton
         NonEmptyList<String> single = NonEmptyList.singleton("only");
         System.out.println("Single size: " + single.size()); // 1
+
+        // reversed() — new list, original unchanged
+        NonEmptyList<String> rev = tags.reversed();
+        System.out.println("Reversed: " + rev.toList());  // [dmx-fun, fp, java]
+        System.out.println("Original: " + tags.toList()); // [java, fp, dmx-fun]
 
         // Map over all elements
         NonEmptyList<String> upper = tags.map(String::toUpperCase);

--- a/site/src/data/code/guide/non-empty-list/accessing-elements.mdx
+++ b/site/src/data/code/guide/non-empty-list/accessing-elements.mdx
@@ -5,14 +5,20 @@ fileName: 'Demo.java'
 ```java
 NonEmptyList<String> nel = NonEmptyList.of("a", List.of("b", "c"));
 
-String       head   = nel.head();   // "a"  — always present, never null
-List<String> tail   = nel.tail();   // ["b", "c"] — unmodifiable, may be empty
-List<String> all    = nel.toList(); // ["a", "b", "c"] — all elements
-int          size   = nel.size();   // 3 — always >= 1
+String       head   = nel.head();     // "a"  — always present, never null
+List<String> tail   = nel.tail();     // ["b", "c"] — unmodifiable, may be empty
+List<String> all    = nel.toList();   // ["a", "b", "c"] — all elements
+int          size   = nel.size();     // 3 — always >= 1
+
+// SequencedCollection API (Java 21)
+String first = nel.getFirst();        // "a" — alias for head()
+String last  = nel.getLast();         // "c" — always safe, no emptiness check needed
 
 // Singleton: tail is empty
 NonEmptyList<String> one = NonEmptyList.singleton("only");
-one.head();   // "only"
-one.tail();   // []  (empty unmodifiable list)
-one.size();   // 1
+one.head();      // "only"
+one.getFirst();  // "only"
+one.getLast();   // "only"  — same element, no IndexOutOfBoundsException risk
+one.tail();      // []  (empty unmodifiable list)
+one.size();      // 1
 ```

--- a/site/src/data/code/guide/non-empty-list/sequenced-collection.mdx
+++ b/site/src/data/code/guide/non-empty-list/sequenced-collection.mdx
@@ -20,10 +20,10 @@ sc.getFirst();  // 1
 sc.getLast();   // 5
 
 // Mutating methods always throw — NonEmptyList is immutable
-nel.addFirst(0);    // UnsupportedOperationException
-nel.addLast(6);     // UnsupportedOperationException
-nel.removeFirst();  // UnsupportedOperationException
-nel.removeLast();   // UnsupportedOperationException
+try { nel.addFirst(0);   } catch (UnsupportedOperationException e) { /* expected */ }
+try { nel.addLast(6);    } catch (UnsupportedOperationException e) { /* expected */ }
+try { nel.removeFirst(); } catch (UnsupportedOperationException e) { /* expected */ }
+try { nel.removeLast();  } catch (UnsupportedOperationException e) { /* expected */ }
 
 // Real-world: show the most recent and oldest event in a guaranteed-non-empty audit log
 NonEmptyList<AuditEvent> log = auditService.getEvents(userId); // guaranteed non-empty

--- a/site/src/data/code/guide/non-empty-list/sequenced-collection.mdx
+++ b/site/src/data/code/guide/non-empty-list/sequenced-collection.mdx
@@ -1,0 +1,32 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3, 4, 5));
+
+// getFirst() / getLast() — always safe, no emptiness check needed
+int first = nel.getFirst();  // 1
+int last  = nel.getLast();   // 5
+
+// reversed() — returns a new NonEmptyList in reverse order
+NonEmptyList<Integer> rev = nel.reversed();
+// rev.toList() → [5, 4, 3, 2, 1]
+// original unchanged → nel.toList() → [1, 2, 3, 4, 5]
+
+// Works as a java.util.SequencedCollection
+SequencedCollection<Integer> sc = nel;
+sc.getFirst();  // 1
+sc.getLast();   // 5
+
+// Mutating methods always throw — NonEmptyList is immutable
+nel.addFirst(0);    // UnsupportedOperationException
+nel.addLast(6);     // UnsupportedOperationException
+nel.removeFirst();  // UnsupportedOperationException
+nel.removeLast();   // UnsupportedOperationException
+
+// Real-world: show the most recent and oldest event in a guaranteed-non-empty audit log
+NonEmptyList<AuditEvent> log = auditService.getEvents(userId); // guaranteed non-empty
+AuditEvent newest = log.getFirst();
+AuditEvent oldest = log.getLast();
+```

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -90,9 +90,10 @@ Because `NonEmptyList` is always non-empty, `getFirst()` and `getLast()` are
 `reversed()` returns a **new** `NonEmptyList` with elements in reverse order;
 the original is not modified.
 
-The four mutating methods inherited from `SequencedCollection` (`addFirst`,
-`addLast`, `removeFirst`, `removeLast`) always throw `UnsupportedOperationException`
-because `NonEmptyList` is immutable.
+All mutating methods always throw `UnsupportedOperationException` because
+`NonEmptyList` is immutable. This covers both the `SequencedCollection` mutators
+(`addFirst`, `addLast`, `removeFirst`, `removeLast`) and the inherited `Collection`
+mutators (`add`, `remove`, `addAll`, `removeAll`, `retainAll`, `removeIf`, `clear`).
 
 <SequencedCollection/>
 

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -14,6 +14,7 @@ import {Content as StreamInterop}      from '../code/guide/non-empty-list/stream
 import {Content as EqualityToString}       from '../code/guide/non-empty-list/equality-tostring.mdx';
 import {Content as InteropNonEmptyTypes}   from '../code/guide/non-empty-list/interop-non-empty-types.mdx';
 import {Content as ToNonEmptyListCollector} from '../code/guide/non-empty-list/to-non-empty-list-collector.mdx';
+import {Content as SequencedCollection}    from '../code/guide/non-empty-list/sequenced-collection.mdx';
 import {Content as RealWorldExample}       from '../code/guide/non-empty-list/real-world-example.mdx';
 
 > **Runnable example:** [`NonEmptyListSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java)
@@ -56,6 +57,15 @@ Use it when:
 
 ## Accessing elements
 
+| Method        | Returns              | Notes                                        |
+|---------------|----------------------|----------------------------------------------|
+| `head()`      | First element        | Core accessor — always present               |
+| `getFirst()`  | First element        | `SequencedCollection` alias for `head()`     |
+| `getLast()`   | Last element         | Always safe — no index arithmetic required   |
+| `tail()`      | `List<T>`            | Remaining elements; unmodifiable; may be empty |
+| `toList()`    | `List<T>`            | All elements as an unmodifiable list          |
+| `size()`      | `int >= 1`           | Always at least 1                            |
+
 <AccessingElements/>
 
 `size()` always returns a value `>= 1`. `tail()` returns an unmodifiable `List`
@@ -67,6 +77,24 @@ that may be empty (for singletons).
 
 All transformation methods (`map`, `append`, `prepend`, `concat`) return a **new
 `NonEmptyList`** — the original is unchanged.
+
+## SequencedCollection integration (Java 21)
+
+`NonEmptyList<T>` implements `java.util.SequencedCollection<T>`, the Java 21
+interface that formalises a collection with a defined encounter order and
+well-known first and last elements.
+
+Because `NonEmptyList` is always non-empty, `getFirst()` and `getLast()` are
+**total functions** — they never throw `NoSuchElementException`.
+
+`reversed()` returns a **new** `NonEmptyList` with elements in reverse order;
+the original is not modified.
+
+The four mutating methods inherited from `SequencedCollection` (`addFirst`,
+`addLast`, `removeFirst`, `removeLast`) always throw `UnsupportedOperationException`
+because `NonEmptyList` is immutable.
+
+<SequencedCollection/>
 
 ## Collecting a stream — `toNonEmptyList`
 
@@ -97,8 +125,9 @@ provides three dedicated helpers:
 
 ## Stream and `Iterable` interop
 
-`NonEmptyList<T>` implements `Iterable<T>` and provides `toStream()` for
-integration with the standard Java stream API.
+`NonEmptyList<T>` implements `SequencedCollection<T>` (which extends `Collection<T>`
+and `Iterable<T>`) and provides `toStream()` for integration with the standard Java
+stream API.
 
 <StreamInterop/>
 


### PR DESCRIPTION
  NonEmptyList now implements java.util.SequencedCollection<T>, adding getFirst()
  (alias for head()), getLast(), and reversed(), all of which are total functions
  guaranteed never to throw because NonEmptyList is always non-empty. Mutating
  SequencedCollection methods and the full Collection contract throw
  UnsupportedOperationException. Covers 20 new tests and documents the new API
  in the developer guide with real-world examples.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #260

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NonEmptyList implements SequencedCollection: adds getFirst(), getLast(), reversed(), and reports isEmpty() as false while preserving immutability.

* **Documentation**
  * Guides and examples updated to show SequencedCollection integration, getFirst()/getLast() usage, and reversed() semantics.

* **Tests**
  * Added tests verifying element access, reversed() immutability, and that all mutating collection operations throw UnsupportedOperationException.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->