### PR TITLE
feat(guard): add checkToEither, checkToTry, and checkToOptional interop methods (#289)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -504,11 +504,11 @@ public interface Guard<T> {
      * }</pre>
      *
      * @param value the value to validate
-     * @return {@code Optional.of(value)} if the guard passes, or {@code Optional.empty()} if
-     *         it fails
+     * @return {@code Optional.of(value)} if the guard passes and {@code value} is non-null,
+     *         {@code Optional.empty()} if the guard fails or {@code value} is null
      */
     default Optional<T> checkToOptional(T value) {
-        return this.check(value).isValid() ? Optional.of(value) : Optional.empty();
+        return this.check(value).isValid() ? Optional.ofNullable(value) : Optional.empty();
     }
 
     /**

--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -1,6 +1,7 @@
 package dmx.fun;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
@@ -389,6 +390,125 @@ public interface Guard<T> {
     default Option<T> checkToOption(T value) {
         var result = this.check(value);
         return result.isValid() ? Option.some(result.get()) : Option.none();
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns an {@link Either Either&lt;NonEmptyList&lt;String&gt;, T&gt;}.
+     *
+     * <p>Returns {@code Either.right(value)} when the guard passes and
+     * {@code Either.left(errors)} when it fails. Use this when downstream logic is already
+     * expressed in terms of {@link Either}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * Either<NonEmptyList<String>, String> right = notBlank.checkToEither("hello");
+     * // Either.right("hello")
+     *
+     * Either<NonEmptyList<String>, String> left = notBlank.checkToEither("   ");
+     * // Either.left(NonEmptyList.of("must not be blank"))
+     * }</pre>
+     *
+     * @param value the value to validate
+     * @return {@code Either.right(value)} if the guard passes, or
+     *         {@code Either.left(errors)} if it fails
+     */
+    default Either<NonEmptyList<String>, T> checkToEither(T value) {
+        var result = this.check(value);
+        return result.isValid()
+            ? Either.right(result.get())
+            : Either.left(result.getError());
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns a {@code Try<T>}.
+     *
+     * <p>Returns {@code Try.success(value)} when the guard passes. When it fails, the
+     * accumulated error messages are joined with {@code "; "} and wrapped in an
+     * {@link IllegalArgumentException}. Use {@link #checkToTry(Object, Function)} to supply
+     * a domain-specific exception instead.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * Try<String> success = notBlank.checkToTry("hello");
+     * // Try.success("hello")
+     *
+     * Try<String> failure = notBlank.checkToTry("   ");
+     * // Try.failure(new IllegalArgumentException("must not be blank"))
+     * }</pre>
+     *
+     * @param value the value to validate
+     * @return {@code Try.success(value)} if the guard passes, or a {@code Try.failure} wrapping
+     *         an {@link IllegalArgumentException} with the joined error messages
+     */
+    default Try<T> checkToTry(T value) {
+        return checkToTry(
+            value,
+            errors -> new IllegalArgumentException(
+                String.join("; ", errors.toList())
+            )
+        );
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns a {@code Try<T>}, converting any
+     * accumulated errors to a domain-specific {@link Throwable} via {@code toThrowable}.
+     *
+     * <p>Use this at boundaries where the caller controls the exception type.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = notBlank.and(minLength3);
+     *
+     * Try<String> result = username.checkToTry(
+     *     input,
+     *     errors -> new ValidationException(errors.toList())
+     * );
+     * }</pre>
+     *
+     * @param <X>         the throwable type
+     * @param value       the value to validate
+     * @param toThrowable function mapping the accumulated error list to a {@link Throwable};
+     *                    must not be {@code null}
+     * @return {@code Try.success(value)} if the guard passes, or
+     *         {@code Try.failure(toThrowable(errors))} if it fails
+     * @throws NullPointerException if {@code toThrowable} is {@code null}
+     */
+    default <X extends Throwable> Try<T> checkToTry(
+        T value,
+        Function<NonEmptyList<String>, X> toThrowable
+    ) {
+        Objects.requireNonNull(toThrowable, "toThrowable");
+        var result = this.check(value);
+        return result.isValid()
+            ? Try.success(result.get())
+            : Try.failure(toThrowable.apply(result.getError()));
+    }
+
+    /**
+     * Applies this guard to {@code value} and returns a standard {@link Optional Optional&lt;T&gt;}.
+     *
+     * <p>Returns {@code Optional.of(value)} when the guard passes and {@link Optional#empty()}
+     * when it fails, discarding the error details. Use this to integrate with Java standard
+     * library APIs that work with {@link Optional}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * Optional<String> present = notBlank.checkToOptional("hello"); // Optional.of("hello")
+     * Optional<String> empty   = notBlank.checkToOptional("   ");   // Optional.empty()
+     * }</pre>
+     *
+     * @param value the value to validate
+     * @return {@code Optional.of(value)} if the guard passes, or {@code Optional.empty()} if
+     *         it fails
+     */
+    default Optional<T> checkToOptional(T value) {
+        return this.check(value).isValid() ? Optional.of(value) : Optional.empty();
     }
 
     /**

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -586,6 +586,17 @@ class GuardTest {
     }
 
     @Test
+    void checkToOptional_returnsEmpty_forNullInput_doesNotThrowNPE() {
+        // Guard.nonNull() is typed Guard<@Nullable T> and rejects null → Optional.empty()
+        // Regression: Optional.ofNullable is used so null never reaches Optional.of(null).
+        Guard<@Nullable String> nonNullGuard = Guard.nonNull();
+
+        Optional<@Nullable String> result = nonNullGuard.checkToOptional(null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void checkToOptional_usefulForOptionalChaining() {
         var minLength = Guard.<String>of(s -> s.length() >= 3, "min 3 chars");
         var username = notBeBlank.and(minLength);

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -1,5 +1,6 @@
 package dmx.fun;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -484,6 +485,116 @@ class GuardTest {
     void andThen_shouldThrowNPE_whenNextIsNull() {
         assertThatThrownBy(() -> notBeBlank.andThen(null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToEither
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToEither_returnsRight_whenGuardPasses() {
+        var result = notBeBlank.checkToEither("hello");
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight()).isEqualTo("hello");
+    }
+
+    @Test
+    void checkToEither_returnsLeft_whenGuardFails() {
+        var result = notBeBlank.checkToEither("   ");
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft().toList()).containsExactly("must not be blank");
+    }
+
+    @Test
+    void checkToEither_accumulatesAllErrors_whenComposedGuardFails() {
+        var minLength = Guard.<String>of(s -> s.length() >= 3, "min 3 chars");
+        var result = notBeBlank.and(minLength).checkToEither("  ");
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft().toList()).containsExactly("must not be blank", "min 3 chars");
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToTry — default IllegalArgumentException
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToTry_returnsSuccess_whenGuardPasses() {
+        var result = notBeBlank.checkToTry("hello");
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void checkToTry_returnsFailure_whenGuardFails() {
+        var result = notBeBlank.checkToTry("   ");
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(IllegalArgumentException.class);
+        assertThat(result.getCause().getMessage()).isEqualTo("must not be blank");
+    }
+
+    @Test
+    void checkToTry_joinsMultipleErrors_withSemicolon() {
+        var minLength = Guard.<String>of(s -> s.length() >= 3, "min 3 chars");
+        var result = notBeBlank.and(minLength).checkToTry("  ");
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause().getMessage()).isEqualTo("must not be blank; min 3 chars");
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToTry — custom throwable mapper
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToTry_withMapper_returnsSuccess_whenGuardPasses() {
+        var result = notBeBlank.checkToTry("hello", errors -> new RuntimeException("oops"));
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void checkToTry_withMapper_usesProvidedThrowable_whenGuardFails() {
+        var result = notBeBlank.checkToTry(
+            "   ",
+            errors -> new IllegalStateException(String.join("|", errors.toList()))
+        );
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(IllegalStateException.class);
+        assertThat(result.getCause().getMessage()).isEqualTo("must not be blank");
+    }
+
+    @Test
+    void checkToTry_withMapper_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> notBeBlank.checkToTry("x",
+            (java.util.function.Function<NonEmptyList<String>, RuntimeException>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("toThrowable");
+    }
+
+    // -------------------------------------------------------------------------
+    // checkToOptional
+    // -------------------------------------------------------------------------
+
+    @Test
+    void checkToOptional_returnsPresent_whenGuardPasses() {
+        Optional<String> result = notBeBlank.checkToOptional("hello");
+        assertThat(result).isPresent().contains("hello");
+    }
+
+    @Test
+    void checkToOptional_returnsEmpty_whenGuardFails() {
+        Optional<String> result = notBeBlank.checkToOptional("   ");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void checkToOptional_usefulForOptionalChaining() {
+        var minLength = Guard.<String>of(s -> s.length() >= 3, "min 3 chars");
+        var username = notBeBlank.and(minLength);
+
+        Optional<String> valid = username.checkToOptional("alice").map(String::toUpperCase);
+        assertThat(valid).contains("ALICE");
+
+        Optional<String> invalid = username.checkToOptional("a!").map(String::toUpperCase);
+        assertThat(invalid).isEmpty();
     }
 
     @Test

--- a/site/src/data/code/guide/guard/interop.mdx
+++ b/site/src/data/code/guide/guard/interop.mdx
@@ -28,6 +28,25 @@ Result<String, String> r2 = username.checkToResult(
     "a!", errors -> String.join("; ", errors.toList()));
 // Result.err("min 3 chars")
 
+// checkToEither(value) — Either<NonEmptyList<String>, T>
+Either<NonEmptyList<String>, String> right = username.checkToEither("alice");
+// Either.right("alice")
+Either<NonEmptyList<String>, String> left  = username.checkToEither("a!");
+// Either.left(NonEmptyList.of("min 3 chars"))
+
+// checkToTry(value) — Try<T> with default IllegalArgumentException
+Try<String> success = username.checkToTry("alice");
+// Try.success("alice")
+Try<String> failure = username.checkToTry("a!");
+// Try.failure(new IllegalArgumentException("min 3 chars"))
+
+// checkToTry(value, toThrowable) — caller controls the exception type
+Try<String> typed = username.checkToTry(
+    "a!",
+    errors -> new ValidationException(errors.toList())
+);
+// Try.failure(new ValidationException(["min 3 chars"]))
+
 // checkToOption(value) — discard errors, keep value or None
 Option<String> opt = username.checkToOption("alice");   // Some("alice")
 username.checkToOption("a!");                           // None
@@ -37,4 +56,13 @@ List<String> valid = Stream.of("alice", "a!", "bob")
     .flatMap(s -> username.checkToOption(s).stream())
     .toList();
 // ["alice", "bob"]
+
+// checkToOptional(value) — Java standard Optional<T>
+Optional<String> present = username.checkToOptional("alice"); // Optional.of("alice")
+Optional<String> empty   = username.checkToOptional("a!");    // Optional.empty()
+
+// integrates naturally with Optional chaining
+String upper = username.checkToOptional(input)
+    .map(String::toUpperCase)
+    .orElse("INVALID");
 ```

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -104,13 +104,17 @@ Validated<NonEmptyList<String>, Form> form =
 
 ## Interoperability
 
-| Method                         | Returns                           | Use case                                                                |
-|--------------------------------|-----------------------------------|-------------------------------------------------------------------------|
-| `asPredicate()`                | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
-| `contramap(fn)`                | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
-| `checkToResult(value)`         | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic                       |
-| `checkToResult(value, mapper)` | `Result<T, E>`                    | Map errors to a domain-specific error type at service boundaries        |
-| `checkToOption(value)`         | `Option<T>`                       | Discard errors — keep only valid values (stream filtering)              |
+| Method                             | Returns                           | Use case                                                                |
+|------------------------------------|-----------------------------------|-------------------------------------------------------------------------|
+| `asPredicate()`                    | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
+| `contramap(fn)`                    | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
+| `checkToResult(value)`             | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic                       |
+| `checkToResult(value, mapper)`     | `Result<T, E>`                    | Map errors to a domain-specific error type at service boundaries        |
+| `checkToEither(value)`             | `Either<NonEmptyList<String>, T>` | Integrate with Either-based pipelines (left = errors, right = value)    |
+| `checkToTry(value)`                | `Try<T>`                          | Integrate with Try-based pipelines; errors joined as `IllegalArgumentException` |
+| `checkToTry(value, toThrowable)`   | `Try<T>`                          | Integrate with Try-based pipelines; caller controls the exception type  |
+| `checkToOption(value)`             | `Option<T>`                       | Discard errors — keep only valid values (stream filtering)              |
+| `checkToOptional(value)`           | `Optional<T>`                     | Java standard `Optional` interop — drop-in for APIs expecting `Optional` |
 
 <Interop/>
 


### PR DESCRIPTION
# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #289

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added result-conversion helpers for validation guards so callers can obtain Either, Try (with optional custom exception mapping), or Optional forms from guard evaluations.

* **Tests**
  * Added coverage for the new conversions, including success/failure paths, error accumulation, and custom-exception mapping behavior.

* **Documentation**
  * Updated guides and examples demonstrating each conversion and common usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->