### PR TITLE
feat(site): add ADR section sourced from docs/adr/

### DIFF
--- a/docs/adr/ADR-001-java-version.md
+++ b/docs/adr/ADR-001-java-version.md
@@ -1,0 +1,31 @@
+---
+number: 1
+title: "Java 25 as the minimum required version"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+At project inception, a minimum Java version was chosen. This decision affects which language and JDK features can be used, and which audience can adopt the library.
+
+## Decision
+
+Require **Java 25** as the minimum version.
+
+## Consequences
+
+**Positive:**
+- Access to `Gatherer` (Java 22+) to implement `sequence`/`traverse` with true short-circuit.
+- Stable virtual threads (Java 21+) used in `Try.withTimeout`.
+- Exhaustive pattern matching in `switch` over sealed interfaces.
+- Record patterns, unnamed variables (`_`), and other post-17 features.
+
+**Negative / tradeoffs:**
+- Limits the audience to projects already migrated to Java 21+.
+- Enterprise projects with slow upgrade cycles cannot adopt the library immediately.
+
+## Alternatives considered
+
+- **Java 21 (LTS):** would have covered most features but excludes `Gatherer`.
+- **Java 17 (LTS):** wider adoption, but lacks full sealed interfaces and advanced pattern matching.

--- a/docs/adr/ADR-002-jpms.md
+++ b/docs/adr/ADR-002-jpms.md
@@ -1,0 +1,30 @@
+---
+number: 2
+title: "JPMS from day one"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+The library could be published as a plain jar (classpath) or adopt the Java Platform Module System from the first release.
+
+## Decision
+
+Adopt **JPMS** from the start with a `module-info.java` that declares explicit exports.
+
+## Consequences
+
+**Positive:**
+- The public API is deliberate: only `dmx.fun` is exported.
+- Strong encapsulation of internals without relying on naming conventions.
+- Compatibility with environments that require modules (`jlink`, `jpackage`).
+
+**Negative / tradeoffs:**
+- Additional build complexity (classpath vs module-path in tests, `--add-opens`, `jpmsTest` configuration).
+- Some testing and reflection frameworks require extra configuration.
+
+## Alternatives considered
+
+- **Plain jar:** simpler, wider immediate compatibility, but no strong encapsulation.
+- **Automatic module:** module name inferred from the jar, no control over exports — discarded as a transitional approach.

--- a/docs/adr/ADR-003-sealed-interfaces-records.md
+++ b/docs/adr/ADR-003-sealed-interfaces-records.md
@@ -1,0 +1,31 @@
+---
+number: 3
+title: "Sealed interfaces + records as ADT representation"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+Algebraic types (`Result`, `Try`, `Option`, `Either`, `Validated`) need to represent exactly two variants without allowing external extension.
+
+## Decision
+
+Implement each type as a **`sealed interface`** with **`record`** variants (`Ok`/`Err`, `Success`/`Failure`, `Some`/`None`, etc.).
+
+## Consequences
+
+**Positive:**
+- The compiler verifies exhaustiveness in `switch` — no risk of missing a variant.
+- Records eliminate boilerplate (constructor, `equals`, `hashCode`, `toString`).
+- Pattern matching (`case Ok<V, E>(V v) ->`) extracts values in a single expression.
+- No third variant can be created externally — the contract is unbreakable.
+
+**Negative / tradeoffs:**
+- Requires Java 17+ for sealed, Java 21+ for full pattern matching in switch.
+- Records do not support state inheritance — all logic must live on the interface as `default` methods.
+
+## Alternatives considered
+
+- **Abstract class + subclasses:** no exhaustiveness guarantee, more boilerplate.
+- **Enum with generic payload:** impossible with generic types in Java.

--- a/docs/adr/ADR-004-null-in-try-vs-result.md
+++ b/docs/adr/ADR-004-null-in-try-vs-result.md
@@ -1,0 +1,31 @@
+---
+number: 4
+title: "Try<V> allows Success(null); Result.Ok rejects null"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Try.run()` executes a void `CheckedRunnable`. In Java, `Void` has no instances, so the successful return value is necessarily `null`. `Result.Ok`, on the other hand, models an explicit domain value that must always be meaningful.
+
+## Decision
+
+- **`Try.Success`** accepts `null` as a valid value (produced by `Try.run()`).
+- **`Result.Ok`** rejects `null` — its constructor throws `NullPointerException`.
+
+## Consequences
+
+**Positive:**
+- `Try.run()` can represent void side-effects without requiring a dedicated `Unit` type.
+- `Result` guarantees that a successful value is always meaningful.
+
+**Negative / tradeoffs:**
+- Deliberate asymmetry between `Try` and `Result` that must be documented.
+- `Try.Success(null).toOption()` always returns `None` — surprising behavior if the reason is not known.
+- `Try.Success(null).toEither()` throws `NullPointerException` — `Either` does not allow null on either track.
+
+## Alternatives considered
+
+- **Reject null in both:** would require a `Unit` or sentinel `Void` type, adding complexity.
+- **Allow null in both:** removes the non-null guarantee from `Result`, which is part of its safety contract.

--- a/docs/adr/ADR-005-guard-error-type.md
+++ b/docs/adr/ADR-005-guard-error-type.md
@@ -1,0 +1,30 @@
+---
+number: 5
+title: "Guard<T> accumulates errors as a fixed NonEmptyList<String>"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Guard<T>` needs an error type to represent validation failures. The natural alternative would be to make it generic (`Guard<T, E>`), but that drastically complicates composition.
+
+## Decision
+
+The error type of `Guard<T>` is always **`NonEmptyList<String>`** — human-readable error messages as strings.
+
+## Consequences
+
+**Positive:**
+- Composition (`and`, `or`, `negate`) does not require an external `Monoid<E>` — list concatenation is the only merge operator needed.
+- Validation lambdas are simple: `Guard.of(predicate, "error message")`.
+- Direct interop with `Validated<NonEmptyList<String>, T>`.
+
+**Negative / tradeoffs:**
+- Not suitable when the error must be a typed domain object (e.g., a `ValidationError` enum).
+- In that case the user must work directly with `Validated<E, A>`.
+
+## Alternatives considered
+
+- **Generic `Guard<T, E>`:** requires the user to provide a `BinaryOperator<E>` for merging in `and`/`or` — more complex API.
+- **`Guard<T>` with `List<String>`:** allows an empty list, which is semantically invalid for an error.

--- a/docs/adr/ADR-006-validated-vs-result.md
+++ b/docs/adr/ADR-006-validated-vs-result.md
@@ -1,0 +1,31 @@
+---
+number: 6
+title: "Validated (error accumulation) vs Result (fail-fast)"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+The library includes two types for modelling operations that can fail: `Result<V, E>` and `Validated<E, A>`. A new user may be confused about when to use each one.
+
+## Decision
+
+- **`Validated<E, A>`**: applicative-style error accumulation — all errors are collected before returning.
+- **`Result<V, E>`**: fail-fast — the first error stops the chain.
+
+## Consequences
+
+**Positive:**
+- Each type has clear semantics and does not try to do both things.
+- `Validated` is ideal for form/DTO validation where the user needs to see all errors at once.
+- `Result` is ideal for business pipelines where an intermediate error makes continuing pointless.
+
+**Negative / tradeoffs:**
+- Two types that "look" similar can confuse users coming from other libraries (e.g., Vavr only has `Validation`).
+- The user must learn when to use each one.
+
+## Alternatives considered
+
+- **A single type with a configurable mode:** increases API complexity.
+- **Only `Result`:** does not model accumulative validation well without losing the first error.

--- a/docs/adr/ADR-007-either-neutral.md
+++ b/docs/adr/ADR-007-either-neutral.md
@@ -1,0 +1,29 @@
+---
+number: 7
+title: "Either as a neutral type with no directional bias"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+In Haskell and Scala, `Either` is right-biased: `map`/`flatMap` operate on the right side. dmx-fun includes `Either<L, R>` but must decide whether to adopt that bias or remain neutral.
+
+## Decision
+
+`Either<L, R>` in dmx-fun is **neutral** — it does not expose `map`/`flatMap`. It serves as an interoperability and transport type, not as a functional monad.
+
+## Consequences
+
+**Positive:**
+- Avoids semantic ambiguity: if `L` represents an error, use `Result`; if `R` is success, use `Result` or `Try`.
+- Forces the user to convert to a type with explicit semantics (`toResult()`, `toTry()`) in order to operate functionally.
+- `Either` remains useful as a return type in APIs that need two symmetric cases with no error/success connotation.
+
+**Negative / tradeoffs:**
+- Users coming from Scala/Haskell expect `map`/`flatMap` on `Either`.
+- Some conversions require an extra step.
+
+## Alternatives considered
+
+- **Right-biased with `map`/`flatMap`:** introduces redundancy with `Result` and adds confusion about when to use each type.

--- a/docs/adr/ADR-008-jspecify-null-safety.md
+++ b/docs/adr/ADR-008-jspecify-null-safety.md
@@ -1,0 +1,31 @@
+---
+number: 8
+title: "jspecify (@NullMarked, @Nullable) for null safety"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+The library needs a null-safety annotation system compatible with static analysis tools (IntelliJ, Error Prone, NullAway) and aligned with the JDK roadmap.
+
+## Decision
+
+Adopt **jspecify** (`org.jspecify:jspecify`) with `@NullMarked` at the module level and `@Nullable` in the few places where null is valid.
+
+## Consequences
+
+**Positive:**
+- `@NullMarked` at the module level establishes that everything is non-null by default — minimal annotation noise.
+- jspecify is the emerging standard backed by the OpenJDK team and adopted by Guava, Error Prone, and others.
+- Lightweight compile/runtime dependency (`jspecify` is an `api` dependency so that users see the annotations).
+
+**Negative / tradeoffs:**
+- jspecify 1.0 is relatively recent; tooling support is still maturing.
+- Not all IDEs process `@NullMarked` the same way as JSR-305.
+
+## Alternatives considered
+
+- **JSR-305 (Findbugs/SpotBugs `@NonNull`):** widely supported but no longer actively maintained.
+- **Checker Framework:** more powerful but heavier and with a steeper learning curve.
+- **JetBrains annotations:** excellent IntelliJ support but vendor-coupled.

--- a/docs/adr/ADR-009-unmodifiable-list-try.md
+++ b/docs/adr/ADR-009-unmodifiable-list-try.md
@@ -1,0 +1,29 @@
+---
+number: 9
+title: "unmodifiableList instead of List.copyOf in Try"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Try.Partition` and the `Try` collectors return immutable lists of successful values. `Try.run()` produces `Success(null)`, and those nulls can appear in the result lists of `sequence`/`partitioningBy`.
+
+## Decision
+
+`Try` uses **`Collections.unmodifiableList(new ArrayList<>(...))`** instead of **`List.copyOf`** for lists of successful values.
+
+## Consequences
+
+**Positive:**
+- Preserves `null` elements in the list (produced by `Try.run()`).
+- `sequence(List.of(Try.run(() -> {})))` returns `Success([null])` without throwing NPE.
+
+**Negative / tradeoffs:**
+- `unmodifiableList` allows `null` internally; `List.copyOf` is stricter and clearer about nullability.
+- Behavioural difference with `Result`, which does use `List.copyOf` (because `Ok` guarantees non-null).
+
+## Alternatives considered
+
+- **`List.copyOf` in both:** breaks compatibility with `Try.run()` and `Try<Void>`.
+- **Prohibit null in `Success`:** removes the ability to represent void side-effects without a `Unit` type.

--- a/docs/adr/ADR-010-gatherer-sequence-traverse.md
+++ b/docs/adr/ADR-010-gatherer-sequence-traverse.md
@@ -1,0 +1,31 @@
+---
+number: 10
+title: "Gatherer for sequence/traverse with true short-circuit"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`sequence` and `traverse` must implement fail-fast semantics: upon encountering the first `Err`/`Failure` they must stop processing elements. The `Stream` API does not allow short-circuit with a `Collector`.
+
+## Decision
+
+Implement `sequence`/`traverse` using **`Stream.gather(Gatherer.ofSequential(...))`** (Java 22+) instead of `reduce`, `forEach`, or `Collector`.
+
+## Consequences
+
+**Positive:**
+- True short-circuit: the stream is closed upon encountering the first error without consuming the rest.
+- The code is declarative and composable within the stream pipeline.
+- `Gatherer` is Java's official abstraction for stateful transformations in streams.
+
+**Negative / tradeoffs:**
+- Requires Java 22+ (preview feature in 22, finalized in 24).
+- Collector-based operations (`toList()`, `partitioningBy()`) continue consuming the entire stream — different behavior explicitly documented.
+
+## Alternatives considered
+
+- **Manual `reduce`:** does not allow short-circuit in sequential streams without using exceptions as control flow.
+- **`forEach` with mutable state:** works but is not idiomatic with streams and breaks composability.
+- **Custom `Collector`:** cannot short-circuit by design of the `Collector` API.

--- a/docs/adr/ADR-011-guard-functional-interface.md
+++ b/docs/adr/ADR-011-guard-functional-interface.md
@@ -1,0 +1,30 @@
+---
+number: 11
+title: "Guard<T> as a @FunctionalInterface with default methods"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Guard<T>` needs to be composable (`and`, `or`, `negate`) while also allowing concise definition via lambdas or method references.
+
+## Decision
+
+`Guard<T>` is a **`@FunctionalInterface`** whose single abstract method is `check(T value)`. All composition logic is implemented as **`default methods`** on the interface.
+
+## Consequences
+
+**Positive:**
+- The user can define a guard with a lambda: `Guard<String> notBlank = s -> Validated.valid(s)`.
+- Composition (`and`, `or`, `negate`, `contramap`) is available without inheritance.
+- No state: each guard is a pure function.
+
+**Negative / tradeoffs:**
+- `default methods` cannot be `final` — any implementor could override the composition logic (though that would be a misuse of the API).
+- The interface grows in surface area as more composition operators are added.
+
+## Alternatives considered
+
+- **Abstract class `AbstractGuard<T>`:** allows `final` on composition methods but prevents lambda usage and multiple inheritance.
+- **Concrete class `Guard<T>` with a `Function` field:** more rigid, not extensible as an interface.

--- a/docs/adr/ADR-012-lazy-double-checked-locking.md
+++ b/docs/adr/ADR-012-lazy-double-checked-locking.md
@@ -1,0 +1,31 @@
+---
+number: 12
+title: "Lazy<T> with volatile Try<T> and double-checked locking"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Lazy<T>` must guarantee that the supplier is executed exactly once even under concurrent access, without blocking reads after the first evaluation.
+
+## Decision
+
+`Lazy<T>` uses a **`volatile @Nullable Try<T> state`** field (null = not yet evaluated) with **double-checked locking**: the first read is lock-free; if null, a `synchronized` block is entered and the value is checked again before evaluating.
+
+## Consequences
+
+**Positive:**
+- Concurrent reads after the first evaluation are lock-free (only a single volatile read).
+- `volatile` guarantees write visibility without needing `synchronized` on the fast path.
+- The state is modelled as `Try<T>` to capture supplier exceptions on the first evaluation.
+
+**Negative / tradeoffs:**
+- Double-checked locking with `volatile` is correct in Java 5+, but the pattern can be confusing for maintainers unfamiliar with it.
+- If the supplier throws, the exception is stored and rethrown on every subsequent call — behaviour that must be documented.
+
+## Alternatives considered
+
+- **`AtomicReference<Try<T>>`:** correct and more explicit, but `compareAndSet` can cause redundant evaluations under contention.
+- **`synchronized` on `get()`:** correct but blocks every read, even after the initial evaluation.
+- **`Supplier` with a holder class:** the initialization-on-demand holder pattern does not capture supplier exceptions.

--- a/docs/adr/ADR-013-try-with-timeout-virtual-threads.md
+++ b/docs/adr/ADR-013-try-with-timeout-virtual-threads.md
@@ -1,0 +1,29 @@
+---
+number: 13
+title: "Try.withTimeout uses virtual threads (Thread.ofVirtual())"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+`Try.withTimeout` needs to run user-supplied code with a wall-clock deadline. Options were:
+- Platform threads via `ExecutorService`
+- Virtual threads via `Thread.ofVirtual()`
+- `CompletableFuture` with a shared pool
+
+## Decision
+
+Use `Thread.ofVirtual().start(task)` to spawn a lightweight carrier for the timed operation. The calling thread blocks on `FutureTask.get(timeout, unit)` and interrupts the virtual thread on timeout.
+
+## Consequences
+
+- No `ExecutorService` lifecycle to manage; threads are fire-and-forget.
+- Near-zero overhead for blocking I/O inside the timeout block (virtual thread parks, not blocks a carrier).
+- The `CancellationException` branch (external cancellation of the internal `FutureTask`) is unreachable from outside the method — accepted as an untestable defensive guard.
+- Requires Java 21+ (virtual threads GA); already met by the Java 25 baseline (ADR-001).
+
+## Alternatives considered
+
+- **Platform threads via `ExecutorService`:** requires lifecycle management and heavier overhead for blocking I/O.
+- **`CompletableFuture` with a shared pool:** uses the common ForkJoin pool, which is inappropriate for blocking operations.

--- a/docs/adr/ADR-014-facade-collectors.md
+++ b/docs/adr/ADR-014-facade-collectors.md
@@ -1,0 +1,27 @@
+---
+number: 14
+title: "Facade collectors (Results, Options, Tries) as a single entry point"
+status: Accepted
+date: 2026-05-05
+---
+
+## Context
+
+Each ADT (`Result`, `Try`, `Option`) exposes static collector factories (`toList()`, `partitioningBy()`, `groupingBy()`). Users working with streams need a discoverable, consistent entry point.
+
+## Decision
+
+Provide companion facade classes — `Results`, `Tries`, `Options` — that re-export all collector factories and common static helpers as top-level static methods. The ADT classes retain the canonical implementations; facades are pure delegation.
+
+## Consequences
+
+- Single import (`import static dmx.fun.Results.*`) gives access to all stream collectors.
+- Facade classes are final with a private constructor (no instantiation).
+- No logic duplication — all methods delegate to the ADT static methods.
+- Discoverability: IDE auto-complete on `Results.` surfaces all stream operations without knowing the ADT class names.
+- Slight API surface increase; mitigated by `@NullMarked` and consistent Javadoc.
+
+## Alternatives considered
+
+- **No facades — access via ADT class directly:** users must remember which static method lives on which class; less discoverable.
+- **Single `Dmx` utility class:** mixes collectors for all types in one namespace, reducing clarity.

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -41,5 +41,15 @@ const guide = defineCollection({
     }),
 });
 
+const adr = defineCollection({
+    loader: glob({pattern: "**/*.md", base: "../docs/adr"}),
+    schema: z.object({
+        number: z.number().int().positive(),
+        title: z.string(),
+        status: z.enum(['Proposed', 'Accepted', 'Superseded']),
+        date: z.date(),
+    }),
+});
+
 // Export a single `collections` object to register your collection(s)
-export const collections = {code, blog, guide};
+export const collections = {code, blog, guide, adr};

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -106,6 +106,7 @@ const GA_MEASUREMENT_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
                 <a href={`${base}getting-started`}>Getting Started</a>
                 <a href={`${base}guide`}>Guide</a>
                 <a href={`${base}blog`}>Blog</a>
+                <a href={`${base}adr`}>ADR</a>
                 <a href={`${base}javadoc/index.html`} target="_blank" rel="noopener">API</a>
                 <a href={site.github} target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/site/src/pages/adr/[...slug].astro
+++ b/site/src/pages/adr/[...slug].astro
@@ -1,0 +1,247 @@
+---
+import { getCollection, render } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+const base = import.meta.env.BASE_URL;
+
+export async function getStaticPaths() {
+    const adrEntries = await getCollection('adr');
+    return adrEntries.map(entry => ({
+        params: { slug: entry.id },
+        props: { entry },
+    }));
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+
+const allAdrs = (await getCollection('adr')).sort((a, b) => a.data.number - b.data.number);
+const currentIndex = allAdrs.findIndex(e => e.id === entry.id);
+const prev = currentIndex > 0 ? allAdrs[currentIndex - 1] : null;
+const next = currentIndex < allAdrs.length - 1 ? allAdrs[currentIndex + 1] : null;
+
+const toc = headings.filter(h => h.depth === 2);
+
+const statusColor: Record<string, string> = {
+    Accepted: 'status-accepted',
+    Proposed: 'status-proposed',
+    Superseded: 'status-superseded',
+};
+
+const num = String(entry.data.number).padStart(3, '0');
+---
+
+<DocsLayout
+    title={`ADR-${num} — ${entry.data.title}`}
+    description={`Architecture Decision Record ${num}: ${entry.data.title}`}
+>
+    <div class="adr-content">
+        <div class="adr-header">
+            <a href={`${base}adr`} class="back-link">&larr; All ADRs</a>
+            <div class="adr-meta">
+                <span class="adr-id">ADR-{num}</span>
+                <span class={`status-badge ${statusColor[entry.data.status]}`}>{entry.data.status}</span>
+                <span class="adr-date">{entry.data.date.toISOString().slice(0, 10)}</span>
+            </div>
+        </div>
+
+        <h1>{entry.data.title}</h1>
+
+        {toc.length > 0 && (
+            <nav class="toc" aria-label="Table of contents">
+                <ol>
+                    {toc.map(h => (
+                        <li><a href={`#${h.slug}`}>{h.text}</a></li>
+                    ))}
+                </ol>
+            </nav>
+        )}
+
+        <Content />
+
+        <div class="page-nav">
+            {prev ? (
+                <a href={`${base}adr/${prev.id}`}>&larr; ADR-{String(prev.data.number).padStart(3, '0')}</a>
+            ) : (
+                <a href={`${base}adr`}>&larr; All ADRs</a>
+            )}
+            {next ? (
+                <a href={`${base}adr/${next.id}`}>ADR-{String(next.data.number).padStart(3, '0')} &rarr;</a>
+            ) : (
+                <span></span>
+            )}
+        </div>
+    </div>
+</DocsLayout>
+
+<style>
+    .adr-content {
+        max-width: 860px;
+    }
+
+    .adr-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .back-link {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        font-size: 0.9rem;
+        transition: color 0.2s ease;
+    }
+
+    .back-link:hover {
+        color: var(--color-primary);
+    }
+
+    .adr-meta {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .adr-id {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+    }
+
+    .adr-date {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+    }
+
+    h1 {
+        border-bottom: 2px solid var(--color-border);
+        padding-bottom: 0.5rem;
+    }
+
+    .adr-content :global(h2) {
+        margin-top: 3rem;
+        border-bottom: 1px solid var(--color-border);
+        padding-bottom: 0.5rem;
+    }
+
+    .adr-content :global(h3) {
+        margin-top: 1.75rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .adr-content :global(p) {
+        line-height: 1.7;
+    }
+
+    .adr-content :global(ul),
+    .adr-content :global(ol:not(.toc ol)) {
+        line-height: 1.8;
+        padding-left: 1.5rem;
+    }
+
+    .adr-content :global(li) {
+        margin: 0.3rem 0;
+    }
+
+    .adr-content :global(strong) {
+        color: var(--color-text);
+    }
+
+    .adr-content :global(a) {
+        color: var(--color-primary);
+        text-decoration: underline;
+    }
+
+    .adr-content :global(a:hover) {
+        color: var(--color-primary-hover);
+    }
+
+    .status-badge {
+        display: inline-block;
+        padding: 0.2rem 0.55rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .status-accepted {
+        background-color: #d1fae5;
+        color: #065f46;
+    }
+
+    [data-theme="dark"] .status-accepted {
+        background-color: #064e3b;
+        color: #6ee7b7;
+    }
+
+    .status-proposed {
+        background-color: #dbeafe;
+        color: #1e3a8a;
+    }
+
+    [data-theme="dark"] .status-proposed {
+        background-color: #1e3a8a;
+        color: #93c5fd;
+    }
+
+    .status-superseded {
+        background-color: var(--color-surface);
+        color: var(--color-text-secondary);
+        border: 1px solid var(--color-border);
+    }
+
+    /* TOC */
+    .toc {
+        background-color: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        padding: 1.25rem 1.5rem;
+        margin: 2rem 0;
+        display: inline-block;
+        min-width: 220px;
+    }
+
+    .toc ol {
+        margin: 0;
+        padding-left: 1.25rem;
+    }
+
+    .toc li {
+        line-height: 1.9;
+        font-size: 0.9rem;
+    }
+
+    .toc a {
+        text-decoration: none;
+        color: var(--color-text-secondary);
+        transition: color 0.2s ease;
+    }
+
+    .toc a:hover {
+        color: var(--color-primary);
+    }
+
+    /* Page navigation */
+    .page-nav {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 4rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-size: 0.9rem;
+    }
+
+    .page-nav a {
+        text-decoration: none;
+        color: var(--color-primary);
+    }
+
+    .page-nav a:hover {
+        text-decoration: underline;
+    }
+</style>

--- a/site/src/pages/adr/index.astro
+++ b/site/src/pages/adr/index.astro
@@ -1,0 +1,192 @@
+---
+import { getCollection } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+const base = import.meta.env.BASE_URL;
+
+const adrs = (await getCollection('adr')).sort((a, b) => a.data.number - b.data.number);
+
+const statusColor: Record<string, string> = {
+    Accepted: 'status-accepted',
+    Proposed: 'status-proposed',
+    Superseded: 'status-superseded',
+};
+---
+
+<DocsLayout
+    title="Architecture Decision Records"
+    description="A log of architectural decisions made in dmx-fun, with context, rationale, and consequences."
+>
+    <div class="adr-content">
+        <h1>Architecture Decision Records</h1>
+
+        <div class="intro">
+            <p>
+                ADRs document the significant design choices made in dmx-fun — the context that led to each
+                decision, the alternatives considered, and the consequences accepted. They are the authoritative
+                record of <em>why</em> the library is built the way it is.
+            </p>
+        </div>
+
+        <table class="adr-table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Title</th>
+                    <th>Status</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {adrs.map(adr => (
+                    <tr>
+                        <td class="adr-number">{String(adr.data.number).padStart(3, '0')}</td>
+                        <td>
+                            <a href={`${base}adr/${adr.id}`}>{adr.data.title}</a>
+                        </td>
+                        <td>
+                            <span class={`status-badge ${statusColor[adr.data.status]}`}>
+                                {adr.data.status}
+                            </span>
+                        </td>
+                        <td class="adr-date">
+                            {adr.data.date.toISOString().slice(0, 10)}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    </div>
+</DocsLayout>
+
+<style>
+    .adr-content {
+        max-width: 900px;
+    }
+
+    .intro {
+        background-color: var(--color-surface);
+        padding: 1.5rem;
+        border-radius: 8px;
+        border-left: 4px solid var(--color-primary);
+        margin: 2rem 0;
+    }
+
+    .intro p {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.7;
+    }
+
+    h1 {
+        border-bottom: 2px solid var(--color-border);
+        padding-bottom: 0.5rem;
+    }
+
+    .adr-table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+        margin: 1.5rem 0;
+        font-size: 0.925rem;
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .adr-table thead tr {
+        background-color: var(--color-surface);
+    }
+
+    .adr-table th {
+        padding: 0.75rem 1.25rem;
+        text-align: left;
+        font-weight: 600;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--color-text-secondary);
+        border-bottom: 2px solid var(--color-border);
+    }
+
+    .adr-table td {
+        padding: 0.75rem 1.25rem;
+        border-bottom: 1px solid var(--color-border);
+        vertical-align: middle;
+    }
+
+    .adr-table tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    .adr-table tbody tr:hover {
+        background-color: var(--color-code-bg);
+        transition: background-color 0.15s ease;
+    }
+
+    .adr-table a {
+        color: var(--color-primary);
+        text-decoration: none;
+    }
+
+    .adr-table a:hover {
+        text-decoration: underline;
+    }
+
+    .adr-number {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+    }
+
+    .adr-date {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+    }
+
+    .status-badge {
+        display: inline-block;
+        padding: 0.2rem 0.55rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+    }
+
+    .status-accepted {
+        background-color: #d1fae5;
+        color: #065f46;
+    }
+
+    [data-theme="dark"] .status-accepted {
+        background-color: #064e3b;
+        color: #6ee7b7;
+    }
+
+    .status-proposed {
+        background-color: #dbeafe;
+        color: #1e3a8a;
+    }
+
+    [data-theme="dark"] .status-proposed {
+        background-color: #1e3a8a;
+        color: #93c5fd;
+    }
+
+    .status-superseded {
+        background-color: var(--color-surface);
+        color: var(--color-text-secondary);
+        border: 1px solid var(--color-border);
+    }
+
+    @media (max-width: 600px) {
+        .adr-table {
+            display: block;
+            overflow-x: auto;
+        }
+    }
+</style>


### PR DESCRIPTION
  Create docs/adr/ as the single source of truth for all 14 Architecture
  Decision Records (ADR-001 through ADR-014). Each file carries YAML
  frontmatter with number, title, status, and date fields.

  Register an `adr` Astro content collection in content.config.ts pointing
  its glob loader at ../docs/adr so the files are readable both on GitHub
  and on the website without duplication.

  Add two new pages:
  - /adr — index table listing all ADRs sorted by number, with color-coded
    status badges (Accepted/Proposed/Superseded) and dark-mode support.
  - /adr/[slug] — individual ADR page with ToC, prev/next navigation, and
    the same status badge; reuses DocsLayout.

  Add an "ADR" link to the main navigation bar in DocsLayout.astro.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #372

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
