### PR TITLE
refactor(resilience4j): import resilience4j-bom via platform() instead of per-artifact version strings

### DIFF
--- a/resilience4j/build.gradle
+++ b/resilience4j/build.gradle
@@ -13,15 +13,18 @@ def r4jVersion = findProperty('resilience4jVersion') ?: libs.versions.resilience
 dependencies {
     api project(':lib')
 
-    compileOnly "io.github.resilience4j:resilience4j-retry:${r4jVersion}"
-    compileOnly "io.github.resilience4j:resilience4j-circuitbreaker:${r4jVersion}"
-    compileOnly "io.github.resilience4j:resilience4j-ratelimiter:${r4jVersion}"
-    compileOnly "io.github.resilience4j:resilience4j-bulkhead:${r4jVersion}"
+    compileOnly     platform("io.github.resilience4j:resilience4j-bom:${r4jVersion}")
+    testImplementation platform("io.github.resilience4j:resilience4j-bom:${r4jVersion}")
 
-    testImplementation "io.github.resilience4j:resilience4j-retry:${r4jVersion}"
-    testImplementation "io.github.resilience4j:resilience4j-circuitbreaker:${r4jVersion}"
-    testImplementation "io.github.resilience4j:resilience4j-ratelimiter:${r4jVersion}"
-    testImplementation "io.github.resilience4j:resilience4j-bulkhead:${r4jVersion}"
+    compileOnly "io.github.resilience4j:resilience4j-retry"
+    compileOnly "io.github.resilience4j:resilience4j-circuitbreaker"
+    compileOnly "io.github.resilience4j:resilience4j-ratelimiter"
+    compileOnly "io.github.resilience4j:resilience4j-bulkhead"
+
+    testImplementation "io.github.resilience4j:resilience4j-retry"
+    testImplementation "io.github.resilience4j:resilience4j-circuitbreaker"
+    testImplementation "io.github.resilience4j:resilience4j-ratelimiter"
+    testImplementation "io.github.resilience4j:resilience4j-bulkhead"
 
     compileOnly        project(':assertj')
     testImplementation project(':assertj')


### PR DESCRIPTION
  Resolves #321.

  Replace eight explicit "artifact:${r4jVersion}" declarations with a single
  resilience4j-bom platform() import in both compileOnly and testImplementation
  scopes. Individual artifact declarations no longer carry a version string —
  the BOM manages alignment. The -PresilicE4jVersion=X.Y.Z CI override
  continues to work unchanged as it still targets the BOM version.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #321

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration for Resilience4j components to use centralized version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->