### PR TITLE
feature/quarkus/transaction/declarative

### DIFF
--- a/frameworks/quarkus/integration-test/src/main/java/dmx/fun/quarkus/it/CounterService.java
+++ b/frameworks/quarkus/integration-test/src/main/java/dmx/fun/quarkus/it/CounterService.java
@@ -188,6 +188,15 @@ public class CounterService {
         return increment(id);
     }
 
+    /**
+     * Outer tx (from txResult.execute) wraps a MANDATORY inner call.
+     * The inner MANDATORY method joins the outer tx; when the outer commits, the increment
+     * is persisted.
+     */
+    public Result<Long, String> outerOkInnerMandatory(long id) {
+        return txResult.execute(() -> self.incrementDeclarativeResultMandatory(id));
+    }
+
     // ── @TransactionalResult(NOT_SUPPORTED) ──────────────────────────────────
 
     /**
@@ -217,5 +226,17 @@ public class CounterService {
     @TransactionalResult(Transactional.TxType.NEVER)
     public Result<Long, String> incrementDeclarativeResultNever(long id) {
         return increment(id);
+    }
+
+    /**
+     * Outer tx (from txResult.execute) wraps a NEVER inner call.
+     * The inner NEVER method throws TransactionalException because an active tx is present;
+     * the outer tx rolls back and the exception propagates to the caller.
+     */
+    public Result<Long, String> outerWithInnerNever(long id) {
+        return txResult.execute(() -> {
+            self.incrementDeclarativeResultNever(id); // throws TransactionalException
+            return Result.ok(0L);
+        });
     }
 }

--- a/frameworks/quarkus/integration-test/src/main/java/dmx/fun/quarkus/it/CounterService.java
+++ b/frameworks/quarkus/integration-test/src/main/java/dmx/fun/quarkus/it/CounterService.java
@@ -8,6 +8,7 @@ import dmx.fun.quarkus.TxResult;
 import dmx.fun.quarkus.TxTry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 
@@ -22,6 +23,10 @@ public class CounterService {
 
     @Inject
     TxTry txTry;
+
+    /** Self-reference through the CDI proxy so interceptors fire on internal calls. */
+    @Inject
+    CounterService self;
 
     public void createTable() throws SQLException {
         try (var conn = dataSource.getConnection();
@@ -81,6 +86,8 @@ public class CounterService {
         }
     }
 
+    // ── Programmatic API ──────────────────────────────────────────────────────
+
     public Result<Long, String> incrementExecuteOk(long id) {
         return txResult.execute(() -> increment(id));
     }
@@ -103,6 +110,8 @@ public class CounterService {
         );
     }
 
+    // ── @TransactionalResult — REQUIRED (default) ─────────────────────────────
+
     @TransactionalResult
     public Result<Long, String> incrementDeclarativeResultOk(long id) {
         return increment(id);
@@ -112,6 +121,8 @@ public class CounterService {
     public Result<Long, String> incrementDeclarativeResultErr(long id) {
         return increment(id).flatMap(_ -> Result.err("declarative error"));
     }
+
+    // ── @TransactionalTry — REQUIRED (default) ────────────────────────────────
 
     @TransactionalTry
     public Try<Long> incrementDeclarativeTryOk(long id) {
@@ -124,10 +135,87 @@ public class CounterService {
                   .flatMap(_ -> Try.failure(new RuntimeException("declarative failure")));
     }
 
+    // ── TxResult.executeNew() — REQUIRES_NEW (programmatic) ───────────────────
+
     public Result<Long, String> outerErrInnerNewOk(long id) {
         return txResult.execute(() -> {
             txResult.executeNew(() -> increment(id));
             return Result.err("outer forced error");
         });
+    }
+
+    // ── @TransactionalResult(REQUIRES_NEW) ────────────────────────────────────
+
+    /**
+     * Increments and returns ok — annotated with REQUIRES_NEW so the outer tx is
+     * always suspended and a fresh tx is started.
+     */
+    @TransactionalResult(Transactional.TxType.REQUIRES_NEW)
+    public Result<Long, String> incrementDeclarativeResultRequiresNewOk(long id) {
+        return increment(id);
+    }
+
+    /**
+     * Outer tx (from txResult.execute) wraps an inner REQUIRES_NEW call.
+     * Even though the outer returns Err (rollback), the inner tx already committed.
+     */
+    public Result<Long, String> outerErrInnerRequiresNewOk(long id) {
+        return txResult.execute(() -> {
+            self.incrementDeclarativeResultRequiresNewOk(id);
+            return Result.err("outer forced error");
+        });
+    }
+
+    // ── @TransactionalResult — REQUIRED join (via self-call) ──────────────────
+
+    /**
+     * Outer tx (from txResult.execute) wraps an inner REQUIRED call that returns Ok.
+     * The inner REQUIRED method joins the outer tx. When the outer tx rolls back,
+     * the joined inner changes are rolled back too.
+     */
+    public Result<Long, String> outerErrInnerRequiredOk(long id) {
+        return txResult.execute(() -> {
+            self.incrementDeclarativeResultOk(id); // REQUIRED join — same tx as outer
+            return Result.err("outer forced error");
+        });
+    }
+
+    // ── @TransactionalResult(MANDATORY) ──────────────────────────────────────
+
+    /** Requires an existing transaction; throws TransactionalException if none. */
+    @TransactionalResult(Transactional.TxType.MANDATORY)
+    public Result<Long, String> incrementDeclarativeResultMandatory(long id) {
+        return increment(id);
+    }
+
+    // ── @TransactionalResult(NOT_SUPPORTED) ──────────────────────────────────
+
+    /**
+     * Suspends any active transaction and runs without one (auto-commit semantics).
+     * Changes are visible immediately after the method returns, regardless of any outer tx.
+     */
+    @TransactionalResult(Transactional.TxType.NOT_SUPPORTED)
+    public Result<Long, String> incrementDeclarativeResultNotSupported(long id) {
+        return increment(id);
+    }
+
+    /**
+     * Outer tx (from txResult.execute) wraps a NOT_SUPPORTED inner call.
+     * The inner call suspends the outer tx, increments (auto-commits), then resumes the outer.
+     * Even when the outer rolls back, the inner increment persists.
+     */
+    public Result<Long, String> outerErrInnerNotSupported(long id) {
+        return txResult.execute(() -> {
+            self.incrementDeclarativeResultNotSupported(id);
+            return Result.err("outer forced error");
+        });
+    }
+
+    // ── @TransactionalResult(NEVER) ──────────────────────────────────────────
+
+    /** Throws TransactionalException if called with an active transaction. */
+    @TransactionalResult(Transactional.TxType.NEVER)
+    public Result<Long, String> incrementDeclarativeResultNever(long id) {
+        return increment(id);
     }
 }

--- a/frameworks/quarkus/integration-test/src/test/java/dmx/fun/quarkus/it/TransactionIntegrationTest.java
+++ b/frameworks/quarkus/integration-test/src/test/java/dmx/fun/quarkus/it/TransactionIntegrationTest.java
@@ -2,11 +2,13 @@ package dmx.fun.quarkus.it;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static dmx.fun.assertj.DmxFunAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @QuarkusTest
 class TransactionIntegrationTest {
@@ -50,7 +52,7 @@ class TransactionIntegrationTest {
         assertThat(service.getValue(ID)).isEqualTo(0L);
     }
 
-    // ── @TransactionalResult declarative ─────────────────────────────────────
+    // ── @TransactionalResult — REQUIRED ──────────────────────────────────────
 
     @Test
     void transactionalResult_okResult_commitsToDb() throws Exception {
@@ -64,7 +66,7 @@ class TransactionIntegrationTest {
         assertThat(service.getValue(ID)).isEqualTo(0L);
     }
 
-    // ── @TransactionalTry declarative ────────────────────────────────────────
+    // ── @TransactionalTry — REQUIRED ─────────────────────────────────────────
 
     @Test
     void transactionalTry_successTry_commitsToDb() throws Exception {
@@ -78,13 +80,67 @@ class TransactionIntegrationTest {
         assertThat(service.getValue(ID)).isEqualTo(0L);
     }
 
-    // ── TxResult.executeNew() — REQUIRES_NEW semantics ────────────────────────
+    // ── TxResult.executeNew() — REQUIRES_NEW (programmatic) ──────────────────
 
     @Test
     void executeNew_innerTxCommits_evenWhenOuterRollsBack() throws Exception {
-        // outer tx returns Err (rolls back) but the inner executeNew already committed
         var result = service.outerErrInnerNewOk(ID);
         assertThat(result).isErr();
+        assertThat(service.getValue(ID)).isEqualTo(1L);
+    }
+
+    // ── @TransactionalResult(REQUIRES_NEW) ────────────────────────────────────
+
+    @Test
+    void requiresNew_innerTxCommits_evenWhenOuterRollsBack() throws Exception {
+        // inner @TransactionalResult(REQUIRES_NEW) suspends the outer tx and commits
+        // independently; the outer rolls back but cannot undo the inner commit
+        var result = service.outerErrInnerRequiresNewOk(ID);
+        assertThat(result).isErr();
+        assertThat(service.getValue(ID)).isEqualTo(1L);
+    }
+
+    // ── @TransactionalResult — REQUIRED join ─────────────────────────────────
+
+    @Test
+    void required_innerJoinsOuterTx_rollsBackWithOuter() throws Exception {
+        // inner @TransactionalResult(REQUIRED) joins the outer txResult.execute tx;
+        // when the outer rolls back, the inner's increment is rolled back too
+        var result = service.outerErrInnerRequiredOk(ID);
+        assertThat(result).isErr();
+        assertThat(service.getValue(ID)).isEqualTo(0L);
+    }
+
+    // ── @TransactionalResult(MANDATORY) ──────────────────────────────────────
+
+    @Test
+    void mandatory_withoutActiveTx_throwsTransactionalException() throws Exception {
+        // No outer transaction → MANDATORY must throw
+        assertThatThrownBy(() -> service.incrementDeclarativeResultMandatory(ID))
+            .isInstanceOf(TransactionalException.class);
+        // DB must be unchanged
+        assertThat(service.getValue(ID)).isEqualTo(0L);
+    }
+
+    // ── @TransactionalResult(NOT_SUPPORTED) ──────────────────────────────────
+
+    @Test
+    void notSupported_innerRunsWithoutTx_committedEvenWhenOuterRollsBack() throws Exception {
+        // inner @TransactionalResult(NOT_SUPPORTED) suspends the outer tx and runs
+        // without one (auto-commit); the outer tx rolls back but cannot touch the
+        // already-committed inner increment
+        var result = service.outerErrInnerNotSupported(ID);
+        assertThat(result).isErr();
+        assertThat(service.getValue(ID)).isEqualTo(1L);
+    }
+
+    // ── @TransactionalResult(NEVER) ──────────────────────────────────────────
+
+    @Test
+    void never_withoutActiveTx_executesNormally() throws Exception {
+        // No outer transaction → NEVER proceeds normally
+        var result = service.incrementDeclarativeResultNever(ID);
+        assertThat(result).isOk();
         assertThat(service.getValue(ID)).isEqualTo(1L);
     }
 }

--- a/frameworks/quarkus/integration-test/src/test/java/dmx/fun/quarkus/it/TransactionIntegrationTest.java
+++ b/frameworks/quarkus/integration-test/src/test/java/dmx/fun/quarkus/it/TransactionIntegrationTest.java
@@ -134,6 +134,16 @@ class TransactionIntegrationTest {
         assertThat(service.getValue(ID)).isEqualTo(1L);
     }
 
+    // ── @TransactionalResult(MANDATORY) with active tx ────────────────────────
+
+    @Test
+    void mandatory_withActiveTx_joinsAndCommits() throws Exception {
+        // Outer tx (txResult.execute) is active → MANDATORY joins it and commits
+        var result = service.outerOkInnerMandatory(ID);
+        assertThat(result).isOk();
+        assertThat(service.getValue(ID)).isEqualTo(1L);
+    }
+
     // ── @TransactionalResult(NEVER) ──────────────────────────────────────────
 
     @Test
@@ -142,5 +152,14 @@ class TransactionIntegrationTest {
         var result = service.incrementDeclarativeResultNever(ID);
         assertThat(result).isOk();
         assertThat(service.getValue(ID)).isEqualTo(1L);
+    }
+
+    @Test
+    void never_withActiveTx_throwsTransactionalException() throws Exception {
+        // Outer tx (txResult.execute) is active → NEVER must throw
+        assertThatThrownBy(() -> service.outerWithInnerNever(ID))
+            .isInstanceOf(TransactionalException.class);
+        // DB must be unchanged — outer tx rolled back
+        assertThat(service.getValue(ID)).isEqualTo(0L);
     }
 }

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalDmxInterceptor.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalDmxInterceptor.java
@@ -8,6 +8,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.TransactionManager;
+import jakarta.transaction.Transactional;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -18,9 +19,10 @@ import org.jspecify.annotations.NullMarked;
  * meta-interceptor-binding, per CDI §2.7.1.1). For each intercepted method the
  * interceptor:
  * <ol>
- *   <li>Begins a new JTA transaction.</li>
- *   <li>Proceeds with the method invocation.</li>
- *   <li>Rolls back if the returned {@code Result} is error or {@code Try} is failure.</li>
+ *   <li>Resolves the {@link Transactional.TxType} from the annotation (default REQUIRED).</li>
+ *   <li>Applies the corresponding JTA propagation semantics via {@link TxExecutor}.</li>
+ *   <li>Rolls back (or marks rollback-only) if the returned {@code Result} is error or
+ *       {@code Try} is failure.</li>
  *   <li>Commits on success; rolls back and re-throws on any unchecked exception.</li>
  * </ol>
  *
@@ -45,15 +47,19 @@ public class TransactionalDmxInterceptor {
     }
 
     /**
-     * Wraps the intercepted method invocation in a JTA transaction, rolling back when
-     * the returned {@link Result} is error or {@link Try} is failure.
+     * Wraps the intercepted method invocation in a JTA transaction, rolling back (or marking
+     * rollback-only when joining an existing transaction) when the returned {@link Result} is
+     * error or {@link Try} is failure.
      *
      * @param ctx the invocation context; must not be {@code null}
      * @return the value returned by the intercepted method
+     * @throws IllegalStateException if the annotated method does not return {@link Result}
+     *                               or {@link Try}
      * @throws Exception if the intercepted method throws, after rolling back the transaction
      */
     @AroundInvoke
     public Object intercept(InvocationContext ctx) throws Exception {
+        var txType = resolveTxType(ctx);
         return executor.execute(() -> {
             try {
                 return ctx.proceed();
@@ -70,6 +76,33 @@ public class TransactionalDmxInterceptor {
                 return t.isFailure();
             }
             return false;
-        });
+        }, txType);
+    }
+
+    private static Transactional.TxType resolveTxType(InvocationContext ctx) {
+        // Method-level annotations take precedence over class-level.
+        var resultAnn = ctx.getMethod().getAnnotation(TransactionalResult.class);
+        if (resultAnn != null) {
+            return resultAnn.value();
+        }
+
+        var tryAnn = ctx.getMethod().getAnnotation(TransactionalTry.class);
+        if (tryAnn != null) {
+            return tryAnn.value();
+        }
+
+        // Fall back to the declaring class (supports class-level @TransactionalResult/Try).
+        var declaring = ctx.getMethod().getDeclaringClass();
+        resultAnn = declaring.getAnnotation(TransactionalResult.class);
+        if (resultAnn != null) {
+            return resultAnn.value();
+        }
+
+        tryAnn = declaring.getAnnotation(TransactionalTry.class);
+        if (tryAnn != null) {
+            return tryAnn.value();
+        }
+
+        return Transactional.TxType.REQUIRED;
     }
 }

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalResult.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalResult.java
@@ -1,7 +1,9 @@
 package dmx.fun.quarkus;
 
 import dmx.fun.Result;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.interceptor.InterceptorBinding;
+import jakarta.transaction.Transactional;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -28,8 +30,28 @@ import java.lang.annotation.Target;
  *             .flatMap(this::persistOrder)
  *             .flatMap(this::notifyInventory);
  *     }
+ *
+ *     // Always suspend any outer transaction and start a fresh one.
+ *     @TransactionalResult(Transactional.TxType.REQUIRES_NEW)
+ *     public Result<AuditEntry, String> audit(Event event) { ... }
  * }
  * }</pre>
+ *
+ * <h2>Transaction semantics</h2>
+ * <ul>
+ *   <li>{@link Transactional.TxType#REQUIRED} (default) — join an existing transaction or
+ *       begin a new one.</li>
+ *   <li>{@link Transactional.TxType#REQUIRES_NEW} — always suspend any active transaction
+ *       and begin a fresh one; the new transaction commits or rolls back independently.</li>
+ *   <li>{@link Transactional.TxType#MANDATORY} — require an active transaction; throw
+ *       {@link jakarta.transaction.TransactionalException} if none exists.</li>
+ *   <li>{@link Transactional.TxType#SUPPORTS} — join an active transaction if present;
+ *       otherwise execute without one.</li>
+ *   <li>{@link Transactional.TxType#NOT_SUPPORTED} — suspend any active transaction and
+ *       execute without one; resume it afterwards.</li>
+ *   <li>{@link Transactional.TxType#NEVER} — throw
+ *       {@link jakarta.transaction.TransactionalException} if a transaction is active.</li>
+ * </ul>
  *
  * @see TransactionalTry
  * @see TransactionalDmxInterceptor
@@ -40,4 +62,13 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-public @interface TransactionalResult {}
+public @interface TransactionalResult {
+
+    /**
+     * The transaction propagation type.
+     *
+     * <p>Marked {@link Nonbinding} so that CDI selects the same interceptor regardless
+     * of the chosen {@link Transactional.TxType}; the interceptor reads the value at runtime.
+     */
+    @Nonbinding Transactional.TxType value() default Transactional.TxType.REQUIRED;
+}

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalTry.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TransactionalTry.java
@@ -1,7 +1,9 @@
 package dmx.fun.quarkus;
 
 import dmx.fun.Try;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.interceptor.InterceptorBinding;
+import jakarta.transaction.Transactional;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -27,8 +29,28 @@ import java.lang.annotation.Target;
  *         return Try.of(() -> reportRepo.save(build(req)))
  *             .map(r -> { auditLog.record(r); return r; });
  *     }
+ *
+ *     // Always start a fresh transaction, independent of any outer one.
+ *     @TransactionalTry(Transactional.TxType.REQUIRES_NEW)
+ *     public Try<AuditEntry> audit(Event event) { ... }
  * }
  * }</pre>
+ *
+ * <h2>Transaction semantics</h2>
+ * <ul>
+ *   <li>{@link Transactional.TxType#REQUIRED} (default) — join an existing transaction or
+ *       begin a new one.</li>
+ *   <li>{@link Transactional.TxType#REQUIRES_NEW} — always suspend any active transaction
+ *       and begin a fresh one; the new transaction commits or rolls back independently.</li>
+ *   <li>{@link Transactional.TxType#MANDATORY} — require an active transaction; throw
+ *       {@link jakarta.transaction.TransactionalException} if none exists.</li>
+ *   <li>{@link Transactional.TxType#SUPPORTS} — join an active transaction if present;
+ *       otherwise execute without one.</li>
+ *   <li>{@link Transactional.TxType#NOT_SUPPORTED} — suspend any active transaction and
+ *       execute without one; resume it afterwards.</li>
+ *   <li>{@link Transactional.TxType#NEVER} — throw
+ *       {@link jakarta.transaction.TransactionalException} if a transaction is active.</li>
+ * </ul>
  *
  * @see TransactionalResult
  * @see TransactionalDmxInterceptor
@@ -39,4 +61,13 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-public @interface TransactionalTry {}
+public @interface TransactionalTry {
+
+    /**
+     * The transaction propagation type.
+     *
+     * <p>Marked {@link Nonbinding} so that CDI selects the same interceptor regardless
+     * of the chosen {@link Transactional.TxType}; the interceptor reads the value at runtime.
+     */
+    @Nonbinding Transactional.TxType value() default Transactional.TxType.REQUIRED;
+}

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
@@ -188,19 +188,37 @@ final class TxExecutor {
      *
      * <p>Does NOT begin, commit, or rollback — the caller owns the transaction boundary.
      * Marks the transaction rollback-only when {@code shouldRollback} returns {@code true}
-     * or when the action throws an unchecked exception.
+     * or when the action or predicate throws any throwable, including {@link Error}.
+     * If {@link #setRollbackOnlyQuietly()} itself fails with an infrastructure exception,
+     * that exception is attached as a suppressed exception to the original throwable so
+     * neither failure is silently lost.
      */
     private <T> T executeJoined(Supplier<T> action, Predicate<T> shouldRollback) {
         T result;
         try {
             result = action.get();
             Objects.requireNonNull(result, "action must not return null");
-        } catch (RuntimeException e) {
-            setRollbackOnlyQuietly();
-            throw e;
+        } catch (RuntimeException | Error appEx) {
+            try {
+                setRollbackOnlyQuietly();
+            } catch (RuntimeException infraEx) {
+                appEx.addSuppressed(infraEx);
+            }
+            throw appEx;
         }
-        if (shouldRollback.test(result)) {
-            setRollbackOnlyQuietly();
+        boolean rollback;
+        try {
+            rollback = shouldRollback.test(result);
+        } catch (RuntimeException | Error predicateEx) {
+            try {
+                setRollbackOnlyQuietly();
+            } catch (RuntimeException infraEx) {
+                predicateEx.addSuppressed(infraEx);
+            }
+            throw predicateEx;
+        }
+        if (rollback) {
+            setRollbackOnlyQuietly(); // no original exception — infra failure propagates directly
         }
         return result;
     }
@@ -247,7 +265,8 @@ final class TxExecutor {
     private void setRollbackOnlyQuietly() {
         try {
             transactionManager.setRollbackOnly();
-        } catch (SystemException _) {
+        } catch (SystemException e) {
+            throw new RuntimeException("JTA transaction management failed", e);
         }
     }
 }

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
@@ -5,13 +5,18 @@ import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionRequiredException;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionalException;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Package-private helper that executes a value-returning action inside a JTA-managed
@@ -30,7 +35,7 @@ final class TxExecutor {
     }
 
     /**
-     * Runs {@code action} inside a new JTA transaction.
+     * Runs {@code action} inside a new JTA transaction (programmatic API).
      *
      * <p>If {@code shouldRollback} returns {@code true} for the action's result, the
      * transaction is rolled back. If the action throws, the exception propagates and
@@ -93,12 +98,136 @@ final class TxExecutor {
         try {
             return execute(action, shouldRollback);
         } finally {
-            if (suspended != null) {
-                try {
-                    transactionManager.resume(suspended);
-                } catch (InvalidTransactionException | SystemException e) {
-                    throw new RuntimeException("Failed to resume suspended transaction", e);
-                }
+            resumeIfPresent(suspended);
+        }
+    }
+
+    /**
+     * Runs {@code action} applying JTA semantics described by {@code txType}.
+     *
+     * <p>Used by the declarative interceptor; callers that always want a new transaction
+     * should use {@link #execute(Supplier, Predicate)} or {@link #executeNew(Supplier, Predicate)}
+     * directly.
+     *
+     * @param <T>            the return type of the action
+     * @param action         the transactional action; must not be {@code null} and must not
+     *                       return {@code null}
+     * @param shouldRollback predicate that returns {@code true} when the result represents
+     *                       a failure; must not be {@code null}
+     * @param txType         the JTA propagation type; must not be {@code null}
+     * @return the value returned by {@code action}
+     * @throws TransactionalException if MANDATORY is requested with no active transaction,
+     *                                or NEVER is requested with an active transaction
+     */
+    <T> T execute(Supplier<T> action, Predicate<T> shouldRollback, Transactional.TxType txType) {
+        Objects.requireNonNull(action, "action");
+        Objects.requireNonNull(shouldRollback, "shouldRollback");
+        Objects.requireNonNull(txType, "txType");
+        return switch (txType) {
+            case REQUIRED      -> executeRequired(action, shouldRollback);
+            case REQUIRES_NEW  -> executeNew(action, shouldRollback);
+            case MANDATORY     -> executeMandatory(action, shouldRollback);
+            case SUPPORTS      -> executeSupports(action, shouldRollback);
+            case NOT_SUPPORTED -> executeNotSupported(action, shouldRollback);
+            case NEVER         -> executeNever(action, shouldRollback);
+        };
+    }
+
+    // ── TxType implementations ────────────────────────────────────────────────
+
+    private <T> T executeRequired(Supplier<T> action, Predicate<T> shouldRollback) {
+        if (hasActiveTransaction()) {
+            return executeJoined(action, shouldRollback);
+        }
+        return execute(action, shouldRollback);
+    }
+
+    private <T> T executeMandatory(Supplier<T> action, Predicate<T> shouldRollback) {
+        if (!hasActiveTransaction()) {
+            throw new TransactionalException(
+                "MANDATORY: no active transaction",
+                new TransactionRequiredException());
+        }
+        return executeJoined(action, shouldRollback);
+    }
+
+    private <T> T executeSupports(Supplier<T> action, Predicate<T> shouldRollback) {
+        if (hasActiveTransaction()) {
+            return executeJoined(action, shouldRollback);
+        }
+        return runWithoutTx(action);
+    }
+
+    private <T> T executeNotSupported(Supplier<T> action, Predicate<T> shouldRollback) {
+        @Nullable Transaction suspended = null;
+        try {
+            if (hasActiveTransaction()) {
+                suspended = transactionManager.suspend();
+            }
+        } catch (SystemException e) {
+            throw new RuntimeException("JTA transaction management failed", e);
+        }
+        try {
+            return runWithoutTx(action);
+        } finally {
+            resumeIfPresent(suspended);
+        }
+    }
+
+    private <T> T executeNever(Supplier<T> action, Predicate<T> shouldRollback) {
+        if (hasActiveTransaction()) {
+            throw new TransactionalException(
+                "NEVER: active transaction found",
+                new InvalidTransactionException());
+        }
+        return runWithoutTx(action);
+    }
+
+    /**
+     * Runs within the CALLER'S transaction (join semantics).
+     *
+     * <p>Does NOT begin, commit, or rollback — the caller owns the transaction boundary.
+     * Marks the transaction rollback-only when {@code shouldRollback} returns {@code true}
+     * or when the action throws an unchecked exception.
+     */
+    private <T> T executeJoined(Supplier<T> action, Predicate<T> shouldRollback) {
+        T result;
+        try {
+            result = action.get();
+            Objects.requireNonNull(result, "action must not return null");
+        } catch (RuntimeException e) {
+            setRollbackOnlyQuietly();
+            throw e;
+        }
+        if (shouldRollback.test(result)) {
+            setRollbackOnlyQuietly();
+        }
+        return result;
+    }
+
+    /** Runs the action outside of any JTA transaction (no begin/commit/rollback). */
+    private <T> T runWithoutTx(Supplier<T> action) {
+        T result = action.get();
+        Objects.requireNonNull(result, "action must not return null");
+        return result;
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private boolean hasActiveTransaction() {
+        try {
+            return transactionManager.getStatus() == Status.STATUS_ACTIVE;
+        } catch (SystemException e) {
+            throw new RuntimeException("JTA transaction management failed", e);
+        }
+    }
+
+    private void resumeIfPresent(@Nullable Transaction suspended) {
+        if (suspended != null) {
+            try {
+                transactionManager.resume(suspended);
+            } catch (InvalidTransactionException | SystemException e) {
+                throw new RuntimeException("Failed to resume suspended transaction", e);
             }
         }
     }
@@ -106,7 +235,14 @@ final class TxExecutor {
     private void rollbackQuietly() {
         try {
             transactionManager.rollback();
-        } catch (SystemException ignored) {
+        } catch (SystemException _) {
+        }
+    }
+
+    private void setRollbackOnlyQuietly() {
+        try {
+            transactionManager.setRollbackOnly();
+        } catch (SystemException _) {
         }
     }
 }

--- a/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
+++ b/frameworks/quarkus/runtime/src/main/java/dmx/fun/quarkus/TxExecutor.java
@@ -216,7 +216,12 @@ final class TxExecutor {
 
     private boolean hasActiveTransaction() {
         try {
-            return transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            int status = transactionManager.getStatus();
+            // STATUS_MARKED_ROLLBACK is still a joinable/suspendable transaction —
+            // treat it as active so propagation decisions (REQUIRED join, MANDATORY
+            // join, NOT_SUPPORTED suspend, NEVER throw) remain correct even after
+            // setRollbackOnly() has been called on an enclosing transaction.
+            return status == Status.STATUS_ACTIVE || status == Status.STATUS_MARKED_ROLLBACK;
         } catch (SystemException e) {
             throw new RuntimeException("JTA transaction management failed", e);
         }

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/StubTransactionManager.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/StubTransactionManager.java
@@ -5,6 +5,7 @@ import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
@@ -17,6 +18,10 @@ class StubTransactionManager implements TransactionManager {
     int rollbackCount;
     int suspendCount;
     int resumeCount;
+    int setRollbackOnlyCount;
+
+    /** Controls what {@link #getStatus()} returns. Defaults to {@link Status#STATUS_ACTIVE}. */
+    int statusToReturn = Status.STATUS_ACTIVE;
 
     @Nullable Transaction lastResumedTx;
     @Nullable Transaction transactionToReturn;
@@ -30,31 +35,48 @@ class StubTransactionManager implements TransactionManager {
     @Override
     public void begin() throws NotSupportedException, SystemException {
         beginCount++;
-        if (throwOnBegin instanceof NotSupportedException e) throw e;
-        if (throwOnBegin instanceof SystemException e)       throw e;
+        if (throwOnBegin instanceof NotSupportedException e) {
+            throw e;
+        }
+
+        if (throwOnBegin instanceof SystemException e) {
+            throw e;
+        }
     }
 
     @Override
     public void commit() throws RollbackException, HeuristicMixedException,
             HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
         commitCount++;
-        if (throwOnCommit instanceof RollbackException e)          throw e;
-        if (throwOnCommit instanceof HeuristicMixedException e)    throw e;
-        if (throwOnCommit instanceof HeuristicRollbackException e) throw e;
-        if (throwOnCommit instanceof SystemException e)            throw e;
+        if (throwOnCommit instanceof RollbackException e) {
+            throw e;
+        }
+        if (throwOnCommit instanceof HeuristicMixedException e) {
+            throw e;
+        }
+        if (throwOnCommit instanceof HeuristicRollbackException e) {
+            throw e;
+        }
+        if (throwOnCommit instanceof SystemException e) {
+            throw e;
+        }
     }
 
     @Override
     public void rollback() throws IllegalStateException, SecurityException, SystemException {
         rollbackCount++;
-        if (throwOnRollback instanceof SystemException e) throw e;
+        if (throwOnRollback instanceof SystemException e) {
+            throw e;
+        }
     }
 
     @Override
-    public void setRollbackOnly() throws IllegalStateException, SystemException {}
+    public void setRollbackOnly() throws IllegalStateException, SystemException {
+        setRollbackOnlyCount++;
+    }
 
     @Override
-    public int getStatus() throws SystemException { return 0; }
+    public int getStatus() throws SystemException { return statusToReturn; }
 
     @Override
     public Transaction getTransaction() throws SystemException { return null; }
@@ -62,7 +84,9 @@ class StubTransactionManager implements TransactionManager {
     @Override
     public Transaction suspend() throws SystemException {
         suspendCount++;
-        if (throwOnSuspend instanceof SystemException e) throw e;
+        if (throwOnSuspend instanceof SystemException e) {
+            throw e;
+        }
         return transactionToReturn;
     }
 
@@ -71,8 +95,12 @@ class StubTransactionManager implements TransactionManager {
             throws InvalidTransactionException, IllegalStateException, SystemException {
         resumeCount++;
         lastResumedTx = tobj;
-        if (throwOnResume instanceof InvalidTransactionException e) throw e;
-        if (throwOnResume instanceof SystemException e)             throw e;
+        if (throwOnResume instanceof InvalidTransactionException e) {
+            throw e;
+        }
+        if (throwOnResume instanceof SystemException e) {
+            throw e;
+        }
     }
 
     @Override

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/StubTransactionManager.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/StubTransactionManager.java
@@ -31,6 +31,8 @@ class StubTransactionManager implements TransactionManager {
     @Nullable Exception throwOnRollback;
     @Nullable Exception throwOnSuspend;
     @Nullable Exception throwOnResume;
+    @Nullable SystemException throwOnGetStatus;
+    @Nullable SystemException throwOnSetRollbackOnly;
 
     @Override
     public void begin() throws NotSupportedException, SystemException {
@@ -73,10 +75,18 @@ class StubTransactionManager implements TransactionManager {
     @Override
     public void setRollbackOnly() throws IllegalStateException, SystemException {
         setRollbackOnlyCount++;
+        if (throwOnSetRollbackOnly != null) {
+            throw throwOnSetRollbackOnly;
+        }
     }
 
     @Override
-    public int getStatus() throws SystemException { return statusToReturn; }
+    public int getStatus() throws SystemException {
+        if (throwOnGetStatus != null) {
+            throw throwOnGetStatus;
+        }
+        return statusToReturn;
+    }
 
     @Override
     public Transaction getTransaction() throws SystemException { return null; }

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TransactionalDmxInterceptorTest.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TransactionalDmxInterceptorTest.java
@@ -2,6 +2,9 @@ package dmx.fun.quarkus;
 
 import dmx.fun.Result;
 import dmx.fun.Try;
+import jakarta.transaction.Status;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionalException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,24 @@ class TransactionalDmxInterceptorTest {
         Object doWork() { return null; }
     }
 
+    /** REQUIRES_NEW explicit */
+    static class RequiresNewTarget {
+        @TransactionalResult(Transactional.TxType.REQUIRES_NEW)
+        Object doWork() { return null; }
+    }
+
+    /** MANDATORY explicit */
+    static class MandatoryTarget {
+        @TransactionalResult(Transactional.TxType.MANDATORY)
+        Object doWork() { return null; }
+    }
+
+    /** NEVER explicit */
+    static class NeverTarget {
+        @TransactionalResult(Transactional.TxType.NEVER)
+        Object doWork() { return null; }
+    }
+
     private static Method doWork(Class<?> clazz) {
         try {
             return clazz.getDeclaredMethod("doWork");
@@ -58,6 +79,8 @@ class TransactionalDmxInterceptorTest {
     @BeforeEach
     void setUp() {
         tx = new StubTransactionManager();
+        // Default: no outer transaction so REQUIRED starts a new one (matches pre-TxType behaviour).
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
         interceptor = new TransactionalDmxInterceptor(tx);
     }
 
@@ -241,5 +264,68 @@ class TransactionalDmxInterceptorTest {
 
         assertThat(tx.rollbackCount).isEqualTo(1);
         assertThat(tx.commitCount).isEqualTo(0);
+    }
+
+    // ── TxType resolution ─────────────────────────────────────────────────────
+
+    @Test
+    void requiresNew_alwaysSuspendsAndStartsFreshTx() throws Exception {
+        var outer = new StubTransaction();
+        tx.transactionToReturn = outer;
+        tx.statusToReturn = Status.STATUS_ACTIVE; // outer tx is active
+
+        var ctx = new StubInvocationContext(
+            new RequiresNewTarget(), doWork(RequiresNewTarget.class),
+            () -> Result.ok("v"));
+
+        interceptor.intercept(ctx);
+
+        assertThat(tx.suspendCount).isEqualTo(1);
+        assertThat(tx.beginCount).isEqualTo(1);
+        assertThat(tx.commitCount).isEqualTo(1);
+        assertThat(tx.resumeCount).isEqualTo(1);
+        assertThat(tx.lastResumedTx).isSameAs(outer);
+    }
+
+    @Test
+    void mandatory_withoutActiveTx_throwsTransactionalException() {
+        // statusToReturn is NO_TRANSACTION (set in setUp)
+        var ctx = new StubInvocationContext(
+            new MandatoryTarget(), doWork(MandatoryTarget.class),
+            () -> Result.ok("v"));
+
+        assertThatThrownBy(() -> interceptor.intercept(ctx))
+            .isInstanceOf(TransactionalException.class)
+            .hasMessageContaining("MANDATORY");
+
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    @Test
+    void never_withActiveTx_throwsTransactionalException() {
+        tx.statusToReturn = Status.STATUS_ACTIVE;
+        var ctx = new StubInvocationContext(
+            new NeverTarget(), doWork(NeverTarget.class),
+            () -> Result.ok("v"));
+
+        assertThatThrownBy(() -> interceptor.intercept(ctx))
+            .isInstanceOf(TransactionalException.class)
+            .hasMessageContaining("NEVER");
+
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    @Test
+    void required_withActiveTx_joinsAndSetsRollbackOnlyOnErr() throws Exception {
+        tx.statusToReturn = Status.STATUS_ACTIVE;
+        var ctx = new StubInvocationContext(
+            new ResultMethodTarget(), doWork(ResultMethodTarget.class),
+            () -> Result.err("e"));
+
+        interceptor.intercept(ctx);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.commitCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
     }
 }

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
@@ -476,18 +476,82 @@ class TxExecutorTest {
         assertThat(tx.beginCount).isEqualTo(0);
     }
 
-    // ── setRollbackOnlyQuietly — SystemException swallowed ───────────────────
+    // ── executeJoined — Error handling (Finding 1) ───────────────────────────
 
     @Test
-    void execute_required_setRollbackOnlyThrowsSystemException_isSwallowed() {
-        // STATUS_ACTIVE by default → executeJoined → setRollbackOnlyQuietly(); exception is swallowed
-        tx.throwOnSetRollbackOnly = new SystemException("setRollbackOnly failed");
+    void execute_required_actionThrowsError_setsRollbackOnlyAndRethrows() {
+        // Error must be caught the same as RuntimeException — marks rollback-only then rethrows
+        var oom = new OutOfMemoryError("simulated OOM");
 
-        var result = executor.execute(() -> "err", _ -> true, Transactional.TxType.REQUIRED);
+        assertThatThrownBy(() -> executor.execute(() -> { throw oom; }, _ -> false, Transactional.TxType.REQUIRED))
+            .isSameAs(oom);
 
-        assertThat(result).isEqualTo("err");
         assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
         assertThat(tx.rollbackCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_required_predicateThrowsError_setsRollbackOnlyAndRethrows() {
+        // Error thrown by the predicate must also mark rollback-only
+        var assertionError = new AssertionError("predicate bug");
+
+        assertThatThrownBy(() -> executor.execute(() -> "ok", _ -> { throw assertionError; }, Transactional.TxType.REQUIRED))
+            .isSameAs(assertionError);
+
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+        assertThat(tx.rollbackCount).isEqualTo(0);
+    }
+
+    // ── setRollbackOnlyQuietly — SystemException propagated (Finding 2) ──────
+
+    @Test
+    void execute_required_setRollbackOnlyThrowsSystemException_propagatesWhenPredicateTrue() {
+        // Predicate returns true → setRollbackOnlyQuietly(); no original exception to suppress
+        tx.throwOnSetRollbackOnly = new SystemException("setRollbackOnly failed");
+
+        assertThatThrownBy(() -> executor.execute(() -> "err", _ -> true, Transactional.TxType.REQUIRED))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("JTA transaction management failed")
+            .hasCauseInstanceOf(SystemException.class);
+
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+        assertThat(tx.rollbackCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_required_actionThrows_setRollbackOnlyFails_infraExceptionSuppressed() {
+        // Action throws + setRollbackOnly fails → infra exception is suppressed into the app exception
+        tx.throwOnSetRollbackOnly = new SystemException("setRollbackOnly failed");
+        var appEx = new RuntimeException("app error");
+
+        assertThatThrownBy(() -> executor.execute(() -> { throw appEx; }, _ -> false, Transactional.TxType.REQUIRED))
+            .isSameAs(appEx)
+            .satisfies(e -> {
+                assertThat(e.getSuppressed()).hasSize(1);
+                assertThat(e.getSuppressed()[0])
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(SystemException.class);
+            });
+
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+    }
+
+    @Test
+    void execute_required_predicateThrows_setRollbackOnlyFails_infraExceptionSuppressed() {
+        // Predicate throws + setRollbackOnly fails → infra exception is suppressed into predicate exception
+        tx.throwOnSetRollbackOnly = new SystemException("setRollbackOnly failed");
+        var predicateEx = new RuntimeException("predicate error");
+
+        assertThatThrownBy(() -> executor.execute(() -> "ok", _ -> { throw predicateEx; }, Transactional.TxType.REQUIRED))
+            .isSameAs(predicateEx)
+            .satisfies(e -> {
+                assertThat(e.getSuppressed()).hasSize(1);
+                assertThat(e.getSuppressed()[0])
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(SystemException.class);
+            });
+
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
     }
 
     // ── execute(TxType) — STATUS_MARKED_ROLLBACK regression ──────────────────

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
@@ -5,7 +5,10 @@ import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -293,5 +296,179 @@ class TxExecutorTest {
 
         assertThat(tx.commitCount).isEqualTo(1);
         assertThat(tx.resumeCount).isEqualTo(1);
+    }
+
+    // ── execute(TxType) — REQUIRED ────────────────────────────────────────────
+
+    @Test
+    void execute_required_noOuterTx_beginsAndCommits() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(tx.beginCount).isEqualTo(1);
+        assertThat(tx.commitCount).isEqualTo(1);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_required_noOuterTx_rollsBackOnErr() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        executor.execute(() -> "err", v -> true, Transactional.TxType.REQUIRED);
+
+        assertThat(tx.beginCount).isEqualTo(1);
+        assertThat(tx.rollbackCount).isEqualTo(1);
+        assertThat(tx.commitCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_required_withOuterTx_joinsAndCommitsViaOuter() {
+        // status is ACTIVE by default — should join, not begin
+
+        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.commitCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_required_withOuterTx_setsRollbackOnlyOnErr() {
+        executor.execute(() -> "err", v -> true, Transactional.TxType.REQUIRED);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.rollbackCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+    }
+
+    @Test
+    void execute_required_withOuterTx_setsRollbackOnlyOnException() {
+        assertThatThrownBy(() ->
+            executor.execute(
+                () -> { throw new RuntimeException("boom"); },
+                v -> false,
+                Transactional.TxType.REQUIRED))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("boom");
+
+        assertThat(tx.rollbackCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+    }
+
+    // ── execute(TxType) — MANDATORY ───────────────────────────────────────────
+
+    @Test
+    void execute_mandatory_withoutTx_throwsTransactionalException() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.MANDATORY))
+            .isInstanceOf(TransactionalException.class)
+            .hasMessageContaining("MANDATORY");
+
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_mandatory_withTx_joinsAndSetsRollbackOnlyOnErr() {
+        executor.execute(() -> "err", v -> true, Transactional.TxType.MANDATORY);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+    }
+
+    // ── execute(TxType) — SUPPORTS ────────────────────────────────────────────
+
+    @Test
+    void execute_supports_withTx_joinsAndSetsRollbackOnlyOnErr() {
+        executor.execute(() -> "err", v -> true, Transactional.TxType.SUPPORTS);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+    }
+
+    @Test
+    void execute_supports_withoutTx_runsWithoutBeginOrCommit() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.SUPPORTS);
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.commitCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(0);
+    }
+
+    // ── execute(TxType) — NOT_SUPPORTED ──────────────────────────────────────
+
+    @Test
+    void execute_notSupported_withTx_suspendsAndResumes() {
+        var outer = new StubTransaction();
+        tx.transactionToReturn = outer;
+
+        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(tx.suspendCount).isEqualTo(1);
+        assertThat(tx.resumeCount).isEqualTo(1);
+        assertThat(tx.lastResumedTx).isSameAs(outer);
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_notSupported_withoutTx_doesNotSuspend() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+
+        assertThat(tx.suspendCount).isEqualTo(0);
+        assertThat(tx.resumeCount).isEqualTo(0);
+    }
+
+    // ── execute(TxType) — NEVER ───────────────────────────────────────────────
+
+    @Test
+    void execute_never_withTx_throwsTransactionalException() {
+        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.NEVER))
+            .isInstanceOf(TransactionalException.class)
+            .hasMessageContaining("NEVER");
+
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_never_withoutTx_runsWithoutBeginOrCommit() {
+        tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
+
+        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.NEVER);
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.commitCount).isEqualTo(0);
+    }
+
+    // ── execute(TxType) — null checks ─────────────────────────────────────────
+
+    @Test
+    void execute_txType_nullAction_throwsNPE() {
+        assertThatThrownBy(() -> executor.execute(null, v -> false, Transactional.TxType.REQUIRED))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
+    @Test
+    void execute_txType_nullPredicate_throwsNPE() {
+        assertThatThrownBy(() -> executor.execute(() -> "x", null, Transactional.TxType.REQUIRED))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("shouldRollback");
+    }
+
+    @Test
+    void execute_txType_nullTxType_throwsNPE() {
+        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("txType");
     }
 }

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
@@ -39,7 +39,7 @@ class TxExecutorTest {
 
     @Test
     void execute_predicateFalse_commits() {
-        var result = executor.execute(() -> "ok", v -> false);
+        var result = executor.execute(() -> "ok", _ -> false);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.beginCount).isEqualTo(1);
@@ -49,7 +49,7 @@ class TxExecutorTest {
 
     @Test
     void execute_predicateTrue_rollsBack() {
-        var result = executor.execute(() -> "fail", v -> true);
+        var result = executor.execute(() -> "fail", _ -> true);
 
         assertThat(result).isEqualTo("fail");
         assertThat(tx.beginCount).isEqualTo(1);
@@ -63,7 +63,7 @@ class TxExecutorTest {
     void execute_actionThrows_rollsBackAndRethrows() {
         var boom = new RuntimeException("boom");
 
-        assertThatThrownBy(() -> executor.execute(() -> { throw boom; }, v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> { throw boom; }, _ -> false))
             .isSameAs(boom);
 
         assertThat(tx.beginCount).isEqualTo(1);
@@ -75,7 +75,7 @@ class TxExecutorTest {
     void execute_actionThrows_rollbackSwallowsSystemException() throws SystemException {
         tx.throwOnRollback = new SystemException("rollback failed");
 
-        assertThatThrownBy(() -> executor.execute(() -> { throw new RuntimeException("boom"); }, v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> { throw new RuntimeException("boom"); }, _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("boom");
 
@@ -84,7 +84,7 @@ class TxExecutorTest {
 
     @Test
     void execute_actionReturnsNull_rollsBackAndThrowsNPE() {
-        assertThatThrownBy(() -> executor.execute(() -> null, v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> null, _ -> false))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("null");
 
@@ -96,7 +96,7 @@ class TxExecutorTest {
 
     @Test
     void execute_nullAction_throwsNPE() {
-        assertThatThrownBy(() -> executor.execute(null, v -> false))
+        assertThatThrownBy(() -> executor.execute(null, _ -> false))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("action");
     }
@@ -114,7 +114,7 @@ class TxExecutorTest {
     void execute_beginThrowsNotSupportedException_wrapsInRuntimeException() {
         tx.throwOnBegin = new NotSupportedException("nested tx not supported");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(NotSupportedException.class);
@@ -124,7 +124,7 @@ class TxExecutorTest {
     void execute_beginThrowsSystemException_wrapsInRuntimeException() {
         tx.throwOnBegin = new SystemException("tx system error");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(SystemException.class);
@@ -134,7 +134,7 @@ class TxExecutorTest {
     void execute_commitThrowsRollbackException_wrapsInRuntimeException() {
         tx.throwOnCommit = new RollbackException("tx rolled back");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(RollbackException.class);
@@ -144,7 +144,7 @@ class TxExecutorTest {
     void execute_commitThrowsHeuristicMixedException_wrapsInRuntimeException() {
         tx.throwOnCommit = new HeuristicMixedException("heuristic mixed");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(HeuristicMixedException.class);
@@ -154,7 +154,7 @@ class TxExecutorTest {
     void execute_commitThrowsHeuristicRollbackException_wrapsInRuntimeException() {
         tx.throwOnCommit = new HeuristicRollbackException("heuristic rollback");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(HeuristicRollbackException.class);
@@ -164,7 +164,7 @@ class TxExecutorTest {
     void execute_commitThrowsSystemException_wrapsInRuntimeException() {
         tx.throwOnCommit = new SystemException("tx system error on commit");
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(SystemException.class);
@@ -174,7 +174,7 @@ class TxExecutorTest {
 
     @Test
     void executeNew_nullAction_throwsNPE() {
-        assertThatThrownBy(() -> executor.executeNew(null, v -> false))
+        assertThatThrownBy(() -> executor.executeNew(null, _ -> false))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("action");
     }
@@ -193,7 +193,7 @@ class TxExecutorTest {
         // suspend() returns null → no outer tx to resume
         tx.transactionToReturn = null;
 
-        var result = executor.executeNew(() -> "value", v -> false);
+        var result = executor.executeNew(() -> "value", _ -> false);
 
         assertThat(result).isEqualTo("value");
         assertThat(tx.suspendCount).isEqualTo(1);
@@ -210,7 +210,7 @@ class TxExecutorTest {
         var outer = new StubTransaction();
         tx.transactionToReturn = outer;
 
-        var result = executor.executeNew(() -> "value", v -> false);
+        var result = executor.executeNew(() -> "value", _ -> false);
 
         assertThat(result).isEqualTo("value");
         assertThat(tx.suspendCount).isEqualTo(1);
@@ -226,7 +226,7 @@ class TxExecutorTest {
         var outer = new StubTransaction();
         tx.transactionToReturn = outer;
 
-        var result = executor.executeNew(() -> "fail", v -> true);
+        var result = executor.executeNew(() -> "fail", _ -> true);
 
         assertThat(result).isEqualTo("fail");
         assertThat(tx.suspendCount).isEqualTo(1);
@@ -242,7 +242,7 @@ class TxExecutorTest {
         tx.transactionToReturn = outer;
         var boom = new RuntimeException("boom");
 
-        assertThatThrownBy(() -> executor.executeNew(() -> { throw boom; }, v -> false))
+        assertThatThrownBy(() -> executor.executeNew(() -> { throw boom; }, _ -> false))
             .isSameAs(boom);
 
         assertThat(tx.suspendCount).isEqualTo(1);
@@ -258,7 +258,7 @@ class TxExecutorTest {
     void executeNew_suspendThrowsSystemException_wrapsInRuntimeException() {
         tx.throwOnSuspend = new SystemException("suspend failed");
 
-        assertThatThrownBy(() -> executor.executeNew(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.executeNew(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("JTA transaction management failed")
             .hasCauseInstanceOf(SystemException.class);
@@ -273,7 +273,7 @@ class TxExecutorTest {
         tx.transactionToReturn = outer;
         tx.throwOnResume = new InvalidTransactionException("invalid tx");
 
-        assertThatThrownBy(() -> executor.executeNew(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.executeNew(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Failed to resume suspended transaction")
             .hasCauseInstanceOf(InvalidTransactionException.class);
@@ -289,7 +289,7 @@ class TxExecutorTest {
         tx.transactionToReturn = outer;
         tx.throwOnResume = new SystemException("resume failed");
 
-        assertThatThrownBy(() -> executor.executeNew(() -> "x", v -> false))
+        assertThatThrownBy(() -> executor.executeNew(() -> "x", _ -> false))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Failed to resume suspended transaction")
             .hasCauseInstanceOf(SystemException.class);
@@ -304,7 +304,7 @@ class TxExecutorTest {
     void execute_required_noOuterTx_beginsAndCommits() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+        var result = executor.execute(() -> "ok", _ -> false, Transactional.TxType.REQUIRED);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.beginCount).isEqualTo(1);
@@ -316,7 +316,7 @@ class TxExecutorTest {
     void execute_required_noOuterTx_rollsBackOnErr() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        executor.execute(() -> "err", v -> true, Transactional.TxType.REQUIRED);
+        executor.execute(() -> "err", _ -> true, Transactional.TxType.REQUIRED);
 
         assertThat(tx.beginCount).isEqualTo(1);
         assertThat(tx.rollbackCount).isEqualTo(1);
@@ -327,7 +327,7 @@ class TxExecutorTest {
     void execute_required_withOuterTx_joinsAndCommitsViaOuter() {
         // status is ACTIVE by default — should join, not begin
 
-        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+        var result = executor.execute(() -> "ok", _ -> false, Transactional.TxType.REQUIRED);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.beginCount).isEqualTo(0);
@@ -337,7 +337,7 @@ class TxExecutorTest {
 
     @Test
     void execute_required_withOuterTx_setsRollbackOnlyOnErr() {
-        executor.execute(() -> "err", v -> true, Transactional.TxType.REQUIRED);
+        executor.execute(() -> "err", _ -> true, Transactional.TxType.REQUIRED);
 
         assertThat(tx.beginCount).isEqualTo(0);
         assertThat(tx.rollbackCount).isEqualTo(0);
@@ -349,7 +349,7 @@ class TxExecutorTest {
         assertThatThrownBy(() ->
             executor.execute(
                 () -> { throw new RuntimeException("boom"); },
-                v -> false,
+                _ -> false,
                 Transactional.TxType.REQUIRED))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("boom");
@@ -364,7 +364,7 @@ class TxExecutorTest {
     void execute_mandatory_withoutTx_throwsTransactionalException() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.MANDATORY))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _-> false, Transactional.TxType.MANDATORY))
             .isInstanceOf(TransactionalException.class)
             .hasMessageContaining("MANDATORY");
 
@@ -373,7 +373,7 @@ class TxExecutorTest {
 
     @Test
     void execute_mandatory_withTx_joinsAndSetsRollbackOnlyOnErr() {
-        executor.execute(() -> "err", v -> true, Transactional.TxType.MANDATORY);
+        executor.execute(() -> "err", _ -> true, Transactional.TxType.MANDATORY);
 
         assertThat(tx.beginCount).isEqualTo(0);
         assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
@@ -383,7 +383,7 @@ class TxExecutorTest {
 
     @Test
     void execute_supports_withTx_joinsAndSetsRollbackOnlyOnErr() {
-        executor.execute(() -> "err", v -> true, Transactional.TxType.SUPPORTS);
+        executor.execute(() -> "err", _ -> true, Transactional.TxType.SUPPORTS);
 
         assertThat(tx.beginCount).isEqualTo(0);
         assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
@@ -393,7 +393,7 @@ class TxExecutorTest {
     void execute_supports_withoutTx_runsWithoutBeginOrCommit() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.SUPPORTS);
+        var result = executor.execute(() -> "ok", _ -> false, Transactional.TxType.SUPPORTS);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.beginCount).isEqualTo(0);
@@ -408,7 +408,7 @@ class TxExecutorTest {
         var outer = new StubTransaction();
         tx.transactionToReturn = outer;
 
-        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+        var result = executor.execute(() -> "ok", _ -> false, Transactional.TxType.NOT_SUPPORTED);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.suspendCount).isEqualTo(1);
@@ -421,7 +421,7 @@ class TxExecutorTest {
     void execute_notSupported_withoutTx_doesNotSuspend() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+        executor.execute(() -> "ok", _ -> false, Transactional.TxType.NOT_SUPPORTED);
 
         assertThat(tx.suspendCount).isEqualTo(0);
         assertThat(tx.resumeCount).isEqualTo(0);
@@ -431,7 +431,7 @@ class TxExecutorTest {
 
     @Test
     void execute_never_withTx_throwsTransactionalException() {
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.NEVER))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false, Transactional.TxType.NEVER))
             .isInstanceOf(TransactionalException.class)
             .hasMessageContaining("NEVER");
 
@@ -442,11 +442,52 @@ class TxExecutorTest {
     void execute_never_withoutTx_runsWithoutBeginOrCommit() {
         tx.statusToReturn = Status.STATUS_NO_TRANSACTION;
 
-        var result = executor.execute(() -> "ok", v -> false, Transactional.TxType.NEVER);
+        var result = executor.execute(() -> "ok", _ -> false, Transactional.TxType.NEVER);
 
         assertThat(result).isEqualTo("ok");
         assertThat(tx.beginCount).isEqualTo(0);
         assertThat(tx.commitCount).isEqualTo(0);
+    }
+
+    // ── hasActiveTransaction — SystemException ────────────────────────────────
+
+    @Test
+    void execute_required_getStatusThrowsSystemException_wrapsInRuntimeException() {
+        tx.throwOnGetStatus = new SystemException("getStatus failed");
+
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false, Transactional.TxType.REQUIRED))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("JTA transaction management failed")
+            .hasCauseInstanceOf(SystemException.class);
+    }
+
+    // ── executeNotSupported — suspend SystemException ─────────────────────────
+
+    @Test
+    void execute_notSupported_suspendThrowsSystemException_wrapsInRuntimeException() {
+        // STATUS_ACTIVE by default → hasActiveTransaction() returns true → suspend() is called
+        tx.throwOnSuspend = new SystemException("suspend failed");
+
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false, Transactional.TxType.NOT_SUPPORTED))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("JTA transaction management failed")
+            .hasCauseInstanceOf(SystemException.class);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+    }
+
+    // ── setRollbackOnlyQuietly — SystemException swallowed ───────────────────
+
+    @Test
+    void execute_required_setRollbackOnlyThrowsSystemException_isSwallowed() {
+        // STATUS_ACTIVE by default → executeJoined → setRollbackOnlyQuietly(); exception is swallowed
+        tx.throwOnSetRollbackOnly = new SystemException("setRollbackOnly failed");
+
+        var result = executor.execute(() -> "err", _ -> true, Transactional.TxType.REQUIRED);
+
+        assertThat(result).isEqualTo("err");
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(1);
+        assertThat(tx.rollbackCount).isEqualTo(0);
     }
 
     // ── execute(TxType) — STATUS_MARKED_ROLLBACK regression ──────────────────
@@ -457,7 +498,7 @@ class TxExecutorTest {
     void execute_required_markedRollback_joinsInsteadOfBeginningNew() {
         tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
 
-        executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+        executor.execute(() -> "ok", _ -> false, Transactional.TxType.REQUIRED);
 
         assertThat(tx.beginCount).isEqualTo(0);  // joined, not started
         assertThat(tx.commitCount).isEqualTo(0);
@@ -467,7 +508,7 @@ class TxExecutorTest {
     void execute_mandatory_markedRollback_joinsInsteadOfThrowing() {
         tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
 
-        executor.execute(() -> "ok", v -> false, Transactional.TxType.MANDATORY);
+        executor.execute(() -> "ok", _ -> false, Transactional.TxType.MANDATORY);
 
         assertThat(tx.beginCount).isEqualTo(0);  // joined, not thrown
     }
@@ -476,7 +517,7 @@ class TxExecutorTest {
     void execute_supports_markedRollback_joinsInsteadOfRunningWithoutTx() {
         tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
 
-        executor.execute(() -> "ok", v -> false, Transactional.TxType.SUPPORTS);
+        executor.execute(() -> "ok", _ -> false, Transactional.TxType.SUPPORTS);
 
         assertThat(tx.beginCount).isEqualTo(0);
         assertThat(tx.commitCount).isEqualTo(0);
@@ -488,7 +529,7 @@ class TxExecutorTest {
         tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
         tx.transactionToReturn = new StubTransaction();
 
-        executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+        executor.execute(() -> "ok", _ -> false, Transactional.TxType.NOT_SUPPORTED);
 
         assertThat(tx.suspendCount).isEqualTo(1);
         assertThat(tx.resumeCount).isEqualTo(1);
@@ -498,7 +539,7 @@ class TxExecutorTest {
     void execute_never_markedRollback_throwsLikeActiveTx() {
         tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
 
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.NEVER))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false, Transactional.TxType.NEVER))
             .isInstanceOf(TransactionalException.class)
             .hasMessageContaining("NEVER");
     }
@@ -507,7 +548,7 @@ class TxExecutorTest {
 
     @Test
     void execute_txType_nullAction_throwsNPE() {
-        assertThatThrownBy(() -> executor.execute(null, v -> false, Transactional.TxType.REQUIRED))
+        assertThatThrownBy(() -> executor.execute(null, _ -> false, Transactional.TxType.REQUIRED))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("action");
     }
@@ -521,7 +562,7 @@ class TxExecutorTest {
 
     @Test
     void execute_txType_nullTxType_throwsNPE() {
-        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, null))
+        assertThatThrownBy(() -> executor.execute(() -> "x", _ -> false, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("txType");
     }

--- a/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
+++ b/frameworks/quarkus/runtime/src/test/java/dmx/fun/quarkus/TxExecutorTest.java
@@ -449,6 +449,60 @@ class TxExecutorTest {
         assertThat(tx.commitCount).isEqualTo(0);
     }
 
+    // ── execute(TxType) — STATUS_MARKED_ROLLBACK regression ──────────────────
+    // After setRollbackOnly() the status is MARKED_ROLLBACK, not ACTIVE.
+    // All propagation decisions must treat MARKED_ROLLBACK as "has active tx".
+
+    @Test
+    void execute_required_markedRollback_joinsInsteadOfBeginningNew() {
+        tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
+
+        executor.execute(() -> "ok", v -> false, Transactional.TxType.REQUIRED);
+
+        assertThat(tx.beginCount).isEqualTo(0);  // joined, not started
+        assertThat(tx.commitCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_mandatory_markedRollback_joinsInsteadOfThrowing() {
+        tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
+
+        executor.execute(() -> "ok", v -> false, Transactional.TxType.MANDATORY);
+
+        assertThat(tx.beginCount).isEqualTo(0);  // joined, not thrown
+    }
+
+    @Test
+    void execute_supports_markedRollback_joinsInsteadOfRunningWithoutTx() {
+        tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
+
+        executor.execute(() -> "ok", v -> false, Transactional.TxType.SUPPORTS);
+
+        assertThat(tx.beginCount).isEqualTo(0);
+        assertThat(tx.commitCount).isEqualTo(0);
+        assertThat(tx.setRollbackOnlyCount).isEqualTo(0);
+    }
+
+    @Test
+    void execute_notSupported_markedRollback_suspendsLikeActiveTx() {
+        tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
+        tx.transactionToReturn = new StubTransaction();
+
+        executor.execute(() -> "ok", v -> false, Transactional.TxType.NOT_SUPPORTED);
+
+        assertThat(tx.suspendCount).isEqualTo(1);
+        assertThat(tx.resumeCount).isEqualTo(1);
+    }
+
+    @Test
+    void execute_never_markedRollback_throwsLikeActiveTx() {
+        tx.statusToReturn = Status.STATUS_MARKED_ROLLBACK;
+
+        assertThatThrownBy(() -> executor.execute(() -> "x", v -> false, Transactional.TxType.NEVER))
+            .isInstanceOf(TransactionalException.class)
+            .hasMessageContaining("NEVER");
+    }
+
     // ── execute(TxType) — null checks ─────────────────────────────────────────
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.configuration-cache=true
 group=codes.domix
-version=0.0.15-SNAPSHOT
+version=0.0.14

--- a/site/src/data/code/guide/quarkus/execute-new.mdx
+++ b/site/src/data/code/guide/quarkus/execute-new.mdx
@@ -1,0 +1,24 @@
+---
+fileName: 'OrderService.java'
+---
+
+```java
+@ApplicationScoped
+public class OrderService {
+    @Inject TxResult tx;
+    @Inject AuditLog auditLog;
+    @Inject OrderRepository repo;
+
+    public Result<Order, OrderError> createOrder(OrderRequest req) {
+        return tx.execute(() -> {
+            // Inner call starts a brand-new independent transaction.
+            // Even if the outer tx rolls back, the audit entry is already committed.
+            tx.executeNew(() -> auditLog.record("createOrder attempted", req));
+
+            return validate(req).flatMap(repo::save);
+            // • Ok(order)       → outer tx commits
+            // • Err(orderError) → outer tx rolls back, but audit entry persists
+        });
+    }
+}
+```

--- a/site/src/data/code/guide/quarkus/tx-type-propagation.mdx
+++ b/site/src/data/code/guide/quarkus/tx-type-propagation.mdx
@@ -1,0 +1,39 @@
+---
+fileName: 'OrderService.java'
+---
+
+```java
+@ApplicationScoped
+public class OrderService {
+
+    // REQUIRED (default) — join an existing tx or start a new one.
+    // Most methods should use this.
+    @TransactionalResult
+    public Result<Order, OrderError> createOrder(OrderRequest req) { ... }
+
+    // REQUIRES_NEW — always suspend any active tx and start a fresh one.
+    // Use when the operation must commit/rollback independently of the caller.
+    @TransactionalResult(Transactional.TxType.REQUIRES_NEW)
+    public Result<AuditEntry, String> recordAudit(AuditEvent event) { ... }
+
+    // MANDATORY — require an active transaction; throw if none is present.
+    // Use for internal helpers that must only be called from within a tx.
+    @TransactionalResult(Transactional.TxType.MANDATORY)
+    public Result<Void, String> validateInTx(Order order) { ... }
+
+    // SUPPORTS — join if a tx is active; otherwise run without one.
+    // Use for read-only operations that are safe either way.
+    @TransactionalResult(Transactional.TxType.SUPPORTS)
+    public Result<Order, String> findOrder(String id) { ... }
+
+    // NOT_SUPPORTED — suspend any active tx and run without one (auto-commit).
+    // Use when the operation must not run inside a transaction at all.
+    @TransactionalResult(Transactional.TxType.NOT_SUPPORTED)
+    public Result<Report, String> generateReport(String id) { ... }
+
+    // NEVER — throw if a transaction is active.
+    // Use to assert that no caller holds an open transaction.
+    @TransactionalResult(Transactional.TxType.NEVER)
+    public Result<Stats, String> computeStats() { ... }
+}
+```

--- a/site/src/data/guide/quarkus.mdx
+++ b/site/src/data/guide/quarkus.mdx
@@ -8,9 +8,11 @@ h1: "Quarkus Integration"
 import {Content as Dependency}             from '../code/guide/quarkus/dependency.mdx';
 import {Content as TxResultSnippet}        from '../code/guide/quarkus/tx-result.mdx';
 import {Content as TxTrySnippet}           from '../code/guide/quarkus/tx-try.mdx';
+import {Content as ExecuteNew}             from '../code/guide/quarkus/execute-new.mdx';
 import {Content as VsTransactional}        from '../code/guide/quarkus/vs-transactional.mdx';
 import {Content as TransactionalResult}    from '../code/guide/quarkus/transactional-result.mdx';
 import {Content as TransactionalTry}       from '../code/guide/quarkus/transactional-try.mdx';
+import {Content as TxTypePropagation}      from '../code/guide/quarkus/tx-type-propagation.mdx';
 import {Content as ProgrammaticVsDeclarative} from '../code/guide/quarkus/programmatic-vs-declarative.mdx';
 
 The `fun-quarkus` module adds first-class Quarkus transaction support for `Result<V,E>` and
@@ -53,6 +55,17 @@ result is `isError()`.
 | Action returns `Result.isError()` | Rolls back |
 | Action throws an unchecked exception | Rolls back, rethrows |
 
+### `TxResult.executeNew()` — REQUIRES_NEW semantics
+
+`executeNew()` suspends any currently active transaction, starts a brand-new independent
+one, and resumes the original transaction after the action finishes — regardless of whether
+the inner transaction committed or rolled back.
+
+<ExecuteNew/>
+
+Use `executeNew()` when the inner operation must commit independently of the outer
+transaction (audit logs, billing events, notifications).
+
 ## `TxTry`
 
 Wraps a `Try<V>`-returning action in a JTA-managed transaction. Rolls back when the result
@@ -67,6 +80,8 @@ is `isFailure()`.
 | Action returns `Try.isSuccess()` | Commits |
 | Action returns `Try.isFailure()` | Rolls back |
 | Action throws an unchecked exception | Rolls back, rethrows |
+
+`TxTry` also provides `executeNew()` with the same REQUIRES_NEW semantics described above.
 
 ## `TxResult` vs `TxTry` vs `@Transactional`
 
@@ -98,8 +113,8 @@ without needing two separate interceptor classes.
 
 At runtime the interceptor inspects the method's return value: if `@TransactionalResult` is
 present it checks `Result#isError()`; if `@TransactionalTry` is present it checks
-`Try#isFailure()`. Either way, a truthy result triggers a rollback via
-`UserTransaction.rollback()`.
+`Try#isFailure()`. Either way, a truthy result triggers a rollback (or marks the joined
+transaction rollback-only when the method joined an existing transaction).
 
 ### `@TransactionalResult`
 
@@ -121,6 +136,28 @@ present it checks `Result#isError()`; if `@TransactionalTry` is present it check
 | Returns `Try.isFailure()` | Rolls back |
 | Throws unchecked exception | Rolls back, rethrows |
 
+### Propagation semantics (`TxType`)
+
+Both annotations accept an optional `value()` attribute of type `Transactional.TxType`
+(default `REQUIRED`). The interceptor reads this value at runtime and applies the
+corresponding JTA propagation behaviour.
+
+| `TxType` | Existing tx present | No active tx |
+|---|---|---|
+| `REQUIRED` *(default)* | Joins the existing tx; marks rollback-only on error | Begins a new tx; commits or rolls back |
+| `REQUIRES_NEW` | Suspends outer tx, starts fresh tx, resumes outer after | Starts a fresh tx |
+| `MANDATORY` | Joins the existing tx | Throws `TransactionalException` |
+| `SUPPORTS` | Joins the existing tx; marks rollback-only on error | Runs without a tx (no begin/commit) |
+| `NOT_SUPPORTED` | Suspends outer tx, runs without one, resumes outer after | Runs without a tx |
+| `NEVER` | Throws `TransactionalException` | Runs without a tx |
+
+**Join semantics note:** When a method joins an existing transaction (`REQUIRED`,
+`MANDATORY`, `SUPPORTS`), it does not call `commit()` or `rollback()` — the caller owns
+the boundary. On error or exception the interceptor calls `setRollbackOnly()` so the outer
+transaction is guaranteed to roll back when it eventually closes.
+
+<TxTypePropagation/>
+
 ### Annotation placement
 
 Both annotations can be placed on a **method** or on a **class**. Class-level placement
@@ -140,7 +177,7 @@ public class OrderService {
 <ProgrammaticVsDeclarative/>
 
 Choose **programmatic** (`TxResult` / `TxTry`) when:
-- You want an explicit, testable object — straightforward to unit-test by passing a stub `UserTransaction`.
+- You want an explicit, testable object — straightforward to unit-test by passing a stub `TransactionManager`.
 - The service class already has `@Inject` dependencies and adding one more is natural.
 
 Choose **declarative** (`@TransactionalResult` / `@TransactionalTry`) when:

--- a/site/src/data/guide/quarkus.mdx
+++ b/site/src/data/guide/quarkus.mdx
@@ -15,6 +15,11 @@ import {Content as TransactionalTry}       from '../code/guide/quarkus/transacti
 import {Content as TxTypePropagation}      from '../code/guide/quarkus/tx-type-propagation.mdx';
 import {Content as ProgrammaticVsDeclarative} from '../code/guide/quarkus/programmatic-vs-declarative.mdx';
 
+> **Early-stage support:** The `fun-quarkus` module is in its early stages. The API is
+> functional and tested, but you may encounter rough edges in real-world usage. Please
+> proceed with care and [report any issues](https://github.com/domix/dmx-fun/issues) you
+> find — feedback is very welcome and helps drive the module forward.
+
 The `fun-quarkus` module adds first-class Quarkus transaction support for `Result<V,E>` and
 `Try<V>`. It is an **optional** dependency — the core `fun` library has no runtime dependency
 on Quarkus.


### PR DESCRIPTION
- **feat(quarkus): add TxType propagation support to `@TransactionalResult` and `@TransactionalTry`**
- **docs(quarkus): document TxType propagation, executeNew, and fix stale UserTransaction refs**

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #129

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction propagation added for all TxTypes (REQUIRES_NEW, REQUIRED, MANDATORY, SUPPORTS, NOT_SUPPORTED, NEVER) with declarative and programmatic support
  * Declarative annotations extended to accept a configurable TxType

* **Documentation**
  * New and expanded guides with examples, propagation semantics table, and executeNew guidance

* **Tests**
  * Expanded integration and unit tests covering propagation modes, edge cases, and error/rollback behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->