### PR TITLE
docs(lib): improve Javadoc for Results.Partition and Tries.Partition

### DIFF
--- a/lib/src/main/java/dmx/fun/Results.java
+++ b/lib/src/main/java/dmx/fun/Results.java
@@ -35,11 +35,13 @@ public final class Results {
      * Transparent alias for {@link Result.Partition} so callers can use {@code Results.Partition}
      * without importing {@link Result} directly.
      *
-     * @param <V> the value type of the {@code Ok} elements
-     * @param <E> the error type of the {@code Err} elements
+     * @param <V>    the value type of the {@code Ok} elements
+     * @param <E>    the error type of the {@code Err} elements
+     * @param oks    the list of successful values; must not be {@code null}
+     * @param errors the list of error values; must not be {@code null}
      */
     public record Partition<V, E>(List<V> oks, List<E> errors) {
-        /** Null-checks and defensively copies both lists. */
+        /** Validates non-null inputs and defensively copies both lists. */
         public Partition {
             Objects.requireNonNull(oks,    "oks");
             Objects.requireNonNull(errors, "errors");
@@ -47,7 +49,11 @@ public final class Results {
             errors = List.copyOf(errors);
         }
 
-        /** Converts to the underlying {@link Result.Partition}. */
+        /**
+         * Converts this partition to the underlying {@link Result.Partition}.
+         *
+         * @return a {@link Result.Partition} with the same {@code oks} and {@code errors} lists
+         */
         public Result.Partition<V, E> toResultPartition() {
             return new Result.Partition<>(oks, errors);
         }

--- a/lib/src/main/java/dmx/fun/Results.java
+++ b/lib/src/main/java/dmx/fun/Results.java
@@ -52,7 +52,8 @@ public final class Results {
         /**
          * Converts this partition to the underlying {@link Result.Partition}.
          *
-         * @return a {@link Result.Partition} with the same {@code oks} and {@code errors} lists
+         * @return a {@link Result.Partition} containing the same elements as this partition's
+         *         {@code oks} and {@code errors} collections
          */
         public Result.Partition<V, E> toResultPartition() {
             return new Result.Partition<>(oks, errors);

--- a/lib/src/main/java/dmx/fun/Tries.java
+++ b/lib/src/main/java/dmx/fun/Tries.java
@@ -48,7 +48,8 @@ public final class Tries {
         /**
          * Converts this partition to the underlying {@link Try.Partition}.
          *
-         * @return a {@link Try.Partition} with the same {@code successes} and {@code failures} lists
+         * @return a {@link Try.Partition} containing the same elements as this partition's
+         *         {@code successes} and {@code failures} collections
          */
         public Try.Partition<V> toTryPartition() {
             return new Try.Partition<>(successes, failures);

--- a/lib/src/main/java/dmx/fun/Tries.java
+++ b/lib/src/main/java/dmx/fun/Tries.java
@@ -33,17 +33,23 @@ public final class Tries {
      * Transparent alias for {@link Try.Partition} so callers can use {@code Tries.Partition}
      * without importing {@link Try} directly.
      *
-     * @param <V> the value type of the {@code Success} elements
+     * @param <V>       the value type of the {@code Success} elements
+     * @param successes the list of successful values; must not be {@code null}
+     * @param failures  the list of failure causes; must not be {@code null}
      */
     public record Partition<V>(List<V> successes, List<Throwable> failures) {
-        /** Delegates to {@link Try.Partition} for consistent null/copy semantics. */
+        /** Validates non-null inputs and defensively copies both lists. */
         public Partition {
             var delegate = new Try.Partition<>(successes, failures);
             successes = delegate.successes();
             failures  = delegate.failures();
         }
 
-        /** Converts to the underlying {@link Try.Partition}. */
+        /**
+         * Converts this partition to the underlying {@link Try.Partition}.
+         *
+         * @return a {@link Try.Partition} with the same {@code successes} and {@code failures} lists
+         */
         public Try.Partition<V> toTryPartition() {
             return new Try.Partition<>(successes, failures);
         }


### PR DESCRIPTION
  Add missing @param tags for record components (oks, errors, successes,
  failures), expand toResultPartition/toTryPartition to full Javadoc with
  @return tags, and clarify compact constructor descriptions.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #276

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Javadoc documentation for partition handling utilities, including enhanced descriptions for list-type parameters, clarified non-null validation behaviors, expanded documentation for conversion methods with explicit return type information, and refined explanatory text. These documentation updates provide better guidance for developers working with partition operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->