### PR TITLE
feat(spring): add readOnly attribute and propagation contract tests

### DIFF
--- a/site/src/data/code/guide/spring/transactional-attributes.mdx
+++ b/site/src/data/code/guide/spring/transactional-attributes.mdx
@@ -8,11 +8,15 @@ public class PaymentService {
 
     // Custom propagation, isolation, and timeout
     @TransactionalResult(
-        propagation        = Propagation.REQUIRES_NEW,
-        isolation          = Isolation.SERIALIZABLE,
-        timeout            = 10
+        propagation = Propagation.REQUIRES_NEW,
+        isolation   = Isolation.SERIALIZABLE,
+        timeout     = 10
     )
     public Result<Receipt, PaymentError> charge(PaymentRequest req) { ... }
+
+    // Read-only hint — lets the driver/ORM skip dirty checks or route to a replica
+    @TransactionalResult(readOnly = true)
+    public Result<List<Receipt>, String> listReceipts(CustomerId id) { ... }
 
     // Named transaction manager (multiple DataSources)
     @TransactionalResult(transactionManager = "ledgerTxManager")

--- a/site/src/data/guide/spring.mdx
+++ b/site/src/data/guide/spring.mdx
@@ -260,12 +260,13 @@ or register the aspect explicitly with the `@Bean` declaration shown above.
 
 All three annotations accept the same attributes as Spring's `@Transactional`:
 
-| Attribute | Type | Default |
-|---|---|---|
-| `propagation` | `Propagation` | `REQUIRED` |
-| `isolation` | `Isolation` | `DEFAULT` |
-| `timeout` | `int` (seconds) | `TIMEOUT_DEFAULT` (-1, no explicit timeout) |
-| `transactionManager` | `String` (bean name) | primary `PlatformTransactionManager` |
+| Attribute | Type | Default | Notes |
+|---|---|---|---|
+| `propagation` | `Propagation` | `REQUIRED` | |
+| `isolation` | `Isolation` | `DEFAULT` | |
+| `timeout` | `int` (seconds) | `TIMEOUT_DEFAULT` (-1) | |
+| `readOnly` | `boolean` | `false` | Hint to the driver/ORM; enforcement depends on the transaction manager |
+| `transactionManager` | `String` (bean name) | primary `PlatformTransactionManager` | |
 
 <TransactionalAttributes/>
 

--- a/spring/src/main/java/dmx/fun/spring/DmxTransactionalAspect.java
+++ b/spring/src/main/java/dmx/fun/spring/DmxTransactionalAspect.java
@@ -79,7 +79,7 @@ public class DmxTransactionalAspect {
     public Object aroundResult(ProceedingJoinPoint pjp, TransactionalResult ann) {
         return executor(ann.transactionManager())
             .execute(
-                definition(ann.propagation(), ann.isolation(), ann.timeout()),
+                definition(ann.propagation(), ann.isolation(), ann.timeout(), ann.readOnly()),
                 () -> (Result<Object, Object>) proceed(pjp),
                 Result::isError
             );
@@ -98,7 +98,7 @@ public class DmxTransactionalAspect {
     public Object aroundTry(ProceedingJoinPoint pjp, TransactionalTry ann) {
         return executor(ann.transactionManager())
             .execute(
-                definition(ann.propagation(), ann.isolation(), ann.timeout()),
+                definition(ann.propagation(), ann.isolation(), ann.timeout(), ann.readOnly()),
                 () -> (Try<Object>) proceed(pjp),
                 Try::isFailure
             );
@@ -117,7 +117,7 @@ public class DmxTransactionalAspect {
     public Object aroundValidated(ProceedingJoinPoint pjp, TransactionalValidated ann) {
         return executor(ann.transactionManager())
             .execute(
-                definition(ann.propagation(), ann.isolation(), ann.timeout()),
+                definition(ann.propagation(), ann.isolation(), ann.timeout(), ann.readOnly()),
                 () -> (Validated<Object, Object>) proceed(pjp),
                 Validated::isInvalid
             );
@@ -131,11 +131,12 @@ public class DmxTransactionalAspect {
     }
 
     private static DefaultTransactionDefinition definition(
-            Propagation propagation, Isolation isolation, int timeout) {
+            Propagation propagation, Isolation isolation, int timeout, boolean readOnly) {
         var def = new DefaultTransactionDefinition();
         def.setPropagationBehavior(propagation.value());
         def.setIsolationLevel(isolation.value());
         def.setTimeout(timeout);
+        def.setReadOnly(readOnly);
         return def;
     }
 

--- a/spring/src/main/java/dmx/fun/spring/TransactionalResult.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalResult.java
@@ -66,6 +66,19 @@ public @interface TransactionalResult {
     int timeout() default TransactionDefinition.TIMEOUT_DEFAULT;
 
     /**
+     * Whether the transaction is read-only.
+     *
+     * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
+     * optimisations (e.g. skip dirty checking, use a read replica). It does
+     * not prevent write statements — enforcement depends on the actual
+     * transaction manager and data source.
+     *
+     * @return {@code true} to request a read-only transaction;
+     *         defaults to {@code false}
+     */
+    boolean readOnly() default false;
+
+    /**
      * Bean name of a specific {@link org.springframework.transaction.PlatformTransactionManager}
      * to use.
      *

--- a/spring/src/main/java/dmx/fun/spring/TransactionalResult.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalResult.java
@@ -69,8 +69,8 @@ public @interface TransactionalResult {
      * Whether the transaction is read-only.
      *
      * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
-     * optimisations (e.g. skip dirty checking, use a read replica). It does
-     * not prevent write statements — enforcement depends on the actual
+     * optimizations (e.g., skip dirty checking, use a read replica). It does
+     * not prevent writing statements — enforcement depends on the actual
      * transaction manager and data source.
      *
      * @return {@code true} to request a read-only transaction;

--- a/spring/src/main/java/dmx/fun/spring/TransactionalTry.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalTry.java
@@ -64,6 +64,19 @@ public @interface TransactionalTry {
     int timeout() default TransactionDefinition.TIMEOUT_DEFAULT;
 
     /**
+     * Whether the transaction is read-only.
+     *
+     * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
+     * optimisations (e.g. skip dirty checking, use a read replica). It does
+     * not prevent write statements — enforcement depends on the actual
+     * transaction manager and data source.
+     *
+     * @return {@code true} to request a read-only transaction;
+     *         defaults to {@code false}
+     */
+    boolean readOnly() default false;
+
+    /**
      * Bean name of a specific {@link org.springframework.transaction.PlatformTransactionManager}
      * to use.
      *

--- a/spring/src/main/java/dmx/fun/spring/TransactionalTry.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalTry.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Propagation;
 public @interface TransactionalTry {
 
     /**
-     * Transaction propagation behaviour.
+     * Transaction propagation behavior.
      *
      * @return propagation setting; defaults to {@link Propagation#REQUIRED}
      */
@@ -67,8 +67,8 @@ public @interface TransactionalTry {
      * Whether the transaction is read-only.
      *
      * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
-     * optimisations (e.g. skip dirty checking, use a read replica). It does
-     * not prevent write statements — enforcement depends on the actual
+     * optimizations (e.g., skip dirty checking, use a read replica). It does
+     * not prevent writing statements — enforcement depends on the actual
      * transaction manager and data source.
      *
      * @return {@code true} to request a read-only transaction;

--- a/spring/src/main/java/dmx/fun/spring/TransactionalValidated.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalValidated.java
@@ -66,6 +66,19 @@ public @interface TransactionalValidated {
     int timeout() default TransactionDefinition.TIMEOUT_DEFAULT;
 
     /**
+     * Whether the transaction is read-only.
+     *
+     * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
+     * optimisations (e.g. skip dirty checking, use a read replica). It does
+     * not prevent write statements — enforcement depends on the actual
+     * transaction manager and data source.
+     *
+     * @return {@code true} to request a read-only transaction;
+     *         defaults to {@code false}
+     */
+    boolean readOnly() default false;
+
+    /**
      * Bean name of a specific {@link org.springframework.transaction.PlatformTransactionManager}
      * to use.
      *

--- a/spring/src/main/java/dmx/fun/spring/TransactionalValidated.java
+++ b/spring/src/main/java/dmx/fun/spring/TransactionalValidated.java
@@ -44,7 +44,7 @@ import org.springframework.transaction.annotation.Propagation;
 public @interface TransactionalValidated {
 
     /**
-     * Transaction propagation behaviour.
+     * Transaction propagation behavior.
      *
      * @return propagation setting; defaults to {@link Propagation#REQUIRED}
      */
@@ -69,8 +69,8 @@ public @interface TransactionalValidated {
      * Whether the transaction is read-only.
      *
      * <p>A read-only hint allows the underlying JDBC driver or ORM to apply
-     * optimisations (e.g. skip dirty checking, use a read replica). It does
-     * not prevent write statements — enforcement depends on the actual
+     * optimizations (e.g., skip dirty checking, use a read replica). It does
+     * not prevent writing statements — enforcement depends on the actual
      * transaction manager and data source.
      *
      * @return {@code true} to request a read-only transaction;

--- a/spring/src/main/java/module-info.java
+++ b/spring/src/main/java/module-info.java
@@ -10,6 +10,7 @@
  */
 module dmx.fun.spring {
     requires dmx.fun;
+    requires spring.beans;
     requires spring.tx;
     requires spring.context;
     requires static org.aspectj.weaver;

--- a/spring/src/test/java/dmx/fun/spring/RecordingTxManager.java
+++ b/spring/src/test/java/dmx/fun/spring/RecordingTxManager.java
@@ -7,17 +7,20 @@ import org.springframework.transaction.TransactionStatus;
 class RecordingTxManager implements PlatformTransactionManager {
     private final PlatformTransactionManager delegate;
     private boolean used = false;
+    private TransactionDefinition lastDefinition = null;
 
     RecordingTxManager(PlatformTransactionManager delegate) {
         this.delegate = delegate;
     }
 
-    void reset() { used = false; }
+    void reset() { used = false; lastDefinition = null; }
     boolean wasUsed() { return used; }
+    TransactionDefinition lastDefinition() { return lastDefinition; }
 
     @Override
     public TransactionStatus getTransaction(TransactionDefinition definition) {
         used = true;
+        lastDefinition = definition;
         return delegate.getTransaction(definition);
     }
 

--- a/spring/src/test/java/dmx/fun/spring/TransactionalResultAspectTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalResultAspectTest.java
@@ -83,6 +83,7 @@ class TransactionalResultAspectTest extends AbstractH2AspectTestBase {
     @Test
     void readOnly_forwardsHintToTransactionManager() {
         service.selectReadOnly(1);
+        Assertions.assertThat(primaryRecording.lastDefinition()).isNotNull();
         Assertions.assertThat(primaryRecording.lastDefinition().isReadOnly()).isTrue();
     }
 

--- a/spring/src/test/java/dmx/fun/spring/TransactionalResultAspectTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalResultAspectTest.java
@@ -77,6 +77,16 @@ class TransactionalResultAspectTest extends AbstractH2AspectTestBase {
     }
 
     // -------------------------------------------------------------------------
+    // readOnly flag
+    // -------------------------------------------------------------------------
+
+    @Test
+    void readOnly_forwardsHintToTransactionManager() {
+        service.selectReadOnly(1);
+        Assertions.assertThat(primaryRecording.lastDefinition().isReadOnly()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
     // Test service
     // -------------------------------------------------------------------------
 
@@ -87,6 +97,7 @@ class TransactionalResultAspectTest extends AbstractH2AspectTestBase {
         Result<Integer, String> insertAndReturnNull(int id);
         Result<Integer, String> insertWithNamedTxManager(int id);
         Result<Integer, String> insertWithNamedTxManagerAndErr(int id);
+        Result<Integer, String> selectReadOnly(int id);
     }
 
     static class ResultServiceImpl implements ResultService {
@@ -137,6 +148,12 @@ class TransactionalResultAspectTest extends AbstractH2AspectTestBase {
         public Result<Integer, String> insertWithNamedTxManagerAndErr(int id) {
             jdbc.update("INSERT INTO events VALUES (?, 'named-err')", id);
             return Result.err("named-error");
+        }
+
+        @Override
+        @TransactionalResult(readOnly = true)
+        public Result<Integer, String> selectReadOnly(int id) {
+            return Result.ok(id);
         }
     }
 

--- a/spring/src/test/java/dmx/fun/spring/TransactionalResultContractTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalResultContractTest.java
@@ -1,0 +1,280 @@
+package dmx.fun.spring;
+
+import dmx.fun.Result;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests verifying that {@link TransactionalResult} propagation settings
+ * behave consistently with Spring's {@link org.springframework.transaction.annotation.Transactional}
+ * contract.
+ *
+ * <p>Each propagation mode is exercised in both its success and failure paths to confirm
+ * that commit/rollback semantics match Spring's documented behaviour:
+ * <ul>
+ *   <li>{@code REQUIRED} — joins an existing outer transaction; inner error marks the
+ *       shared transaction globally rollback-only, causing the outer commit to throw
+ *       {@link UnexpectedRollbackException}.</li>
+ *   <li>{@code REQUIRES_NEW} — suspends the outer transaction and starts an independent
+ *       one; commit/rollback of the inner transaction does not affect the outer.</li>
+ *   <li>{@code MANDATORY} — throws {@link IllegalTransactionStateException} when no
+ *       active transaction is present.</li>
+ *   <li>{@code NEVER} — throws {@link IllegalTransactionStateException} when an active
+ *       transaction is present.</li>
+ *   <li>{@code SUPPORTS} — runs non-transactionally (auto-commit) when no outer tx is
+ *       present; an error return cannot roll back what was already auto-committed.</li>
+ *   <li>{@code NOT_SUPPORTED} — suspends the outer transaction; the inner method runs
+ *       without a transaction (auto-commit), so its work persists regardless of what
+ *       the outer transaction does.</li>
+ * </ul>
+ */
+class TransactionalResultContractTest extends AbstractH2AspectTestBase {
+
+    static ContractService service;
+
+    @BeforeAll
+    static void startContext() {
+        initContext(ServiceConfig.class);
+        service = ctx.getBean(ContractService.class);
+    }
+
+    // ── Propagation.REQUIRED ─────────────────────────────────────────────────
+
+    @Test
+    void required_joinsOuterTx_outerRollback_undoesInnerWork() {
+        // Inner joins the outer tx; outer rollback cascades to inner work.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            service.insertRequiredAndOk(1);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void required_joinsOuterTx_innerErr_causesUnexpectedRollbackOnOuterCommit() {
+        // Inner error calls setRollbackOnly() on the shared tx (global rollback-only).
+        // The outer template then throws UnexpectedRollbackException on commit.
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertRequiredAndErr(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.REQUIRES_NEW ─────────────────────────────────────────────
+
+    @Test
+    void requiresNew_innerOk_commitsImmediately_outerRollbackDoesNotUndoInner() {
+        // Inner tx commits independently; outer rollback cannot undo already-committed work.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (100, 'outer')");
+            service.insertRequiresNewAndOk(101);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 101", Integer.class)
+        ).isEqualTo(1);
+    }
+
+    @Test
+    void requiresNew_innerErr_rollsBackInnerOnly_outerCommitsItsWork() {
+        // Inner error rolls back only the inner tx; outer is unaffected.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (200, 'outer')");
+            service.insertRequiresNewAndErr(201);
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 200", Integer.class)
+        ).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 201", Integer.class)
+        ).isEqualTo(0);
+    }
+
+    // ── Propagation.MANDATORY ────────────────────────────────────────────────
+
+    @Test
+    void mandatory_throwsWhenNoActiveTx() {
+        assertThatThrownBy(() -> service.insertMandatoryAndOk(1))
+            .isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void mandatory_participatesInActiveTx() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            var result = service.insertMandatoryAndOk(1);
+            assertThat(result).isOk();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Propagation.NEVER ────────────────────────────────────────────────────
+
+    @Test
+    void never_throwsWhenActiveTxPresent() {
+        // The thrown IllegalTransactionStateException propagates through the outer
+        // template, which rolls the outer tx back before rethrowing.
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertNeverAndOk(1);
+                return null;
+            })
+        ).isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void never_runsWithoutTx_whenNoActiveTx() {
+        // No outer tx: method executes and the insert auto-commits.
+        var result = service.insertNeverAndOk(1);
+        assertThat(result).isOk();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Propagation.SUPPORTS ─────────────────────────────────────────────────
+
+    @Test
+    void supports_withoutActiveTx_errDoesNotRollBack() {
+        // Without an outer tx the method runs on an auto-commit connection.
+        // An error return has nothing to roll back, so the insert persists.
+        var result = service.insertSupportsAndErr(1);
+        assertThat(result).isErr();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    @Test
+    void supports_withinActiveTx_errMarksGlobalRollbackOnly() {
+        // Within an outer tx, SUPPORTS behaves like REQUIRED: the inner error marks
+        // the shared tx globally rollback-only, causing UnexpectedRollbackException.
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertSupportsAndErr(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.NOT_SUPPORTED ────────────────────────────────────────────
+
+    @Test
+    void notSupported_withinActiveTx_innerInsertPersists_outerRollbackDoesNotAffectInner() {
+        // NOT_SUPPORTED suspends the outer tx; the inner method runs on a fresh
+        // auto-commit connection, so its insert persists even after the outer rolls back.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (300, 'outer')");
+            service.insertNotSupportedAndErr(301);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 301", Integer.class)
+        ).isEqualTo(1);
+    }
+
+    // ── Service ──────────────────────────────────────────────────────────────
+
+    interface ContractService {
+        Result<Integer, String> insertRequiredAndOk(int id);
+        Result<Integer, String> insertRequiredAndErr(int id);
+        Result<Integer, String> insertRequiresNewAndOk(int id);
+        Result<Integer, String> insertRequiresNewAndErr(int id);
+        Result<Integer, String> insertMandatoryAndOk(int id);
+        Result<Integer, String> insertNeverAndOk(int id);
+        Result<Integer, String> insertSupportsAndErr(int id);
+        Result<Integer, String> insertNotSupportedAndErr(int id);
+    }
+
+    static class ContractServiceImpl implements ContractService {
+        private final JdbcTemplate jdbc;
+
+        ContractServiceImpl(JdbcTemplate jdbc) {
+            this.jdbc = jdbc;
+        }
+
+        @Override
+        @TransactionalResult
+        public Result<Integer, String> insertRequiredAndOk(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-ok')", id);
+            return Result.ok(id);
+        }
+
+        @Override
+        @TransactionalResult
+        public Result<Integer, String> insertRequiredAndErr(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-err')", id);
+            return Result.err("err");
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.REQUIRES_NEW)
+        public Result<Integer, String> insertRequiresNewAndOk(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-ok')", id);
+            return Result.ok(id);
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.REQUIRES_NEW)
+        public Result<Integer, String> insertRequiresNewAndErr(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-err')", id);
+            return Result.err("err");
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.MANDATORY)
+        public Result<Integer, String> insertMandatoryAndOk(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'mand-ok')", id);
+            return Result.ok(id);
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.NEVER)
+        public Result<Integer, String> insertNeverAndOk(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'never-ok')", id);
+            return Result.ok(id);
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.SUPPORTS)
+        public Result<Integer, String> insertSupportsAndErr(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'supp-err')", id);
+            return Result.err("err");
+        }
+
+        @Override
+        @TransactionalResult(propagation = Propagation.NOT_SUPPORTED)
+        public Result<Integer, String> insertNotSupportedAndErr(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'notsup-err')", id);
+            return Result.err("err");
+        }
+    }
+
+    @Configuration
+    static class ServiceConfig {
+        @Bean
+        ContractServiceImpl contractService(JdbcTemplate jdbcTemplate) {
+            return new ContractServiceImpl(jdbcTemplate);
+        }
+    }
+}

--- a/spring/src/test/java/dmx/fun/spring/TransactionalTryContractTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalTryContractTest.java
@@ -20,15 +20,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * behave consistently with Spring's {@link org.springframework.transaction.annotation.Transactional}
  * contract.
  *
- * <p>Covers the subset of propagation modes that are most likely to vary in
- * behaviour for {@code Try}-returning methods:
+ * <p>Each propagation mode is exercised in both its success and failure paths to confirm
+ * that commit/rollback semantics match Spring's documented behaviour:
  * <ul>
  *   <li>{@code REQUIRED} — joins an existing outer transaction; inner failure marks
- *       the shared transaction globally rollback-only.</li>
- *   <li>{@code REQUIRES_NEW} — independent inner transaction; commit/rollback does
- *       not affect the outer.</li>
+ *       the shared transaction globally rollback-only, causing the outer commit to throw
+ *       {@link org.springframework.transaction.UnexpectedRollbackException}.</li>
+ *   <li>{@code REQUIRES_NEW} — suspends the outer transaction and starts an independent
+ *       one; commit/rollback of the inner transaction does not affect the outer.</li>
  *   <li>{@code MANDATORY} — throws {@link IllegalTransactionStateException} when no
  *       active transaction is present.</li>
+ *   <li>{@code NEVER} — throws {@link IllegalTransactionStateException} when an active
+ *       transaction is present.</li>
+ *   <li>{@code SUPPORTS} — runs non-transactionally (auto-commit) when no outer tx is
+ *       present; a failure return cannot roll back what was already auto-committed.</li>
+ *   <li>{@code NOT_SUPPORTED} — suspends the outer transaction; the inner method runs
+ *       without a transaction (auto-commit), so its work persists regardless of what
+ *       the outer transaction does.</li>
  * </ul>
  */
 class TransactionalTryContractTest extends AbstractH2AspectTestBase {
@@ -115,6 +123,68 @@ class TransactionalTryContractTest extends AbstractH2AspectTestBase {
         Assertions.assertThat(countRows()).isEqualTo(1);
     }
 
+    // ── Propagation.NEVER ────────────────────────────────────────────────────
+
+    @Test
+    void never_throwsWhenActiveTxPresent() {
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertNeverAndSucceed(1);
+                return null;
+            })
+        ).isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void never_runsWithoutTx_whenNoActiveTx() {
+        var result = service.insertNeverAndSucceed(1);
+        assertThat(result).isSuccess();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Propagation.SUPPORTS ─────────────────────────────────────────────────
+
+    @Test
+    void supports_withoutActiveTx_failDoesNotRollBack() {
+        // Without an outer tx the method runs on an auto-commit connection.
+        // A failure return has nothing to roll back, so the insert persists.
+        var result = service.insertSupportsAndFail(1);
+        assertThat(result).isFailure();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    @Test
+    void supports_withinActiveTx_failMarksGlobalRollbackOnly() {
+        // Within an outer tx, SUPPORTS behaves like REQUIRED: the inner failure
+        // marks the shared tx globally rollback-only, causing UnexpectedRollbackException.
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertSupportsAndFail(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.NOT_SUPPORTED ────────────────────────────────────────────
+
+    @Test
+    void notSupported_withinActiveTx_innerInsertPersists_outerRollbackDoesNotAffectInner() {
+        // NOT_SUPPORTED suspends the outer tx; the inner method runs on a fresh
+        // auto-commit connection, so its insert persists even after the outer rolls back.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (300, 'outer')");
+            service.insertNotSupportedAndFail(301);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 301", Integer.class)
+        ).isEqualTo(1);
+    }
+
     // ── Service ──────────────────────────────────────────────────────────────
 
     interface ContractService {
@@ -123,6 +193,9 @@ class TransactionalTryContractTest extends AbstractH2AspectTestBase {
         Try<Integer> insertRequiresNewAndSucceed(int id);
         Try<Integer> insertRequiresNewAndFail(int id);
         Try<Integer> insertMandatoryAndSucceed(int id);
+        Try<Integer> insertNeverAndSucceed(int id);
+        Try<Integer> insertSupportsAndFail(int id);
+        Try<Integer> insertNotSupportedAndFail(int id);
     }
 
     static class ContractServiceImpl implements ContractService {
@@ -165,6 +238,27 @@ class TransactionalTryContractTest extends AbstractH2AspectTestBase {
         public Try<Integer> insertMandatoryAndSucceed(int id) {
             jdbc.update("INSERT INTO events VALUES (?, 'mand-ok')", id);
             return Try.success(id);
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.NEVER)
+        public Try<Integer> insertNeverAndSucceed(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'never-ok')", id);
+            return Try.success(id);
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.SUPPORTS)
+        public Try<Integer> insertSupportsAndFail(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'supp-fail')", id);
+            return Try.failure(new RuntimeException("fail"));
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.NOT_SUPPORTED)
+        public Try<Integer> insertNotSupportedAndFail(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'notsup-fail')", id);
+            return Try.failure(new RuntimeException("fail"));
         }
     }
 

--- a/spring/src/test/java/dmx/fun/spring/TransactionalTryContractTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalTryContractTest.java
@@ -1,0 +1,178 @@
+package dmx.fun.spring;
+
+import dmx.fun.Try;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests verifying that {@link TransactionalTry} propagation settings
+ * behave consistently with Spring's {@link org.springframework.transaction.annotation.Transactional}
+ * contract.
+ *
+ * <p>Covers the subset of propagation modes that are most likely to vary in
+ * behaviour for {@code Try}-returning methods:
+ * <ul>
+ *   <li>{@code REQUIRED} — joins an existing outer transaction; inner failure marks
+ *       the shared transaction globally rollback-only.</li>
+ *   <li>{@code REQUIRES_NEW} — independent inner transaction; commit/rollback does
+ *       not affect the outer.</li>
+ *   <li>{@code MANDATORY} — throws {@link IllegalTransactionStateException} when no
+ *       active transaction is present.</li>
+ * </ul>
+ */
+class TransactionalTryContractTest extends AbstractH2AspectTestBase {
+
+    static ContractService service;
+
+    @BeforeAll
+    static void startContext() {
+        initContext(ServiceConfig.class);
+        service = ctx.getBean(ContractService.class);
+    }
+
+    // ── Propagation.REQUIRED ─────────────────────────────────────────────────
+
+    @Test
+    void required_joinsOuterTx_innerFailure_causesUnexpectedRollbackOnOuterCommit() {
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertRequiredAndFail(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void required_joinsOuterTx_outerRollback_undoesInnerWork() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            service.insertRequiredAndSucceed(1);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.REQUIRES_NEW ─────────────────────────────────────────────
+
+    @Test
+    void requiresNew_innerSucceed_commitsImmediately_outerRollbackDoesNotUndoInner() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (100, 'outer')");
+            service.insertRequiresNewAndSucceed(101);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 101", Integer.class)
+        ).isEqualTo(1);
+    }
+
+    @Test
+    void requiresNew_innerFail_rollsBackInnerOnly_outerCommitsItsWork() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (200, 'outer')");
+            service.insertRequiresNewAndFail(201);
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 200", Integer.class)
+        ).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 201", Integer.class)
+        ).isEqualTo(0);
+    }
+
+    // ── Propagation.MANDATORY ────────────────────────────────────────────────
+
+    @Test
+    void mandatory_throwsWhenNoActiveTx() {
+        assertThatThrownBy(() -> service.insertMandatoryAndSucceed(1))
+            .isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void mandatory_participatesInActiveTx() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            var result = service.insertMandatoryAndSucceed(1);
+            assertThat(result).isSuccess();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Service ──────────────────────────────────────────────────────────────
+
+    interface ContractService {
+        Try<Integer> insertRequiredAndSucceed(int id);
+        Try<Integer> insertRequiredAndFail(int id);
+        Try<Integer> insertRequiresNewAndSucceed(int id);
+        Try<Integer> insertRequiresNewAndFail(int id);
+        Try<Integer> insertMandatoryAndSucceed(int id);
+    }
+
+    static class ContractServiceImpl implements ContractService {
+        private final JdbcTemplate jdbc;
+
+        ContractServiceImpl(JdbcTemplate jdbc) {
+            this.jdbc = jdbc;
+        }
+
+        @Override
+        @TransactionalTry
+        public Try<Integer> insertRequiredAndSucceed(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-ok')", id);
+            return Try.success(id);
+        }
+
+        @Override
+        @TransactionalTry
+        public Try<Integer> insertRequiredAndFail(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-fail')", id);
+            return Try.failure(new RuntimeException("fail"));
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.REQUIRES_NEW)
+        public Try<Integer> insertRequiresNewAndSucceed(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-ok')", id);
+            return Try.success(id);
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.REQUIRES_NEW)
+        public Try<Integer> insertRequiresNewAndFail(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-fail')", id);
+            return Try.failure(new RuntimeException("fail"));
+        }
+
+        @Override
+        @TransactionalTry(propagation = Propagation.MANDATORY)
+        public Try<Integer> insertMandatoryAndSucceed(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'mand-ok')", id);
+            return Try.success(id);
+        }
+    }
+
+    @Configuration
+    static class ServiceConfig {
+        @Bean
+        ContractServiceImpl contractService(JdbcTemplate jdbcTemplate) {
+            return new ContractServiceImpl(jdbcTemplate);
+        }
+    }
+}

--- a/spring/src/test/java/dmx/fun/spring/TransactionalValidatedContractTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalValidatedContractTest.java
@@ -1,0 +1,178 @@
+package dmx.fun.spring;
+
+import dmx.fun.Validated;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests verifying that {@link TransactionalValidated} propagation settings
+ * behave consistently with Spring's {@link org.springframework.transaction.annotation.Transactional}
+ * contract.
+ *
+ * <p>Covers the subset of propagation modes that are most likely to vary in
+ * behaviour for {@code Validated}-returning methods:
+ * <ul>
+ *   <li>{@code REQUIRED} — joins an existing outer transaction; inner invalid result
+ *       marks the shared transaction globally rollback-only.</li>
+ *   <li>{@code REQUIRES_NEW} — independent inner transaction; commit/rollback does
+ *       not affect the outer.</li>
+ *   <li>{@code MANDATORY} — throws {@link IllegalTransactionStateException} when no
+ *       active transaction is present.</li>
+ * </ul>
+ */
+class TransactionalValidatedContractTest extends AbstractH2AspectTestBase {
+
+    static ContractService service;
+
+    @BeforeAll
+    static void startContext() {
+        initContext(ServiceConfig.class);
+        service = ctx.getBean(ContractService.class);
+    }
+
+    // ── Propagation.REQUIRED ─────────────────────────────────────────────────
+
+    @Test
+    void required_joinsOuterTx_innerInvalid_causesUnexpectedRollbackOnOuterCommit() {
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertRequiredAndInvalid(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void required_joinsOuterTx_outerRollback_undoesInnerWork() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            service.insertRequiredAndValid(1);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.REQUIRES_NEW ─────────────────────────────────────────────
+
+    @Test
+    void requiresNew_innerValid_commitsImmediately_outerRollbackDoesNotUndoInner() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (100, 'outer')");
+            service.insertRequiresNewAndValid(101);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 101", Integer.class)
+        ).isEqualTo(1);
+    }
+
+    @Test
+    void requiresNew_innerInvalid_rollsBackInnerOnly_outerCommitsItsWork() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (200, 'outer')");
+            service.insertRequiresNewAndInvalid(201);
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 200", Integer.class)
+        ).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 201", Integer.class)
+        ).isEqualTo(0);
+    }
+
+    // ── Propagation.MANDATORY ────────────────────────────────────────────────
+
+    @Test
+    void mandatory_throwsWhenNoActiveTx() {
+        assertThatThrownBy(() -> service.insertMandatoryAndValid(1))
+            .isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void mandatory_participatesInActiveTx() {
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            var result = service.insertMandatoryAndValid(1);
+            assertThat(result).isValid();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Service ──────────────────────────────────────────────────────────────
+
+    interface ContractService {
+        Validated<String, Integer> insertRequiredAndValid(int id);
+        Validated<String, Integer> insertRequiredAndInvalid(int id);
+        Validated<String, Integer> insertRequiresNewAndValid(int id);
+        Validated<String, Integer> insertRequiresNewAndInvalid(int id);
+        Validated<String, Integer> insertMandatoryAndValid(int id);
+    }
+
+    static class ContractServiceImpl implements ContractService {
+        private final JdbcTemplate jdbc;
+
+        ContractServiceImpl(JdbcTemplate jdbc) {
+            this.jdbc = jdbc;
+        }
+
+        @Override
+        @TransactionalValidated
+        public Validated<String, Integer> insertRequiredAndValid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-ok')", id);
+            return Validated.valid(id);
+        }
+
+        @Override
+        @TransactionalValidated
+        public Validated<String, Integer> insertRequiredAndInvalid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'req-inv')", id);
+            return Validated.invalid("invalid");
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.REQUIRES_NEW)
+        public Validated<String, Integer> insertRequiresNewAndValid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-ok')", id);
+            return Validated.valid(id);
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.REQUIRES_NEW)
+        public Validated<String, Integer> insertRequiresNewAndInvalid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'new-inv')", id);
+            return Validated.invalid("invalid");
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.MANDATORY)
+        public Validated<String, Integer> insertMandatoryAndValid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'mand-ok')", id);
+            return Validated.valid(id);
+        }
+    }
+
+    @Configuration
+    static class ServiceConfig {
+        @Bean
+        ContractServiceImpl contractService(JdbcTemplate jdbcTemplate) {
+            return new ContractServiceImpl(jdbcTemplate);
+        }
+    }
+}

--- a/spring/src/test/java/dmx/fun/spring/TransactionalValidatedContractTest.java
+++ b/spring/src/test/java/dmx/fun/spring/TransactionalValidatedContractTest.java
@@ -20,15 +20,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * behave consistently with Spring's {@link org.springframework.transaction.annotation.Transactional}
  * contract.
  *
- * <p>Covers the subset of propagation modes that are most likely to vary in
- * behaviour for {@code Validated}-returning methods:
+ * <p>Each propagation mode is exercised in both its success and failure paths to confirm
+ * that commit/rollback semantics match Spring's documented behaviour:
  * <ul>
  *   <li>{@code REQUIRED} — joins an existing outer transaction; inner invalid result
- *       marks the shared transaction globally rollback-only.</li>
- *   <li>{@code REQUIRES_NEW} — independent inner transaction; commit/rollback does
- *       not affect the outer.</li>
+ *       marks the shared transaction globally rollback-only, causing the outer commit to
+ *       throw {@link org.springframework.transaction.UnexpectedRollbackException}.</li>
+ *   <li>{@code REQUIRES_NEW} — suspends the outer transaction and starts an independent
+ *       one; commit/rollback of the inner transaction does not affect the outer.</li>
  *   <li>{@code MANDATORY} — throws {@link IllegalTransactionStateException} when no
  *       active transaction is present.</li>
+ *   <li>{@code NEVER} — throws {@link IllegalTransactionStateException} when an active
+ *       transaction is present.</li>
+ *   <li>{@code SUPPORTS} — runs non-transactionally (auto-commit) when no outer tx is
+ *       present; an invalid return cannot roll back what was already auto-committed.</li>
+ *   <li>{@code NOT_SUPPORTED} — suspends the outer transaction; the inner method runs
+ *       without a transaction (auto-commit), so its work persists regardless of what
+ *       the outer transaction does.</li>
  * </ul>
  */
 class TransactionalValidatedContractTest extends AbstractH2AspectTestBase {
@@ -115,6 +123,68 @@ class TransactionalValidatedContractTest extends AbstractH2AspectTestBase {
         Assertions.assertThat(countRows()).isEqualTo(1);
     }
 
+    // ── Propagation.NEVER ────────────────────────────────────────────────────
+
+    @Test
+    void never_throwsWhenActiveTxPresent() {
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertNeverAndValid(1);
+                return null;
+            })
+        ).isInstanceOf(IllegalTransactionStateException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    @Test
+    void never_runsWithoutTx_whenNoActiveTx() {
+        var result = service.insertNeverAndValid(1);
+        assertThat(result).isValid();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    // ── Propagation.SUPPORTS ─────────────────────────────────────────────────
+
+    @Test
+    void supports_withoutActiveTx_invalidDoesNotRollBack() {
+        // Without an outer tx the method runs on an auto-commit connection.
+        // An invalid return has nothing to roll back, so the insert persists.
+        var result = service.insertSupportsAndInvalid(1);
+        assertThat(result).isInvalid();
+        Assertions.assertThat(countRows()).isEqualTo(1);
+    }
+
+    @Test
+    void supports_withinActiveTx_invalidMarksGlobalRollbackOnly() {
+        // Within an outer tx, SUPPORTS behaves like REQUIRED: the inner invalid result
+        // marks the shared tx globally rollback-only, causing UnexpectedRollbackException.
+        assertThatThrownBy(() ->
+            new TransactionTemplate(primaryRecording).execute(status -> {
+                service.insertSupportsAndInvalid(1);
+                return null;
+            })
+        ).isInstanceOf(UnexpectedRollbackException.class);
+        Assertions.assertThat(countRows()).isEqualTo(0);
+    }
+
+    // ── Propagation.NOT_SUPPORTED ────────────────────────────────────────────
+
+    @Test
+    void notSupported_withinActiveTx_innerInsertPersists_outerRollbackDoesNotAffectInner() {
+        // NOT_SUPPORTED suspends the outer tx; the inner method runs on a fresh
+        // auto-commit connection, so its insert persists even after the outer rolls back.
+        new TransactionTemplate(primaryRecording).execute(status -> {
+            jdbc.update("INSERT INTO events VALUES (300, 'outer')");
+            service.insertNotSupportedAndInvalid(301);
+            status.setRollbackOnly();
+            return null;
+        });
+        Assertions.assertThat(countRows()).isEqualTo(1);
+        Assertions.assertThat(
+            jdbc.queryForObject("SELECT COUNT(*) FROM events WHERE id = 301", Integer.class)
+        ).isEqualTo(1);
+    }
+
     // ── Service ──────────────────────────────────────────────────────────────
 
     interface ContractService {
@@ -123,6 +193,9 @@ class TransactionalValidatedContractTest extends AbstractH2AspectTestBase {
         Validated<String, Integer> insertRequiresNewAndValid(int id);
         Validated<String, Integer> insertRequiresNewAndInvalid(int id);
         Validated<String, Integer> insertMandatoryAndValid(int id);
+        Validated<String, Integer> insertNeverAndValid(int id);
+        Validated<String, Integer> insertSupportsAndInvalid(int id);
+        Validated<String, Integer> insertNotSupportedAndInvalid(int id);
     }
 
     static class ContractServiceImpl implements ContractService {
@@ -165,6 +238,27 @@ class TransactionalValidatedContractTest extends AbstractH2AspectTestBase {
         public Validated<String, Integer> insertMandatoryAndValid(int id) {
             jdbc.update("INSERT INTO events VALUES (?, 'mand-ok')", id);
             return Validated.valid(id);
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.NEVER)
+        public Validated<String, Integer> insertNeverAndValid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'never-ok')", id);
+            return Validated.valid(id);
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.SUPPORTS)
+        public Validated<String, Integer> insertSupportsAndInvalid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'supp-inv')", id);
+            return Validated.invalid("invalid");
+        }
+
+        @Override
+        @TransactionalValidated(propagation = Propagation.NOT_SUPPORTED)
+        public Validated<String, Integer> insertNotSupportedAndInvalid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'notsup-inv')", id);
+            return Validated.invalid("invalid");
         }
     }
 


### PR DESCRIPTION
  Add readOnly() to @TransactionalResult, @TransactionalTry, and
  @TransactionalValidated, wiring it through DmxTransactionalAspect into
  DefaultTransactionDefinition.setReadOnly(). RecordingTxManager now
  captures the last TransactionDefinition so tests can assert on it.

  Add TransactionalResultAspectTest.readOnly_forwardsHintToTransactionManager
  to verify the hint reaches the transaction manager.

  Add propagation contract tests (TransactionalResultContractTest,
  TransactionalTryContractTest, TransactionalValidatedContractTest) that
  verify all propagation modes — REQUIRED, REQUIRES_NEW, MANDATORY, NEVER,
  SUPPORTS, NOT_SUPPORTED — behave consistently with Spring's @Transactional
  contract against a real H2 database.

  Update the Spring integration guide: add readOnly to the attribute table
  with an explanatory note, and add a readOnly usage example to the
  transactional-attributes code snippet.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #284

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readOnly transaction attribute to transaction annotations and a new read-only example API method for listing receipts.

* **Documentation**
  * Transaction attributes table updated to document the new readOnly option and clarify timeout defaults.

* **Tests**
  * Added contract and unit tests to validate readOnly propagation and transactional behavior across propagation modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->