### PR TITLE
test(spring-boot): add end-to-end transaction and aspect integration tests

### DIFF
--- a/spring-boot/build.gradle
+++ b/spring-boot/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     testImplementation project(':observation')
     testImplementation "io.micrometer:micrometer-core:${micrometerVersion}"
     testImplementation "io.micrometer:micrometer-observation-test:${micrometerVersion}"
+
+    // Integration tests — real transaction commit/rollback against H2 embedded database.
+    testImplementation libs.h2
+    testImplementation libs.spring.jdbc
 }
 
 // spring.boot.autoconfigure is required static (optional at runtime): add it

--- a/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunAspectBootIntegrationTest.java
+++ b/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunAspectBootIntegrationTest.java
@@ -1,0 +1,254 @@
+package dmx.fun.spring.boot;
+
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Validated;
+import dmx.fun.spring.TransactionalResult;
+import dmx.fun.spring.TransactionalTry;
+import dmx.fun.spring.TransactionalValidated;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration tests for the auto-configured {@link dmx.fun.spring.DmxTransactionalAspect}
+ * in a Spring Boot context.
+ *
+ * <p>Verifies that {@code @TransactionalResult}, {@code @TransactionalTry}, and
+ * {@code @TransactionalValidated} annotations are intercepted by the auto-configured aspect
+ * and that the correct commit/rollback semantics are applied for each outcome.
+ *
+ * <p>Also documents the proxy self-call limitation: a method that calls another
+ * annotated method within the same bean bypasses the AOP proxy, so the inner
+ * annotation has no effect and the INSERT auto-commits regardless of the returned
+ * value.
+ *
+ * @see DmxFunTransactionBootIntegrationTest
+ */
+class DmxFunAspectBootIntegrationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(DmxFunSpringAutoConfiguration.class))
+        .withUserConfiguration(H2Config.class, EventServiceConfig.class);
+
+    // ── @TransactionalResult ─────────────────────────────────────────────────
+
+    @Test
+    void transactionalResult_ok_commits() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insert(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void transactionalResult_error_rollsBack() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insertAndFail(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void transactionalResult_exception_rollsBackAndPropagates() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            assertThatThrownBy(() -> service.insertAndThrow(1))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("unexpected");
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── @TransactionalTry ─────────────────────────────────────────────────────
+
+    @Test
+    void transactionalTry_success_commits() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insertAsTry(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void transactionalTry_failure_rollsBack() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insertAsTryFailure(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── @TransactionalValidated ───────────────────────────────────────────────
+
+    @Test
+    void transactionalValidated_valid_commits() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insertAsValidated(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void transactionalValidated_invalid_rollsBack() {
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            service.insertAsValidatedInvalid(1);
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── Proxy self-call boundary ──────────────────────────────────────────────
+
+    @Test
+    void selfCall_doesNotIntercept_insertAutoCommits() {
+        // Spring AOP proxies only intercept calls coming in from outside the bean.
+        // When a method calls another @TransactionalResult method on the same instance
+        // ('this.insertAndFail(...)'), the call bypasses the proxy and the aspect is
+        // never invoked. The INSERT runs without a managed transaction and auto-commits,
+        // so the row is present even though the returned Result is an error.
+        runner.run(ctx -> {
+            var service = ctx.getBean(EventService.class);
+            var jdbc    = ctx.getBean(JdbcTemplate.class);
+
+            var result = service.selfCallInsertAndFail(1);
+
+            assertThat(result.isError()).isTrue();
+            assertThat(rowCount(jdbc)).isEqualTo(1);  // not rolled back — proxy bypassed
+        });
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static int rowCount(JdbcTemplate jdbc) {
+        var count = jdbc.queryForObject("SELECT COUNT(*) FROM events", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    // ── Test configurations ───────────────────────────────────────────────────
+
+    @Configuration
+    static class H2Config {
+
+        @Bean(destroyMethod = "shutdown")
+        EmbeddedDatabase dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .generateUniqueName(true)
+                .build();
+        }
+
+        @Bean
+        JdbcTemplate jdbcTemplate(EmbeddedDatabase ds) {
+            var jdbc = new JdbcTemplate(ds);
+            jdbc.execute("CREATE TABLE events (id INT PRIMARY KEY, label VARCHAR(255))");
+            return jdbc;
+        }
+
+        @Bean
+        PlatformTransactionManager txManager(EmbeddedDatabase ds) {
+            return new DataSourceTransactionManager(ds);
+        }
+    }
+
+    @Configuration
+    static class EventServiceConfig {
+        @Bean
+        EventService eventService(JdbcTemplate jdbc) {
+            return new EventService(jdbc);
+        }
+    }
+
+    // ── Service under test ────────────────────────────────────────────────────
+
+    static class EventService {
+
+        private final JdbcTemplate jdbc;
+
+        EventService(JdbcTemplate jdbc) { this.jdbc = jdbc; }
+
+        @TransactionalResult
+        public Result<String, String> insert(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Result.ok("inserted");
+        }
+
+        @TransactionalResult
+        public Result<String, String> insertAndFail(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Result.err("intentional failure");
+        }
+
+        @TransactionalResult
+        public Result<String, String> insertAndThrow(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            throw new RuntimeException("unexpected");
+        }
+
+        @TransactionalTry
+        public Try<String> insertAsTry(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Try.success("inserted");
+        }
+
+        @TransactionalTry
+        public Try<String> insertAsTryFailure(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Try.failure(new RuntimeException("caught failure"));
+        }
+
+        @TransactionalValidated
+        public Validated<String, String> insertAsValidated(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Validated.valid("inserted");
+        }
+
+        @TransactionalValidated
+        public Validated<String, String> insertAsValidatedInvalid(int id) {
+            jdbc.update("INSERT INTO events VALUES (?, 'label')", id);
+            return Validated.invalid("intentional invalid");
+        }
+
+        // No annotation here. Calls annotated insertAndFail directly on 'this',
+        // which bypasses the proxy — the aspect is never invoked.
+        public Result<String, String> selfCallInsertAndFail(int id) {
+            return insertAndFail(id);
+        }
+    }
+}

--- a/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunSpringAutoConfigurationTest.java
+++ b/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunSpringAutoConfigurationTest.java
@@ -68,6 +68,22 @@ class DmxFunSpringAutoConfigurationTest {
             .run(ctx -> assertThat(ctx).doesNotHaveBean(DmxTransactionalAspect.class));
     }
 
+    // ── @ConditionalOnSingleCandidate — multiple PTM ambiguity ───────────────
+
+    @Test
+    void doesNotRegisterBeans_whenMultiplePlatformTransactionManagers() {
+        // Two unambiguous PTMs → @ConditionalOnSingleCandidate blocks all beans.
+        new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(DmxFunSpringAutoConfiguration.class))
+            .withUserConfiguration(MultipleTxManagersConfig.class)
+            .run(ctx -> {
+                assertThat(ctx).doesNotHaveBean(TxResult.class);
+                assertThat(ctx).doesNotHaveBean(TxTry.class);
+                assertThat(ctx).doesNotHaveBean(TxValidated.class);
+                assertThat(ctx).doesNotHaveBean(DmxTransactionalAspect.class);
+            });
+    }
+
     // ── @ConditionalOnMissingBean back-off ────────────────────────────────────
 
     @Test
@@ -142,6 +158,12 @@ class DmxFunSpringAutoConfigurationTest {
                 org.springframework.beans.factory.BeanFactory beanFactory) {
             return new DmxTransactionalAspect(txManager, beanFactory);
         }
+    }
+
+    @Configuration
+    static class MultipleTxManagersConfig {
+        @Bean PlatformTransactionManager txManager1() { return new StubTxManager(); }
+        @Bean PlatformTransactionManager txManager2() { return new StubTxManager(); }
     }
 
 }

--- a/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunTransactionBootIntegrationTest.java
+++ b/spring-boot/src/test/java/dmx/fun/spring/boot/DmxFunTransactionBootIntegrationTest.java
@@ -1,0 +1,186 @@
+package dmx.fun.spring.boot;
+
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Validated;
+import dmx.fun.spring.TxResult;
+import dmx.fun.spring.TxTry;
+import dmx.fun.spring.TxValidated;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end integration tests for auto-configured {@link TxResult}, {@link TxTry}, and
+ * {@link TxValidated} in a Spring Boot context backed by an H2 embedded database.
+ *
+ * <p>These tests verify commit/rollback semantics of the programmatic transaction helpers
+ * as wired by {@link DmxFunSpringAutoConfiguration}. Each scenario uses a fresh H2
+ * instance (unique database name) so tests are fully independent.
+ *
+ * @see DmxFunSpringAutoConfigurationTest
+ * @see DmxFunAspectBootIntegrationTest
+ */
+class DmxFunTransactionBootIntegrationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(DmxFunSpringAutoConfiguration.class))
+        .withUserConfiguration(H2Config.class);
+
+    // ── TxResult ──────────────────────────────────────────────────────────────
+
+    @Test
+    void txResult_ok_commits() {
+        runner.run(ctx -> {
+            var txResult = ctx.getBean(TxResult.class);
+            var jdbc     = ctx.getBean(JdbcTemplate.class);
+
+            txResult.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Result.ok("done");
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void txResult_error_rollsBack() {
+        runner.run(ctx -> {
+            var txResult = ctx.getBean(TxResult.class);
+            var jdbc     = ctx.getBean(JdbcTemplate.class);
+
+            txResult.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Result.err("domain failure");
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void txResult_exception_rollsBackAndPropagates() {
+        runner.run(ctx -> {
+            var txResult = ctx.getBean(TxResult.class);
+            var jdbc     = ctx.getBean(JdbcTemplate.class);
+
+            assertThatThrownBy(() ->
+                txResult.execute(() -> {
+                    jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                    throw new RuntimeException("unexpected");
+                })
+            ).isInstanceOf(RuntimeException.class);
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── TxTry ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void txTry_success_commits() {
+        runner.run(ctx -> {
+            var txTry = ctx.getBean(TxTry.class);
+            var jdbc  = ctx.getBean(JdbcTemplate.class);
+
+            txTry.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Try.success("done");
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void txTry_failure_rollsBack() {
+        runner.run(ctx -> {
+            var txTry = ctx.getBean(TxTry.class);
+            var jdbc  = ctx.getBean(JdbcTemplate.class);
+
+            txTry.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Try.failure(new RuntimeException("caught failure"));
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── TxValidated ───────────────────────────────────────────────────────────
+
+    @Test
+    void txValidated_valid_commits() {
+        runner.run(ctx -> {
+            var txValidated = ctx.getBean(TxValidated.class);
+            var jdbc        = ctx.getBean(JdbcTemplate.class);
+
+            txValidated.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Validated.valid("done");
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void txValidated_invalid_rollsBack() {
+        runner.run(ctx -> {
+            var txValidated = ctx.getBean(TxValidated.class);
+            var jdbc        = ctx.getBean(JdbcTemplate.class);
+
+            txValidated.execute(() -> {
+                jdbc.update("INSERT INTO events VALUES (1, 'a')");
+                return Validated.invalid("validation failed");
+            });
+
+            assertThat(rowCount(jdbc)).isEqualTo(0);
+        });
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static int rowCount(JdbcTemplate jdbc) {
+        var count = jdbc.queryForObject("SELECT COUNT(*) FROM events", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    // ── Test configuration ────────────────────────────────────────────────────
+
+    @Configuration
+    static class H2Config {
+
+        @Bean(destroyMethod = "shutdown")
+        EmbeddedDatabase dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .generateUniqueName(true)
+                .build();
+        }
+
+        @Bean
+        JdbcTemplate jdbcTemplate(EmbeddedDatabase ds) {
+            var jdbc = new JdbcTemplate(ds);
+            jdbc.execute("CREATE TABLE events (id INT PRIMARY KEY, label VARCHAR(255))");
+            return jdbc;
+        }
+
+        @Bean
+        PlatformTransactionManager txManager(EmbeddedDatabase ds) {
+            return new DataSourceTransactionManager(ds);
+        }
+    }
+}


### PR DESCRIPTION
  - DmxFunTransactionBootIntegrationTest (7 tests): end-to-end commit/rollback
    for auto-configured TxResult, TxTry, and TxValidated against a real H2
    database via ApplicationContextRunner — covers ok/success/valid commits,
    error/failure/invalid rollbacks, and exception-driven rollback + propagation
  - DmxFunAspectBootIntegrationTest (8 tests): verifies the auto-configured
    DmxTransactionalAspect intercepts `@TransactionalResult`, `@TransactionalTry`,
    and `@TransactionalValidated` on proxied service beans; includes a dedicated
    test documenting the proxy self-call limitation (inner `@TransactionalResult`
    call on 'this' bypasses the proxy and auto-commits despite the error result)
  - DmxFunSpringAutoConfigurationTest: add doesNotRegisterBeans_whenMultiple
    PlatformTransactionManagers to verify `@ConditionalOnSingleCandidate` blocks
    registration when two unambiguous PTMs are present
  - build.gradle: add testImplementation for H2 and spring-jdbc

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #285

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for transactional behavior verification.
  * Added embedded database infrastructure to validate transaction commit and rollback semantics across multiple result types.
  * Verified auto-configuration behavior in multi-transaction manager scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->