### PR TITLE
feature/micrometer/code cleanup

### DIFF
--- a/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
+++ b/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
@@ -1,7 +1,6 @@
 package dmx.fun.micrometer;
 
 import dmx.fun.CheckedSupplier;
-import dmx.fun.Lazy;
 import dmx.fun.Result;
 import dmx.fun.Try;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -32,7 +31,7 @@ public final class DmxMetered {
 
     private final String name;
     private Tags tags = Tags.empty();
-    private @Nullable Lazy<DmxMicrometer> micrometer;
+    private @Nullable DmxMicrometer micrometer;
 
     private DmxMetered(String name) {
         this.name = name;
@@ -51,8 +50,7 @@ public final class DmxMetered {
 
     /** Sets the {@link MeterRegistry} to register metrics with. */
     public DmxMetered registry(MeterRegistry registry) {
-        MeterRegistry assignedRegistry = Objects.requireNonNull(registry, "registry");
-        this.micrometer = Lazy.of(() -> DmxMicrometer.of(assignedRegistry));
+        this.micrometer = DmxMicrometer.of(Objects.requireNonNull(registry, "registry"));
         return this;
     }
 
@@ -77,10 +75,9 @@ public final class DmxMetered {
     }
 
     private DmxMicrometer requireMicrometer() {
-        Lazy<DmxMicrometer> lazyMicrometer = micrometer;
-        if (lazyMicrometer == null) {
+        if (micrometer == null) {
             throw new IllegalStateException("registry must be set before recording — call .registry(meterRegistry) first");
         }
-        return lazyMicrometer.get();
+        return micrometer;
     }
 }

--- a/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
+++ b/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
@@ -37,18 +37,33 @@ public final class DmxMetered {
         this.name = name;
     }
 
-    /** Creates a builder for the given metric name. */
+    /**
+     * Creates a builder for the given metric name.
+     *
+     * @param name the base metric name; must not be null
+     * @return a new {@code DmxMetered} builder
+     */
     public static DmxMetered of(String name) {
         return new DmxMetered(Objects.requireNonNull(name, "name"));
     }
 
-    /** Sets the tags to attach to all metrics for this operation. */
+    /**
+     * Sets the tags to attach to all metrics for this operation.
+     *
+     * @param tags the tags to apply; must not be null
+     * @return this builder
+     */
     public DmxMetered tags(Tags tags) {
         this.tags = Objects.requireNonNull(tags, "tags");
         return this;
     }
 
-    /** Sets the {@link MeterRegistry} to register metrics with. */
+    /**
+     * Sets the {@link MeterRegistry} to register metrics with.
+     *
+     * @param registry the registry to use; must not be null
+     * @return this builder
+     */
     public DmxMetered registry(MeterRegistry registry) {
         this.micrometer = DmxMicrometer.of(Objects.requireNonNull(registry, "registry"));
         return this;
@@ -57,6 +72,8 @@ public final class DmxMetered {
     /**
      * Executes the supplier and records metrics.
      *
+     * @param <V> the value type returned on success
+     * @param supplier the operation to execute; must not be null
      * @return {@code Success(value)} on success, {@code Failure(cause)} on any exception
      * @throws IllegalStateException if {@link #registry} was not set
      */
@@ -67,6 +84,8 @@ public final class DmxMetered {
     /**
      * Executes the supplier and records metrics.
      *
+     * @param <V> the value type returned on success
+     * @param supplier the operation to execute; must not be null
      * @return {@code Ok(value)} on success, {@code Err(cause)} on any exception
      * @throws IllegalStateException if {@link #registry} was not set
      */

--- a/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
+++ b/micrometer/src/main/java/dmx/fun/micrometer/DmxMetered.java
@@ -65,7 +65,7 @@ public final class DmxMetered {
      * @return this builder
      */
     public DmxMetered registry(MeterRegistry registry) {
-        this.micrometer = DmxMicrometer.of(Objects.requireNonNull(registry, "registry"));
+        this.micrometer = DmxMicrometer.of(registry);
         return this;
     }
 

--- a/micrometer/src/main/java/dmx/fun/micrometer/DmxMicrometer.java
+++ b/micrometer/src/main/java/dmx/fun/micrometer/DmxMicrometer.java
@@ -58,7 +58,7 @@ public final class DmxMicrometer {
         Objects.requireNonNull(tags, "tags");
         Objects.requireNonNull(supplier, "supplier");
 
-        Timer.Sample sample = Timer.start(registry);
+        var sample = Timer.start(registry);
         Try<V> result;
         try {
             result = Try.success(supplier.get());

--- a/micrometer/src/main/java/dmx/fun/micrometer/DmxMicrometer.java
+++ b/micrometer/src/main/java/dmx/fun/micrometer/DmxMicrometer.java
@@ -43,7 +43,12 @@ public final class DmxMicrometer {
         this.registry = registry;
     }
 
-    /** Creates an instance bound to the given {@link MeterRegistry}. */
+    /**
+     * Creates an instance bound to the given {@link MeterRegistry}.
+     *
+     * @param registry the registry to record metrics into; must not be null
+     * @return a new {@code DmxMicrometer} bound to the given registry
+     */
     public static DmxMicrometer of(MeterRegistry registry) {
         return new DmxMicrometer(Objects.requireNonNull(registry, "registry"));
     }
@@ -51,6 +56,10 @@ public final class DmxMicrometer {
     /**
      * Executes the supplier and records metrics under {@code name}.
      *
+     * @param <V> the value type returned on success
+     * @param name the base metric name; must not be null
+     * @param tags additional tags to attach to all metrics; must not be null
+     * @param supplier the operation to execute; must not be null
      * @return {@code Success(value)} on success, {@code Failure(cause)} on any exception
      */
     public <V> Try<V> recordTry(String name, Tags tags, CheckedSupplier<V> supplier) {
@@ -86,6 +95,10 @@ public final class DmxMicrometer {
     /**
      * Executes the supplier and records metrics under {@code name}.
      *
+     * @param <V> the value type returned on success
+     * @param name the base metric name; must not be null
+     * @param tags additional tags to attach to all metrics; must not be null
+     * @param supplier the operation to execute; must not be null
      * @return {@code Ok(value)} on success, {@code Err(cause)} on any exception
      */
     public <V> Result<V, Throwable> recordResult(String name, Tags tags, CheckedSupplier<V> supplier) {

--- a/micrometer/src/main/java/module-info.java
+++ b/micrometer/src/main/java/module-info.java
@@ -5,6 +5,10 @@
  * Micrometer counters, timers, and failure metrics without requiring manual
  * metric tracking at call sites.
  */
+// MeterRegistry and Tags appear in the public API of DmxMicrometer and DmxMetered,
+// so requires-transitive is correct. The warning fires because micrometer-core ships
+// as an automatic module (Automatic-Module-Name only, no module-info.class).
+@SuppressWarnings("requires-transitive-automatic")
 module dmx.fun.micrometer {
     requires transitive dmx.fun;
     requires static transitive micrometer.core;

--- a/micrometer/src/test/java/dmx/fun/micrometer/DmxMeteredTest.java
+++ b/micrometer/src/test/java/dmx/fun/micrometer/DmxMeteredTest.java
@@ -1,8 +1,5 @@
 package dmx.fun.micrometer;
 
-import dmx.fun.Result;
-import dmx.fun.Try;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -17,9 +14,34 @@ class DmxMeteredTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry();
 
+    // ── null contracts ─────────────────────────────────────────────────────────
+
+    @Test
+    void of_nullName_throwsNullPointerException() {
+        assertThatThrownBy(() -> DmxMetered.of(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("name");
+    }
+
+    @Test
+    void tags_nullTags_throwsNullPointerException() {
+        assertThatThrownBy(() -> DmxMetered.of("op").tags(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("tags");
+    }
+
+    @Test
+    void registry_nullRegistry_throwsNullPointerException() {
+        assertThatThrownBy(() -> DmxMetered.of("op").registry(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("registry");
+    }
+
+    // ── recordTry ──────────────────────────────────────────────────────────────
+
     @Test
     void recordTry_success_returnsSuccessValue() {
-        Try<String> result = DmxMetered.of("op")
+        var result = DmxMetered.of("op")
             .registry(registry)
             .recordTry(() -> "ok");
 
@@ -28,7 +50,7 @@ class DmxMeteredTest {
 
     @Test
     void recordTry_failure_returnsFailure() {
-        Try<String> result = DmxMetered.of("op")
+        var result = DmxMetered.of("op")
             .registry(registry)
             .recordTry(() -> { throw new IOException("boom"); });
 
@@ -42,7 +64,7 @@ class DmxMeteredTest {
             .registry(registry)
             .recordTry(() -> "ok");
 
-        Counter counter = registry.get("op.count")
+        var counter = registry.get("op.count")
             .tags("service", "payments", "outcome", "success")
             .counter();
         assertThat(counter.count()).isEqualTo(1.0);
@@ -50,7 +72,7 @@ class DmxMeteredTest {
 
     @Test
     void recordResult_success_returnsOk() {
-        Result<String, Throwable> result = DmxMetered.of("op")
+        var result = DmxMetered.of("op")
             .registry(registry)
             .recordResult(() -> "ok");
 
@@ -59,7 +81,7 @@ class DmxMeteredTest {
 
     @Test
     void recordResult_failure_returnsErr() {
-        Result<String, Throwable> result = DmxMetered.of("op")
+        var result = DmxMetered.of("op")
             .registry(registry)
             .recordResult(() -> { throw new IOException("boom"); });
 
@@ -84,7 +106,7 @@ class DmxMeteredTest {
     void tags_defaultsToEmpty() {
         DmxMetered.of("op").registry(registry).recordTry(() -> "ok");
 
-        Counter counter = registry.get("op.count").tag("outcome", "success").counter();
+        var counter = registry.get("op.count").tag("outcome", "success").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 }

--- a/micrometer/src/test/java/dmx/fun/micrometer/DmxMicrometerTest.java
+++ b/micrometer/src/test/java/dmx/fun/micrometer/DmxMicrometerTest.java
@@ -1,11 +1,7 @@
 package dmx.fun.micrometer;
 
-import dmx.fun.Result;
-import dmx.fun.Try;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.stream.IntStream;
@@ -73,7 +69,7 @@ class DmxMicrometerTest {
 
     @Test
     void recordTry_success_returnsSuccessValue() {
-        Try<String> result = dmx.recordTry("op", Tags.empty(), () -> "ok");
+        var result = dmx.recordTry("op", Tags.empty(), () -> "ok");
 
         assertThat(result).containsValue("ok");
     }
@@ -82,7 +78,7 @@ class DmxMicrometerTest {
     void recordTry_success_incrementsSuccessCounter() {
         dmx.recordTry("op", Tags.empty(), () -> "ok");
 
-        Counter counter = registry.get("op.count").tag("outcome", "success").counter();
+        var counter = registry.get("op.count").tag("outcome", "success").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 
@@ -90,7 +86,7 @@ class DmxMicrometerTest {
     void recordTry_success_recordsDurationTimer() {
         dmx.recordTry("op", Tags.empty(), () -> "ok");
 
-        Timer timer = registry.get("op.duration").tag("outcome", "success").timer();
+        var timer = registry.get("op.duration").tag("outcome", "success").timer();
         assertThat(timer.count()).isEqualTo(1L);
     }
 
@@ -105,8 +101,8 @@ class DmxMicrometerTest {
 
     @Test
     void recordTry_failure_returnsFailure() {
-        IOException boom = new IOException("boom");
-        Try<String> result = dmx.recordTry("op", Tags.empty(), () -> { throw boom; });
+        var boom = new IOException("boom");
+        var result = dmx.recordTry("op", Tags.empty(), () -> { throw boom; });
 
         assertThat(result).failsWith(IOException.class);
         assertThat(result.getCause()).isSameAs(boom);
@@ -116,7 +112,7 @@ class DmxMicrometerTest {
     void recordTry_failure_incrementsFailureCounter() {
         dmx.recordTry("op", Tags.empty(), () -> { throw new IOException("boom"); });
 
-        Counter counter = registry.get("op.count").tag("outcome", "failure").counter();
+        var counter = registry.get("op.count").tag("outcome", "failure").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 
@@ -124,7 +120,7 @@ class DmxMicrometerTest {
     void recordTry_failure_recordsDurationTimer() {
         dmx.recordTry("op", Tags.empty(), () -> { throw new RuntimeException("boom"); });
 
-        Timer timer = registry.get("op.duration").tag("outcome", "failure").timer();
+        var timer = registry.get("op.duration").tag("outcome", "failure").timer();
         assertThat(timer.count()).isEqualTo(1L);
     }
 
@@ -132,7 +128,7 @@ class DmxMicrometerTest {
     void recordTry_failure_incrementsExceptionCounter() {
         dmx.recordTry("op", Tags.empty(), () -> { throw new IOException("boom"); });
 
-        Counter counter = registry.get("op.failure").tag("exception", "IOException").counter();
+        var counter = registry.get("op.failure").tag("exception", "IOException").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 
@@ -140,7 +136,7 @@ class DmxMicrometerTest {
     void recordTry_failure_exceptionCounterTaggedWithSimpleClassName() {
         dmx.recordTry("op", Tags.empty(), () -> { throw new IllegalArgumentException("bad"); });
 
-        Counter counter = registry.get("op.failure").tag("exception", "IllegalArgumentException").counter();
+        var counter = registry.get("op.failure").tag("exception", "IllegalArgumentException").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 
@@ -148,10 +144,10 @@ class DmxMicrometerTest {
 
     @Test
     void recordTry_customTags_propagatedToAllMetrics() {
-        Tags tags = Tags.of("service", "payments");
+        var tags = Tags.of("service", "payments");
         dmx.recordTry("op", tags, () -> "ok");
 
-        Counter counter = registry.get("op.count")
+        var counter = registry.get("op.count")
             .tags("service", "payments", "outcome", "success")
             .counter();
         assertThat(counter.count()).isEqualTo(1.0);
@@ -159,10 +155,10 @@ class DmxMicrometerTest {
 
     @Test
     void recordTry_customTags_propagatedToFailureCounter() {
-        Tags tags = Tags.of("service", "payments");
+        var tags = Tags.of("service", "payments");
         dmx.recordTry("op", tags, () -> { throw new IOException("boom"); });
 
-        Counter counter = registry.get("op.failure")
+        var counter = registry.get("op.failure")
             .tags("service", "payments", "exception", "IOException")
             .counter();
         assertThat(counter.count()).isEqualTo(1.0);
@@ -176,7 +172,7 @@ class DmxMicrometerTest {
         dmx.recordTry("op", Tags.empty(), () -> "b");
         dmx.recordTry("op", Tags.empty(), () -> "c");
 
-        Counter counter = registry.get("op.count").tag("outcome", "success").counter();
+        var counter = registry.get("op.count").tag("outcome", "success").counter();
         assertThat(counter.count()).isEqualTo(3.0);
     }
 
@@ -184,14 +180,14 @@ class DmxMicrometerTest {
 
     @Test
     void recordResult_success_returnsOk() {
-        Result<String, Throwable> result = dmx.recordResult("op", Tags.empty(), () -> "ok");
+        var result = dmx.recordResult("op", Tags.empty(), () -> "ok");
 
         assertThat(result).containsValue("ok");
     }
 
     @Test
     void recordResult_failure_returnsErr() {
-        Result<String, Throwable> result = dmx.recordResult("op", Tags.empty(),
+        var result = dmx.recordResult("op", Tags.empty(),
             () -> { throw new IOException("boom"); });
 
         assertThat(result).isErr();
@@ -202,7 +198,7 @@ class DmxMicrometerTest {
     void recordResult_recordsSameMetricsAsTry() {
         dmx.recordResult("op", Tags.empty(), () -> "ok");
 
-        Counter counter = registry.get("op.count").tag("outcome", "success").counter();
+        var counter = registry.get("op.count").tag("outcome", "success").counter();
         assertThat(counter.count()).isEqualTo(1.0);
     }
 
@@ -220,19 +216,19 @@ class DmxMicrometerTest {
         long expectedFailures = IntStream.range(0, totalCalls).filter(i -> i % 3 == 0).count();
         long expectedSuccesses = totalCalls - expectedFailures;
 
-        Counter success = registry.get("op.concurrent.count")
+        var success = registry.get("op.concurrent.count")
             .tags("component", "test", "outcome", "success")
             .counter();
-        Counter failure = registry.get("op.concurrent.count")
+        var failure = registry.get("op.concurrent.count")
             .tags("component", "test", "outcome", "failure")
             .counter();
-        Counter exception = registry.get("op.concurrent.failure")
+        var exception = registry.get("op.concurrent.failure")
             .tags("component", "test", "exception", "IOException")
             .counter();
-        Timer successTimer = registry.get("op.concurrent.duration")
+        var successTimer = registry.get("op.concurrent.duration")
             .tags("component", "test", "outcome", "success")
             .timer();
-        Timer failureTimer = registry.get("op.concurrent.duration")
+        var failureTimer = registry.get("op.concurrent.duration")
             .tags("component", "test", "outcome", "failure")
             .timer();
 


### PR DESCRIPTION
- **refactor(micrometer): remove Lazy indirection in DmxMetered and add null-contract tests**
- **fix(micrometer): suppress requires-transitive-automatic warning in module-info**
- **docs(micrometer): add missing @param and @return Javadoc tags**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #283

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Javadoc for `DmxMicrometer.of()`, `recordTry()`, and `recordResult()` methods with detailed parameter and return value documentation.

* **Improvements**
  * Enhanced null input validation with explicit error messages for required parameters (`name`, `tags`, `registry`, `supplier`).

* **Chores**
  * Updated module configuration for improved Java Platform Module System compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->