### PR TITLE
feature/assertj/code cleanup

### DIFF
--- a/assertj/README.md
+++ b/assertj/README.md
@@ -147,8 +147,8 @@ assertThat(Resource.of(() -> { throw new IOException("timeout"); }, c -> {}))
 |------------------------------------------|-------------------------------------------------------------------|
 | `accepts(value)`                         | Asserts the guard passes for the given value                      |
 | `rejects(value)`                         | Asserts the guard fails for the given value                       |
-| `rejectsWithMessage(value, message)`     | Asserts the guard fails with the exact given message              |
-| `rejectsWithMessages(value, messages…)`  | Asserts the guard fails with all of the given messages            |
+| `rejectsWithMessage(value, message)`     | Asserts the guard fails and at least one rejection message contains the given string     |
+| `rejectsWithMessages(value, messages…)`  | Asserts the guard fails and each given string appears in at least one rejection message  |
 
 ```java
 Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");

--- a/assertj/src/main/java/dmx/fun/assertj/AbstractDmxFunAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AbstractDmxFunAssert.java
@@ -1,0 +1,19 @@
+package dmx.fun.assertj;
+
+import org.assertj.core.api.AbstractAssert;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+abstract class AbstractDmxFunAssert<SELF extends AbstractDmxFunAssert<SELF, ACTUAL>, ACTUAL>
+    extends AbstractAssert<SELF, ACTUAL> {
+
+    AbstractDmxFunAssert(ACTUAL actual, Class<?> selfType) {
+        super(actual, selfType);
+    }
+
+    final AssertionError buildError(String template, Object... args) {
+        String message = String.format(template.replace("<%s>", "%s"), args);
+        String description = info.descriptionText();
+        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    }
+}

--- a/assertj/src/main/java/dmx/fun/assertj/AbstractDmxFunAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AbstractDmxFunAssert.java
@@ -12,7 +12,7 @@ abstract class AbstractDmxFunAssert<SELF extends AbstractDmxFunAssert<SELF, ACTU
     }
 
     final AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
+        String message = String.format(template, args);
         String description = info.descriptionText();
         return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
     }

--- a/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
@@ -3,7 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Accumulator;
 import java.util.Collection;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -16,7 +15,7 @@ import org.jspecify.annotations.Nullable;
  * @param <A> the primary value type
  */
 @NullMarked
-public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAssert<E, A>, Accumulator<E, A>> {
+public final class AccumulatorAssert<E, A> extends AbstractDmxFunAssert<AccumulatorAssert<E, A>, Accumulator<E, A>> {
 
     AccumulatorAssert(Accumulator<E, A> actual) {
         super(actual, AccumulatorAssert.class);
@@ -62,18 +61,9 @@ public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAss
      */
     public AccumulatorAssert<E, A> accumulationContains(Object element) {
         isNotNull();
-        E accumulated = actual.accumulated();
-        if (accumulated == null) {
-            throw buildError(
-                "Expected accumulated value to be a Collection for accumulationContains, but was <null>");
-        }
-        if (!(accumulated instanceof Collection<?> col)) {
-            throw buildError(
-                "Expected accumulated value to be a Collection for accumulationContains, but was <%s>",
-                accumulated.getClass().getName());
-        }
+        var col = requireCollection("accumulationContains");
         if (!col.contains(element)) {
-            throw buildError("Expected accumulation <%s> to contain <%s>", accumulated, element);
+            throw buildError("Expected accumulation <%s> to contain <%s>", col, element);
         }
         return this;
     }
@@ -88,16 +78,7 @@ public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAss
      */
     public AccumulatorAssert<E, A> accumulationHasSize(int expected) {
         isNotNull();
-        E accumulated = actual.accumulated();
-        if (accumulated == null) {
-            throw buildError(
-                "Expected accumulated value to be a Collection for accumulationHasSize, but was <null>");
-        }
-        if (!(accumulated instanceof Collection<?> col)) {
-            throw buildError(
-                "Expected accumulated value to be a Collection for accumulationHasSize, but was <%s>",
-                accumulated.getClass().getName());
-        }
+        var col = requireCollection("accumulationHasSize");
         if (col.size() != expected) {
             throw buildError("Expected accumulation to have size <%s> but had <%s>",
                 expected, col.size());
@@ -105,9 +86,17 @@ public final class AccumulatorAssert<E, A> extends AbstractAssert<AccumulatorAss
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
+    private Collection<?> requireCollection(String operation) {
+        E accumulated = actual.accumulated();
+        if (accumulated == null) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for " + operation + ", but was <null>");
+        }
+        if (!(accumulated instanceof Collection<?> col)) {
+            throw buildError(
+                "Expected accumulated value to be a Collection for " + operation + ", but was <%s>",
+                accumulated.getClass().getName());
+        }
+        return col;
     }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/AccumulatorAssert.java
@@ -90,12 +90,12 @@ public final class AccumulatorAssert<E, A> extends AbstractDmxFunAssert<Accumula
         E accumulated = actual.accumulated();
         if (accumulated == null) {
             throw buildError(
-                "Expected accumulated value to be a Collection for " + operation + ", but was <null>");
+                "Expected accumulated value to be a Collection for <%s>, but was <null>", operation);
         }
         if (!(accumulated instanceof Collection<?> col)) {
             throw buildError(
-                "Expected accumulated value to be a Collection for " + operation + ", but was <%s>",
-                accumulated.getClass().getName());
+                "Expected accumulated value to be a Collection for <%s>, but was <%s>",
+                operation, accumulated.getClass().getName());
         }
         return col;
     }

--- a/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/EitherAssert.java
@@ -2,7 +2,6 @@ package dmx.fun.assertj;
 
 import dmx.fun.Either;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <R> the right value type
  */
 @NullMarked
-public final class EitherAssert<L, R> extends AbstractAssert<EitherAssert<L, R>, Either<L, R>> {
+public final class EitherAssert<L, R> extends AbstractDmxFunAssert<EitherAssert<L, R>, Either<L, R>> {
 
     EitherAssert(Either<L, R> actual) {
         super(actual, EitherAssert.class);
@@ -74,9 +73,4 @@ public final class EitherAssert<L, R> extends AbstractAssert<EitherAssert<L, R>,
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template, args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
@@ -1,9 +1,6 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Guard;
-import dmx.fun.NonEmptyList;
-import dmx.fun.Validated;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -14,7 +11,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <T> the type of value the guard validates
  */
 @NullMarked
-public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T>> {
+public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, Guard<T>> {
 
     GuardAssert(Guard<T> actual) {
         super(actual, GuardAssert.class);
@@ -28,7 +25,7 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      */
     public GuardAssert<T> accepts(T value) {
         isNotNull();
-        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        var result = actual.check(value);
         if (!result.isValid()) {
             throw buildError("Expected Guard to accept <%s> but rejected it with <%s>",
                 value, result.getError());
@@ -44,7 +41,7 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      */
     public GuardAssert<T> rejects(T value) {
         isNotNull();
-        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        var result = actual.check(value);
         if (!result.isInvalid()) {
             throw buildError("Expected Guard to reject <%s> but accepted it", value);
         }
@@ -61,11 +58,11 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      */
     public GuardAssert<T> rejectsWithMessage(T value, String message) {
         isNotNull();
-        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        var result = actual.check(value);
         if (!result.isInvalid()) {
             throw buildError("Expected Guard to reject <%s> but accepted it", value);
         }
-        NonEmptyList<String> errors = result.getError();
+        var errors = result.getError();
         if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
             throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
         }
@@ -82,11 +79,11 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
      */
     public GuardAssert<T> rejectsWithMessages(T value, String... messages) {
         isNotNull();
-        Validated<NonEmptyList<String>, T> result = actual.check(value);
+        var result = actual.check(value);
         if (!result.isInvalid()) {
             throw buildError("Expected Guard to reject <%s> but accepted it", value);
         }
-        NonEmptyList<String> errors = result.getError();
+        var errors = result.getError();
         for (String message : messages) {
             if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
                 throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
@@ -95,9 +92,4 @@ public final class GuardAssert<T> extends AbstractAssert<GuardAssert<T>, Guard<T
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/OptionAssert.java
@@ -3,7 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Option;
 import java.util.Objects;
 import java.util.function.Consumer;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <V> the type of the optional value
  */
 @NullMarked
-public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Option<V>> {
+public final class OptionAssert<V> extends AbstractDmxFunAssert<OptionAssert<V>, Option<V>> {
 
     OptionAssert(Option<V> actual) {
         super(actual, OptionAssert.class);
@@ -73,9 +72,4 @@ public final class OptionAssert<V> extends AbstractAssert<OptionAssert<V>, Optio
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResourceAssert.java
@@ -3,7 +3,6 @@ package dmx.fun.assertj;
 import dmx.fun.Resource;
 import dmx.fun.Try;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -19,7 +18,7 @@ import org.jspecify.annotations.Nullable;
  * @param <T> the resource value type
  */
 @NullMarked
-public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, Resource<T>> {
+public final class ResourceAssert<T> extends AbstractDmxFunAssert<ResourceAssert<T>, Resource<T>> {
 
     private @Nullable Try<T> cachedResult;
 
@@ -43,7 +42,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> succeedsWith(T expected) {
-        Try<T> result = evaluate();
+        var result = evaluate();
         if (result.isFailure()) {
             throw buildError("Expected Resource to succeed with <%s> but failed with <%s>",
                 expected, result.getCause());
@@ -63,7 +62,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> failsWith(Class<? extends Throwable> exceptionType) {
-        Try<T> result = evaluate();
+        var result = evaluate();
         if (result.isSuccess()) {
             throw buildError("Expected Resource to fail with <%s> but succeeded with <%s>",
                 exceptionType.getName(), result.get());
@@ -83,7 +82,7 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
      * @return this assertion for chaining
      */
     public ResourceAssert<T> failsWithMessage(String message) {
-        Try<T> result = evaluate();
+        var result = evaluate();
         if (result.isSuccess()) {
             throw buildError("Expected Resource to fail but succeeded with <%s>", result.get());
         }
@@ -95,9 +94,4 @@ public final class ResourceAssert<T> extends AbstractAssert<ResourceAssert<T>, R
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ResultAssert.java
@@ -2,7 +2,6 @@ package dmx.fun.assertj;
 
 import dmx.fun.Result;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <E> the error type
  */
 @NullMarked
-public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>, Result<V, E>> {
+public final class ResultAssert<V, E> extends AbstractDmxFunAssert<ResultAssert<V, E>, Result<V, E>> {
 
     ResultAssert(Result<V, E> actual) {
         super(actual, ResultAssert.class);
@@ -74,9 +73,4 @@ public final class ResultAssert<V, E> extends AbstractAssert<ResultAssert<V, E>,
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/TryAssert.java
@@ -2,7 +2,6 @@ package dmx.fun.assertj;
 
 import dmx.fun.Try;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -13,7 +12,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <V> the success value type
  */
 @NullMarked
-public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
+public final class TryAssert<V> extends AbstractDmxFunAssert<TryAssert<V>, Try<V>> {
 
     TryAssert(Try<V> actual) {
         super(actual, TryAssert.class);
@@ -74,9 +73,4 @@ public final class TryAssert<V> extends AbstractAssert<TryAssert<V>, Try<V>> {
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
+++ b/assertj/src/main/java/dmx/fun/assertj/ValidatedAssert.java
@@ -2,7 +2,6 @@ package dmx.fun.assertj;
 
 import dmx.fun.Validated;
 import java.util.Objects;
-import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -14,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
  * @param <A> the value type
  */
 @NullMarked
-public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<E, A>, Validated<E, A>> {
+public final class ValidatedAssert<E, A> extends AbstractDmxFunAssert<ValidatedAssert<E, A>, Validated<E, A>> {
 
     ValidatedAssert(Validated<E, A> actual) {
         super(actual, ValidatedAssert.class);
@@ -74,9 +73,4 @@ public final class ValidatedAssert<E, A> extends AbstractAssert<ValidatedAssert<
         return this;
     }
 
-    private AssertionError buildError(String template, Object... args) {
-        String message = String.format(template.replace("<%s>", "%s"), args);
-        String description = info.descriptionText();
-        return new AssertionError(description.isEmpty() ? message : "[" + description + "] " + message);
-    }
 }

--- a/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
@@ -73,7 +73,8 @@ class GuardAssertTest {
     void rejectsWithMessage_shouldFail_forValidValue() {
         assertThatThrownBy(() -> assertThat(ALPHANUMERIC)
             .rejectsWithMessage("alice", "alphanumeric"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("alice");
     }
 
     // ── rejectsWithMessages ───────────────────────────────────────────────────

--- a/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/OptionAssertTest.java
@@ -41,13 +41,16 @@ class OptionAssertTest {
     @Test
     void containsValue_shouldFail_whenValueDiffers() {
         assertThatThrownBy(() -> assertThat(Option.some(1)).containsValue(99))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99")
+            .hasMessageContaining("1");
     }
 
     @Test
     void containsValue_shouldFail_forNone() {
         assertThatThrownBy(() -> assertThat(Option.<Integer>none()).containsValue(1))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Some");
     }
 
     @Test
@@ -65,7 +68,8 @@ class OptionAssertTest {
     @Test
     void hasValueSatisfying_shouldFail_forNone() {
         assertThatThrownBy(() -> assertThat(Option.<Integer>none()).hasValueSatisfying(v -> {}))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Some");
     }
 
     @Test

--- a/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResourceAssertTest.java
@@ -91,7 +91,8 @@ class ResourceAssertTest {
     @Test
     void failsWithMessage_shouldFail_whenResourceSucceeds() {
         assertThatThrownBy(() -> assertThat(SUCCESSFUL).failsWithMessage("anything"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("fail");
     }
 
     // ── RELEASE_FAILS: body succeeds, release throws ──────────────────────────

--- a/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ResultAssertTest.java
@@ -40,13 +40,16 @@ class ResultAssertTest {
     @Test
     void containsValue_shouldFail_whenValueDiffers() {
         assertThatThrownBy(() -> assertThat(Result.ok("hello")).containsValue("world"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("world")
+            .hasMessageContaining("hello");
     }
 
     @Test
     void containsValue_shouldFail_forErr() {
         assertThatThrownBy(() -> assertThat(Result.<String, String>err("e")).containsValue("v"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Ok");
     }
 
     @Test
@@ -57,13 +60,16 @@ class ResultAssertTest {
     @Test
     void containsError_shouldFail_whenErrorDiffers() {
         assertThatThrownBy(() -> assertThat(Result.<String, String>err("oops")).containsError("other"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("other")
+            .hasMessageContaining("oops");
     }
 
     @Test
     void containsError_shouldFail_forOk() {
         assertThatThrownBy(() -> assertThat(Result.<String, String>ok("v")).containsError("e"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Err");
     }
 
     @Test

--- a/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/TryAssertTest.java
@@ -40,13 +40,16 @@ class TryAssertTest {
     @Test
     void containsValue_shouldFail_whenValueDiffers() {
         assertThatThrownBy(() -> assertThat(Try.success(1)).containsValue(99))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99")
+            .hasMessageContaining("1");
     }
 
     @Test
     void containsValue_shouldFail_forFailure() {
         assertThatThrownBy(() -> assertThat(Try.<Integer>failure(new RuntimeException())).containsValue(1))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Success");
     }
 
     @Test
@@ -63,14 +66,17 @@ class TryAssertTest {
     void failsWith_shouldFail_whenExceptionTypeDiffers() {
         assertThatThrownBy(() ->
             assertThat(Try.failure(new RuntimeException())).failsWith(IllegalArgumentException.class))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("IllegalArgumentException")
+            .hasMessageContaining("RuntimeException");
     }
 
     @Test
     void failsWith_shouldFail_whenTryIsSuccess() {
         assertThatThrownBy(() ->
             assertThat(Try.success(1)).failsWith(RuntimeException.class))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Failure");
     }
 
     @Test

--- a/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
+++ b/assertj/src/test/java/dmx/fun/assertj/ValidatedAssertTest.java
@@ -40,13 +40,16 @@ class ValidatedAssertTest {
     @Test
     void containsValue_shouldFail_whenValueDiffers() {
         assertThatThrownBy(() -> assertThat(Validated.valid(1)).containsValue(99))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("99")
+            .hasMessageContaining("1");
     }
 
     @Test
     void containsValue_shouldFail_forInvalid() {
         assertThatThrownBy(() -> assertThat(Validated.<String, Integer>invalid("e")).containsValue(1))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Valid");
     }
 
     @Test
@@ -57,13 +60,16 @@ class ValidatedAssertTest {
     @Test
     void hasError_shouldFail_whenErrorDiffers() {
         assertThatThrownBy(() -> assertThat(Validated.<String, Integer>invalid("err")).hasError("other"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("other")
+            .hasMessageContaining("err");
     }
 
     @Test
     void hasError_shouldFail_forValid() {
         assertThatThrownBy(() -> assertThat(Validated.<String, Integer>valid(1)).hasError("e"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Invalid");
     }
 
     @Test

--- a/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
+++ b/samples/src/test/java/dmx/fun/samples/AssertJSampleTest.java
@@ -29,7 +29,7 @@ class AssertJSampleTest {
     @Test
     void either_rightContainsValue() {
         // Models a computation that produces the success track (Right).
-        Either<String, Integer> parsed = Either.right(42);
+        var parsed = Either.right(42);
 
         assertThat(parsed)
             .isRight()
@@ -39,7 +39,7 @@ class AssertJSampleTest {
     @Test
     void either_leftContainsError() {
         // Models a computation that ended on the error track (Left).
-        Either<String, Integer> failed = Either.left("invalid input");
+        var failed = Either.left("invalid input");
 
         assertThat(failed)
             .isLeft()
@@ -49,8 +49,8 @@ class AssertJSampleTest {
     @Test
     void either_isRight_afterSwap() {
         // swap() exchanges left and right — a Left becomes a Right.
-        Either<String, Integer> original = Either.left("msg");
-        Either<Integer, String> swapped  = original.swap();
+        var original = Either.<String, Integer>left("msg");
+        var swapped  = original.swap();
 
         assertThat(swapped)
             .isRight()
@@ -61,7 +61,7 @@ class AssertJSampleTest {
 
     @Test
     void option_someContainsExpectedValue() {
-        Option<String> name = Option.some("Alice");
+        var name = Option.some("Alice");
 
         assertThat(name)
             .isSome()
@@ -70,14 +70,14 @@ class AssertJSampleTest {
 
     @Test
     void option_noneIsEmpty() {
-        Option<String> empty = Option.none();
+        var empty = Option.none();
 
         assertThat(empty).isNone();
     }
 
     @Test
     void option_hasValueSatisfyingPredicate() {
-        Option<Integer> age = Option.some(30);
+        var age = Option.some(30);
 
         assertThat(age).hasValueSatisfying(a -> {
             org.assertj.core.api.Assertions.assertThat(a).isGreaterThan(18);
@@ -88,7 +88,7 @@ class AssertJSampleTest {
 
     @Test
     void result_okContainsValue() {
-        Result<Integer, String> result = Result.ok(42);
+        var result = Result.ok(42);
 
         assertThat(result)
             .isOk()
@@ -97,7 +97,7 @@ class AssertJSampleTest {
 
     @Test
     void result_errContainsError() {
-        Result<Integer, String> result = Result.err("not found");
+        var result = Result.err("not found");
 
         assertThat(result)
             .isErr()
@@ -108,7 +108,7 @@ class AssertJSampleTest {
 
     @Test
     void try_successContainsValue() {
-        Try<String> t = Try.of(() -> "hello".toUpperCase());
+        var t = Try.of("hello"::toUpperCase);
 
         assertThat(t)
             .isSuccess()
@@ -117,7 +117,7 @@ class AssertJSampleTest {
 
     @Test
     void try_failureWithSpecificExceptionType() {
-        Try<Integer> t = Try.of(() -> Integer.parseInt("bad"));
+        var t = Try.of(() -> Integer.parseInt("bad"));
 
         assertThat(t)
             .isFailure()
@@ -128,7 +128,7 @@ class AssertJSampleTest {
 
     @Test
     void validated_validContainsValue() {
-        Validated<String, Integer> v = Validated.valid(100);
+        var v = Validated.valid(100);
 
         assertThat(v)
             .isValid()
@@ -137,7 +137,7 @@ class AssertJSampleTest {
 
     @Test
     void validated_invalidHasError() {
-        Validated<String, Integer> v = Validated.invalid("must be positive");
+        var v = Validated.invalid("must be positive");
 
         assertThat(v)
             .isInvalid()
@@ -146,8 +146,7 @@ class AssertJSampleTest {
 
     @Test
     void validated_invalidNelHasErrorList() {
-        Validated<NonEmptyList<String>, Integer> v =
-            Validated.invalidNel("field is required");
+        var v = Validated.invalidNel("field is required");
 
         assertThat(v)
             .isInvalid()
@@ -158,7 +157,7 @@ class AssertJSampleTest {
 
     @Test
     void tuple2_hasFirstAndSecond() {
-        Tuple2<String, Integer> t = new Tuple2<>("Alice", 30);
+        var t = new Tuple2<>("Alice", 30);
 
         assertThat(t)
             .hasFirst("Alice")
@@ -167,7 +166,7 @@ class AssertJSampleTest {
 
     @Test
     void tuple3_hasAllSlots() {
-        Tuple3<String, Integer, Boolean> t = Tuple3.of("Alice", 30, true);
+        var t = Tuple3.of("Alice", 30, true);
 
         assertThat(t)
             .hasFirst("Alice")
@@ -181,9 +180,9 @@ class AssertJSampleTest {
     void resource_succeedsWith_whenAcquireAndReleaseComplete() {
         // Simulates acquiring a database connection string and releasing it safely.
         // succeedsWith checks that use(v -> v) returns the acquired value unchanged.
-        Resource<String> connectionString = Resource.of(
+        var connectionString = Resource.of(
             () -> "jdbc:postgresql://localhost/mydb",
-            conn -> { /* release: return to pool */ }
+            _ -> { /* release: return to pool */ }
         );
 
         assertThat(connectionString).succeedsWith("jdbc:postgresql://localhost/mydb");
@@ -192,9 +191,9 @@ class AssertJSampleTest {
     @Test
     void resource_failsWith_whenAcquireThrows() {
         // A resource whose acquisition always fails — e.g. cannot open the file.
-        Resource<String> unavailable = Resource.of(
+        var unavailable = Resource.of(
             () -> { throw new java.io.IOException("file not found"); },
-            s  -> { /* release never called */ }
+            _  -> { /* release never called */ }
         );
 
         assertThat(unavailable).failsWith(java.io.IOException.class);
@@ -204,9 +203,9 @@ class AssertJSampleTest {
     void resource_failsWithMessage_whenAcquireThrowsWithKnownMessage() {
         // The acquire step fails with a predictable message — useful for asserting
         // that the correct error propagates through the resource lifecycle.
-        Resource<String> unavailable = Resource.of(
+        var unavailable = Resource.of(
             () -> { throw new IllegalStateException("config file missing: app.yml"); },
-            s  -> {}
+            _  -> {}
         );
 
         assertThat(unavailable).failsWithMessage("config file missing: app.yml");
@@ -217,7 +216,7 @@ class AssertJSampleTest {
     @Test
     void guard_accepts_whenPredicatePasses() {
         // A username must be 3–20 characters and contain only alphanumerics.
-        Guard<String> usernameGuard = Guard.of(
+        var usernameGuard = Guard.<String>of(
             s -> s.length() >= 3 && s.length() <= 20 && s.matches("[A-Za-z0-9]+"),
             "username must be 3–20 alphanumeric characters"
         );
@@ -227,7 +226,7 @@ class AssertJSampleTest {
 
     @Test
     void guard_rejects_whenPredicateFails() {
-        Guard<String> usernameGuard = Guard.of(
+        var usernameGuard = Guard.<String>of(
             s -> s.length() >= 3 && s.length() <= 20 && s.matches("[A-Za-z0-9]+"),
             "username must be 3–20 alphanumeric characters"
         );
@@ -237,7 +236,7 @@ class AssertJSampleTest {
 
     @Test
     void guard_rejectsWithMessage_includesContextualError() {
-        Guard<Integer> positiveAmount = Guard.of(
+        var positiveAmount = Guard.<Integer>of(
             n -> n > 0,
             n -> "amount must be positive, got: " + n
         );
@@ -248,9 +247,9 @@ class AssertJSampleTest {
     @Test
     void guard_rejectsWithMessages_whenMultipleRulesApplied() {
         // Compose two guards: minimum length and no whitespace.
-        Guard<String> minLength  = Guard.of(s -> s.length() >= 8, "must be at least 8 characters");
-        Guard<String> noSpaces   = Guard.of(s -> !s.contains(" "), "must not contain spaces");
-        Guard<String> passwordGuard = minLength.and(noSpaces);
+        var minLength  = Guard.<String>of(s -> s.length() >= 8, "must be at least 8 characters");
+        var noSpaces   = Guard.<String>of(s -> !s.contains(" "), "must not contain spaces");
+        var passwordGuard = minLength.and(noSpaces);
 
         // "hi pw" has 5 chars (fails minLength) and a space (fails noSpaces) — both errors accumulated
         assertThat(passwordGuard)
@@ -262,7 +261,7 @@ class AssertJSampleTest {
     @Test
     void accumulator_hasValue_whenPrimaryValuePresent() {
         // Models a pipeline step that produces a result and logs a message.
-        Accumulator<List<String>, Integer> step =
+        var step =
             Accumulator.of(42, List.of("computed answer"));
 
         assertThat(step).hasValue(42);
@@ -270,7 +269,7 @@ class AssertJSampleTest {
 
     @Test
     void accumulator_hasAccumulation_matchesLogEntries() {
-        Accumulator<List<String>, String> step =
+        var step =
             Accumulator.of("Alice", List.of("fetched user", "applied discount"));
 
         assertThat(step).hasAccumulation(List.of("fetched user", "applied discount"));
@@ -278,7 +277,7 @@ class AssertJSampleTest {
 
     @Test
     void accumulator_accumulationContains_singleAuditEntry() {
-        Accumulator<List<String>, Integer> result =
+        var result =
             Accumulator.of(100, List.of("order created", "stock reserved"));
 
         assertThat(result)
@@ -289,7 +288,7 @@ class AssertJSampleTest {
     @Test
     void accumulator_accumulationHasSize_tracksStepCount() {
         // A multi-step pipeline that accumulates one log entry per step.
-        Accumulator<List<String>, String> pipeline =
+        var pipeline =
             Accumulator.of("done", List.of("step1", "step2", "step3"));
 
         assertThat(pipeline).accumulationHasSize(3);
@@ -298,7 +297,7 @@ class AssertJSampleTest {
     @Test
     void accumulator_tell_sideEffectOnly() {
         // tell() creates an accumulator with no primary value — useful for pure logging steps.
-        Accumulator<List<String>, Void> log =
+        var log =
             Accumulator.tell(List.of("audit: payment initiated"));
 
         assertThat(log)

--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -68,7 +68,7 @@
 
 51. How functional can an object-oriented language really be?
 52. Functional libraries worth knowing
-53. ~~JDK-first functional programming: how far can you go without dependencies?~~ [310]
+53. ~~JDK-first functional programming: how far can you go without dependencies?~~ [311]
 54. Vavr, Arrow, Cats, fp-ts: what problems do they solve?
 55. Do you need a functional library or just better habits?
 
@@ -104,4 +104,4 @@
 [205]: https://github.com/domix/dmx-fun/pull/205
 [241]: https://github.com/domix/dmx-fun/pull/241
 [265]: https://github.com/domix/dmx-fun/pull/265
-[310]: https://github.com/domix/dmx-fun/pull/310
+[311]: https://github.com/domix/dmx-fun/pull/311

--- a/site/src/data/code/guide/tuples/collapsing-map.mdx
+++ b/site/src/data/code/guide/tuples/collapsing-map.mdx
@@ -3,10 +3,16 @@ fileName: 'Demo.java'
 ---
 
 ```java
+// Tuple2.map — collapses two elements into one value via BiFunction
+Tuple2<String, Integer> t2 = Tuple2.of("Alice", 30);
+
+String label2 = t2.map((name, age) -> name + " (age " + age + ")");
+// "Alice (age 30)"
+
 // Tuple3.map — collapses three elements into one value via TriFunction
 Tuple3<String, Integer, Boolean> t3 = Tuple3.of("Alice", 30, true);
 
-String label = t3.map((name, age, active) ->
+String label3 = t3.map((name, age, active) ->
     name + " (age " + age + ")" + (active ? " ✓" : ""));
 // "Alice (age 30) ✓"
 

--- a/site/src/data/code/guide/tuples/creating-instances.mdx
+++ b/site/src/data/code/guide/tuples/creating-instances.mdx
@@ -3,8 +3,8 @@ fileName: 'Demo.java'
 ---
 
 ```java
-// Tuple2 — a pair
-Tuple2<String, Integer> t2 = new Tuple2<>("Alice", 30);
+// Tuple2 — a pair (null-guarded factory method)
+Tuple2<String, Integer> t2 = Tuple2.of("Alice", 30);
 
 // Tuple3 — a triple (null-guarded factory method)
 Tuple3<String, Integer, Boolean> t3 = Tuple3.of("Alice", 30, true);
@@ -12,6 +12,7 @@ Tuple3<String, Integer, Boolean> t3 = Tuple3.of("Alice", 30, true);
 // Tuple4 — a quadruple (null-guarded factory method)
 Tuple4<String, Integer, Boolean, Double> t4 = Tuple4.of("Alice", 30, true, 1.75);
 
-// All fields are @NullMarked — null arguments throw NullPointerException
+// All of() factory methods are @NullMarked — null arguments throw NullPointerException
+Tuple2.of("Alice", null);       // throws NullPointerException
 Tuple3.of("Alice", null, true); // throws NullPointerException
 ```

--- a/site/src/data/code/guide/tuples/creating-instances.mdx
+++ b/site/src/data/code/guide/tuples/creating-instances.mdx
@@ -12,7 +12,9 @@ Tuple3<String, Integer, Boolean> t3 = Tuple3.of("Alice", 30, true);
 // Tuple4 — a quadruple (null-guarded factory method)
 Tuple4<String, Integer, Boolean, Double> t4 = Tuple4.of("Alice", 30, true, 1.75);
 
-// All of() factory methods are @NullMarked — null arguments throw NullPointerException
-Tuple2.of("Alice", null);       // throws NullPointerException
-Tuple3.of("Alice", null, true); // throws NullPointerException
+// of() methods and Tuple3/Tuple4 compact constructors use Objects.requireNonNull —
+// null arguments throw NullPointerException at runtime
+Tuple2.of("Alice", null);       // throws NullPointerException (of() validates)
+Tuple3.of("Alice", null, true); // throws NullPointerException (compact constructor validates)
+new Tuple3<>("Alice", null, true); // also throws — compact constructor always runs
 ```

--- a/site/src/data/code/guide/tuples/transforming-slots.mdx
+++ b/site/src/data/code/guide/tuples/transforming-slots.mdx
@@ -3,12 +3,18 @@ fileName: 'Demo.java'
 ---
 
 ```java
+// Tuple2 — transform individual slots; the other is unchanged
+Tuple2<String, Integer> t2 = Tuple2.of("alice", 30);
+
+Tuple2<String, Integer> upper = t2.mapFirst(String::toUpperCase); // ("ALICE", 30)
+Tuple2<String, Integer> older = t2.mapSecond(age -> age + 1);     // ("alice", 31)
+
 // Tuple3 — transform individual slots; the others are unchanged
 Tuple3<String, Integer, Boolean> t3 = Tuple3.of("alice", 30, true);
 
-Tuple3<String, Integer, Boolean>  upper   = t3.mapFirst(String::toUpperCase); // ("ALICE", 30, true)
-Tuple3<String, Integer, Boolean>  older   = t3.mapSecond(age -> age + 1);    // ("alice", 31, true)
-Tuple3<String, Integer, Boolean>  toggled = t3.mapThird(b -> !b);            // ("alice", 30, false)
+Tuple3<String, Integer, Boolean> upper3   = t3.mapFirst(String::toUpperCase); // ("ALICE", 30, true)
+Tuple3<String, Integer, Boolean> older3   = t3.mapSecond(age -> age + 1);    // ("alice", 31, true)
+Tuple3<String, Integer, Boolean> toggled3 = t3.mapThird(b -> !b);            // ("alice", 30, false)
 
 // Tuple4 — additionally has mapFourth
 Tuple4<String, Integer, Boolean, Double> t4 = Tuple4.of("alice", 30, true, 1.75);

--- a/site/src/data/guide/tuples.mdx
+++ b/site/src/data/guide/tuples.mdx
@@ -26,10 +26,15 @@ All three are Java `record` types, which means:
 - Fields are exposed via accessor methods `_1()`, `_2()`, `_3()`, `_4()` — consistent
   across all tuple arities.
 
-**Null policy**: All three types are `@NullMarked`. The `of()` factory method on
-each validates that no element is `null` — a `NullPointerException` is thrown at
-construction time. The raw record constructor (`new Tuple2<>(...)`) is still
-accessible and does not validate; prefer `of()` in application code.
+**Null policy**: All three types are `@NullMarked`, but the enforcement point differs:
+
+- **`Tuple3` and `Tuple4`** use compact record constructors that call
+  `Objects.requireNonNull` on every component. Both the `of()` factory and the
+  raw record constructor (`new Tuple3<>(...)` / `new Tuple4<>(...)`) throw
+  `NullPointerException` if any element is `null`.
+- **`Tuple2`** validates only inside its `of()` factory. The raw record constructor
+  (`new Tuple2<>(...)`) bypasses the check and accepts `null` elements. Prefer
+  `Tuple2.of(...)` in application code.
 
 Use Tuples when:
 

--- a/site/src/data/guide/tuples.mdx
+++ b/site/src/data/guide/tuples.mdx
@@ -26,9 +26,10 @@ All three are Java `record` types, which means:
 - Fields are exposed via accessor methods `_1()`, `_2()`, `_3()`, `_4()` — consistent
   across all tuple arities.
 
-**Null policy**: `Tuple3` and `Tuple4` are `@NullMarked` — null elements throw
-`NullPointerException` at construction time. `Tuple2` is a plain record without
-null guards; prefer `Tuple3`/`Tuple4` when null-safety is required.
+**Null policy**: All three types are `@NullMarked`. The `of()` factory method on
+each validates that no element is `null` — a `NullPointerException` is thrown at
+construction time. The raw record constructor (`new Tuple2<>(...)`) is still
+accessible and does not validate; prefer `of()` in application code.
 
 Use Tuples when:
 
@@ -51,21 +52,24 @@ Fields are accessed via zero-argument methods `_1()`, `_2()`, `_3()`, and `_4()`
 
 ## Transforming individual slots
 
-`Tuple3` and `Tuple4` provide `mapFirst`, `mapSecond`, `mapThird` (and `mapFourth`
-for `Tuple4`). Each returns a **new tuple** with the targeted slot replaced; the
-remaining slots are carried through unchanged.
+All three types provide per-slot transformation methods. Each returns a **new tuple**
+with the targeted slot replaced; the remaining slots are carried through unchanged.
+
+- `Tuple2` — `mapFirst`, `mapSecond`
+- `Tuple3` — `mapFirst`, `mapSecond`, `mapThird`
+- `Tuple4` — `mapFirst`, `mapSecond`, `mapThird`, `mapFourth`
 
 <TransformingSlots/>
 
 ## Collapsing to a single value — `map`
 
-`Tuple3.map(TriFunction)` and `Tuple4.map(QuadFunction)` collapse the entire tuple
-into a single result by applying a function to all slots at once.
+Every tuple type can collapse all its elements into a single value:
+
+- `Tuple2.map(BiFunction)` — uses the standard `java.util.function.BiFunction`
+- `Tuple3.map(TriFunction)` — uses the library-provided `TriFunction<A,B,C,R>`
+- `Tuple4.map(QuadFunction)` — uses the library-provided `QuadFunction<A,B,C,D,R>`
 
 <CollapsingMap/>
-
-`TriFunction<A,B,C,R>` and `QuadFunction<A,B,C,D,R>` are functional interfaces
-provided by the library, analogous to `java.util.function.BiFunction`.
 
 ## Equality and `toString`
 


### PR DESCRIPTION
- **refactor(assertj): extract shared buildError base class and fix EitherAssert bug**
- **docs: update documentation to reflect Tuple2 enhancements and assertj fixes**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #278

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Guard assertion behavior: `rejectsWithMessage` and `rejectsWithMessages` now validate substring containment instead of exact message equality.
  * Enhanced tuple API documentation with null-safety guarantees and expanded examples for `Tuple2` transformations.
  * Clarified that factory methods (`Tuple.of()`) enforce non-null validation.

* **Chores**
  * Improved assertion error messages across the framework for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->