### PR TITLE
feat(Option): add fromEither/toFuture, fix toTry null-check, expand tests and docs to 100% coverage

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Option.java
+++ b/core/lib/src/main/java/dmx/fun/Option.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -372,6 +373,31 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     }
 
     /**
+     * Converts this {@code Option} into an already-completed {@link CompletableFuture}.
+     *
+     * <ul>
+     *   <li>{@code Some(v)} → {@code CompletableFuture.completedFuture(v)}</li>
+     *   <li>{@code None} → a future failed with {@link NoSuchElementException}</li>
+     * </ul>
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Option.some("hello").toFuture(); // CompletableFuture completed with "hello"
+     * Option.none().toFuture();        // CompletableFuture failed with NoSuchElementException
+     * }</pre>
+     *
+     * @return a completed or failed {@code CompletableFuture<Value>}
+     */
+    default CompletableFuture<Value> toFuture() {
+        return switch (this) {
+            case Some<Value> s -> CompletableFuture.completedFuture(s.value());
+            case None<Value> _ -> CompletableFuture.failedFuture(
+                new NoSuchElementException("Option is None")
+            );
+        };
+    }
+
+    /**
      * Collects all present (non-empty) values from a stream of {@code Option} instances into an
      * unmodifiable list.
      *
@@ -571,6 +597,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * if the current instance is {@code None}.
      */
     default Try<Value> toTry(Supplier<? extends Throwable> exceptionSupplier) {
+        Objects.requireNonNull(exceptionSupplier, "exceptionSupplier");
         return switch (this) {
             case Some<Value> s -> Try.success(s.value());
             case None<Value> _ -> Try.failure(
@@ -649,6 +676,31 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     static <V> Option<V> fromTryOptional(Try<Optional<V>> t) {
         Objects.requireNonNull(t, "t");
         return t.isSuccess() ? fromOptional(t.get()) : Option.none();
+    }
+
+    /**
+     * Converts an {@link Either} into an {@link Option}, keeping only the {@link Either.Right} value.
+     *
+     * <ul>
+     *   <li>{@link Either.Right Right(r)} → {@code Some(r)}</li>
+     *   <li>{@link Either.Left Left(_)} → {@code None}</li>
+     * </ul>
+     *
+     * <p>This is the static complement of {@link Either#toOption()}: both express the same
+     * conversion but from different call sites.
+     *
+     * @param <L>    the left type (discarded on conversion)
+     * @param <R>    the right type (preserved as the {@code Option} value)
+     * @param either the {@link Either} to convert; must not be {@code null}
+     * @return {@code Some(r)} if {@code either} is {@code Right}, otherwise {@code None}
+     * @throws NullPointerException if {@code either} is {@code null}
+     */
+    static <L, R> Option<R> fromEither(Either<? extends L, ? extends R> either) {
+        Objects.requireNonNull(either, "either");
+        return switch (either) {
+            case Either.Right<? extends L, ? extends R> r -> Option.some(r.value());
+            case Either.Left<? extends L, ? extends R>  _ -> Option.none();
+        };
     }
 
     // ---------- zip / map2 ----------

--- a/core/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/core/lib/src/test/java/dmx/fun/OptionTest.java
@@ -5,6 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -684,5 +686,166 @@ class OptionTest {
             .collect(Option.sequenceCollector());
         assertThatThrownBy(() -> result.get().add("z"))
             .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void sequenceCollector_parallelStream_allSome_shouldCombinePartialAccumulators() {
+        List<Option<Integer>> items = List.of(
+            Option.some(1), Option.some(2), Option.some(3), Option.some(4));
+        Optional<List<Integer>> result = items.parallelStream()
+            .collect(Option.sequenceCollector());
+        assertThat(result).isPresent();
+        assertThat(result.get()).containsExactlyInAnyOrder(1, 2, 3, 4);
+    }
+
+    @Test
+    void sequenceCollector_parallelStream_withNone_shouldReturnEmpty() {
+        List<Option<Integer>> items = List.of(
+            Option.some(1), Option.none(), Option.some(3));
+        Optional<List<Integer>> result = items.parallelStream()
+            .collect(Option.sequenceCollector());
+        assertThat(result).isEmpty();
+    }
+
+    // ---------- fromResult ----------
+
+    @Test
+    void fromResult_ok_shouldReturnSome() {
+        Option<String> opt = Option.fromResult(Result.ok("hello"));
+        assertThat(opt.isDefined()).isTrue();
+        assertThat(opt.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void fromResult_err_shouldReturnNone() {
+        Option<String> opt = Option.fromResult(Result.<String, String>err("error"));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromResult_null_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.fromResult(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // ---------- fromTry ----------
+
+    @Test
+    void fromTry_success_shouldReturnSome() {
+        Option<String> opt = Option.fromTry(Try.success("value"));
+        assertThat(opt.isDefined()).isTrue();
+        assertThat(opt.get()).isEqualTo("value");
+    }
+
+    @Test
+    void fromTry_failure_shouldReturnNone() {
+        Option<String> opt = Option.fromTry(Try.failure(new RuntimeException("boom")));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromTry_successWithNullValue_shouldReturnNone() {
+        // Try.run() produces Success(null) for void side-effects
+        Option<Void> opt = Option.fromTry(Try.run(() -> {}));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromTry_null_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.fromTry(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // ---------- fromTryOptional ----------
+
+    @Test
+    void fromTryOptional_successPresent_shouldReturnSome() {
+        Option<String> opt = Option.fromTryOptional(Try.success(Optional.of("hi")));
+        assertThat(opt.isDefined()).isTrue();
+        assertThat(opt.get()).isEqualTo("hi");
+    }
+
+    @Test
+    void fromTryOptional_successEmpty_shouldReturnNone() {
+        Option<String> opt = Option.fromTryOptional(Try.success(Optional.<String>empty()));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromTryOptional_failure_shouldReturnNone() {
+        Option<String> opt = Option.fromTryOptional(
+            Try.failure(new RuntimeException("fail")));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromTryOptional_null_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.fromTryOptional(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // ---------- toTry NPE edge cases ----------
+
+    @Test
+    void toTry_nullExceptionSupplier_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.some("v").toTry(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("exceptionSupplier");
+    }
+
+    @Test
+    void toTry_supplierReturnsNull_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.<String>none().toTry(() -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("exceptionSupplier returned null");
+    }
+
+    // ---------- fromEither ----------
+
+    @Test
+    void fromEither_right_shouldReturnSome() {
+        Option<String> opt = Option.fromEither(Either.<Integer, String>right("hello"));
+        assertThat(opt.isDefined()).isTrue();
+        assertThat(opt.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void fromEither_left_shouldReturnNone() {
+        Option<String> opt = Option.fromEither(Either.<Integer, String>left(42));
+        assertThat(opt.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromEither_null_shouldThrowNPE() {
+        assertThatThrownBy(() -> Option.fromEither(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void fromEither_isConsistentWith_eitherToOption() {
+        Either<Integer, String> right = Either.right("v");
+        Either<Integer, String> left  = Either.left(0);
+        assertThat(Option.fromEither(right)).isEqualTo(right.toOption());
+        assertThat(Option.fromEither(left)).isEqualTo(left.toOption());
+    }
+
+    // ---------- toFuture ----------
+
+    @Test
+    void toFuture_some_shouldReturnCompletedFutureWithValue() throws Exception {
+        CompletableFuture<String> future = Option.some("hello").toFuture();
+        assertThat(future.isDone()).isTrue();
+        assertThat(future.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void toFuture_none_shouldReturnFailedFutureWithNoSuchElementException() {
+        CompletableFuture<String> future = Option.<String>none().toFuture();
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatThrownBy(future::join)
+            .isInstanceOf(CompletionException.class)
+            .cause()
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("Option is None");
     }
 }

--- a/site/src/data/code/guide/option/creating-from-result-try.mdx
+++ b/site/src/data/code/guide/option/creating-from-result-try.mdx
@@ -3,15 +3,19 @@ fileName: 'Demo.java'
 ---
 
 ```java
-// Result -> Option (discards the error)
-Option<User> user = userResult.toOption();
+// Result -> Option: discard the error track
+Option<User> fromResult1 = userResult.toOption();          // instance method
+Option<User> fromResult2 = Option.fromResult(userResult);  // static factory (same semantics)
 
-// Try -> Option (discards the exception)
-Option<Config> cfg = tryReadConfig.toOption();
+// Try -> Option: discard the exception track
+// Note: Try.Success(null) produced by Try.run() maps to None
+Option<Config> fromTry1 = tryReadConfig.toOption();       // instance method
+Option<Config> fromTry2 = Option.fromTry(tryReadConfig);  // static factory (same semantics)
 
-// Try<Optional<T>> -> Option<T>  (flattens both layers in one step)
+// Try<Optional<T>> -> Option<T>: flatten both layers in one step
 // Success(Optional.of(v))  -> Some(v)
 // Success(Optional.empty()) -> None
-// Failure(ex)              -> None
-Option<Item> item = Option.fromTryOptional(Try.of(() -> repository.findById(id)));
+// Failure(ex)               -> None  (exception discarded)
+Option<Item> item = Option.fromTryOptional(
+    Try.of(() -> repository.findById(id)));
 ```

--- a/site/src/data/code/guide/option/interop-conversions.mdx
+++ b/site/src/data/code/guide/option/interop-conversions.mdx
@@ -3,10 +3,40 @@ fileName: 'Demo.java'
 ---
 
 ```java
-// Promote to Result when absence should be an error
-Result<User, String> result = findUser(id)
-    .toResult(() -> "User not found: " + id);
+Option<User> user = findUser(id);
 
-// Demote to JDK Optional for older APIs
-Optional<User> opt = findUser(id).toOptional();
+// ── Option → other types ────────────────────────────────────────────────────
+
+// → Optional  (bridge to JDK APIs)
+Optional<User> optional = user.toOptional();
+
+// → Result  (None becomes Err with the supplied error value)
+Result<User, String> result = user.toResult("User not found: " + id);
+
+// → Try  (None becomes Failure; supplier is called lazily)
+Try<User> tried = user.toTry(() -> new NoSuchElementException("User " + id + " not found"));
+
+// → Either  (Some → Right, None → Left with the supplied left value)
+Either<String, User> either = user.toEither("not-found");
+
+// → CompletableFuture  (Some → completed, None → failed with NoSuchElementException)
+CompletableFuture<User> future = user.toFuture();
+
+// ── Other types → Option ────────────────────────────────────────────────────
+
+// Optional → Option
+Option<User> fromOptional = Option.fromOptional(legacyOptional);
+
+// Result → Option  (Err is discarded)
+Option<User> fromResult = Option.fromResult(userResult);
+
+// Try → Option  (Failure is discarded; Try.Success(null) from Try.run() → None)
+Option<Config> fromTry = Option.fromTry(tryReadConfig);
+
+// Try<Optional<T>> → Option<T>  (flattens both layers in one step)
+Option<Item> fromTryOpt = Option.fromTryOptional(
+    Try.of(() -> repository.findById(id)));
+
+// Either → Option  (Left is discarded; Right(v) → Some(v))
+Option<User> fromEither = Option.fromEither(eitherValue);
 ```

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -75,7 +75,9 @@ Converts a `java.util.Optional` into an `Option`.
 
 ### Converting from Result or Try
 
-Both `Result` and `Try` can be narrowed to an `Option` when you only care about presence:
+`Result` and `Try` expose `toOption()` to discard the error/exception track.
+The static factory forms are symmetric: `Option.fromResult(result)` and `Option.fromTry(t)`.
+`Option.fromTryOptional(t)` flattens a `Try<Optional<T>>` in one step.
 
 <CreatingFromResultTry/>
 
@@ -203,16 +205,18 @@ Useful for integrating into Stream pipelines without `filter + map`.
 
 ## Interoperability
 
-| Conversion                    | Method                                          |
-|-------------------------------|-------------------------------------------------|
-| `Option` → `Optional`         | `option.toOptional()`                           |
-| `Option` → `Result`           | `option.toResult(errorSupplier)`                |
-| `Option` → `Try`              | `option.toTry(exceptionSupplier)`               |
-| `Option` → `Either`           | `option.toEither(leftSupplier)`                 |
-| `Result` → `Option`           | `result.toOption()`                             |
-| `Try` → `Option`              | `tryVal.toOption()`                             |
-| `Optional` → `Option`         | `Option.fromOptional(optional)`                 |
-| `Try<Optional<T>>` → `Option` | `Option.fromTryOptional(tryOfOptional)` _(flattens both layers; converts Failure to None — drops the error)_ |
+| Conversion                    | Method                                          | Notes                                                           |
+|-------------------------------|-------------------------------------------------|-----------------------------------------------------------------|
+| `Option` → `Optional`         | `option.toOptional()`                           | `Some(v)` → `Optional.of(v)`, `None` → `Optional.empty()`      |
+| `Option` → `Result`           | `option.toResult(errorIfNone)`                  | `None` becomes `Err(errorIfNone)`                               |
+| `Option` → `Try`              | `option.toTry(exceptionSupplier)`               | `None` becomes `Failure`; supplier called lazily                |
+| `Option` → `Either`           | `option.toEither(leftIfNone)`                   | `Some(v)` → `Right(v)`, `None` → `Left(leftIfNone)`            |
+| `Option` → `CompletableFuture`| `option.toFuture()`                             | `Some(v)` → completed future, `None` → failed with `NoSuchElementException` |
+| `Optional` → `Option`         | `Option.fromOptional(optional)`                 |                                                                 |
+| `Result` → `Option`           | `Option.fromResult(result)` or `result.toOption()` | `Err` is discarded                                           |
+| `Try` → `Option`              | `Option.fromTry(t)` or `t.toOption()`           | `Failure` is discarded; `Success(null)` → `None`               |
+| `Try<Optional<T>>` → `Option` | `Option.fromTryOptional(t)`                     | Flattens both layers; `Failure` and `Optional.empty()` → `None` |
+| `Either` → `Option`           | `Option.fromEither(either)` or `either.toOption()` | `Left` is discarded; `Right(v)` → `Some(v)`                 |
 
 <InteropConversions/>
 


### PR DESCRIPTION
  API additions:
  - Option.fromEither(Either<L,R>) — static complement of Either.toOption();
    Right(r) → Some(r), Left → None.
  - Option.toFuture() — Some(v) → completedFuture(v),
    None → failedFuture(NoSuchElementException("Option is None")).

  API fix:
  - toTry(Supplier) now eagerly requiresNonNull on the supplier argument,
    consistent with orElse(Supplier) and the rest of the API.

  Tests (OptionTest.java, +19 tests):
  - fromResult, fromTry, fromTryOptional — previously untested static factories,
    including NPE and Try.run() null-value edge cases.
  - toTry NPE edge cases (null supplier, supplier returns null).
  - fromEither (right, left, null, round-trip vs Either.toOption()).
  - toFuture (Some → completed value, None → failed with correct cause/message).
  - sequenceCollector parallel combiner — all-Some and with-None paths,
    bringing Option.java to 100% line and branch coverage.

  Docs (option.mdx + code snippets):
  - Interop table: fixed toResult/toEither signatures (were incorrectly labelled
    as *Supplier overloads; they take direct values); added toFuture, fromResult,
    fromTry, fromEither rows with Notes column.
  - creating-from-result-try.mdx: shows both instance (toOption()) and static
    (fromResult/fromTry) forms side by side; adds fromTryOptional example.
  - interop-conversions.mdx: rewritten to cover all 10 conversion directions.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #294

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting `Option` to/from `CompletableFuture` for Java concurrency integration
  * Introduced conversion method to transform `Either` values into `Option`
  * Enhanced null-safety validation in existing conversion methods

* **Documentation**
  * Expanded conversion guides with examples demonstrating new interoperability options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->