### PR TITLE
feat(Either): add toOptional, stream, toTry, match — complete interop audit (#288)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Either.java
+++ b/core/lib/src/main/java/dmx/fun/Either.java
@@ -2,8 +2,10 @@ package dmx.fun;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -303,5 +305,107 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
             case Right<L, R> right -> Validated.valid(right.value());
             case Left<L, R> left   -> Validated.invalid(left.value());
         };
+    }
+
+    /**
+     * Converts this {@code Either} to a standard {@link Optional Optional&lt;R&gt;}.
+     *
+     * <p>{@link Right Right(r)} maps to {@link Optional#of(Object) Optional.of(r)};
+     * {@link Left} maps to {@link Optional#empty()}, discarding the left value.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Either.<String, Integer>right(42).toOptional(); // Optional.of(42)
+     * Either.<String, Integer>left("err").toOptional(); // Optional.empty()
+     * }</pre>
+     *
+     * @return an {@code Optional} containing the right value, or empty if this is {@code Left}
+     */
+    default Optional<R> toOptional() {
+        return switch (this) {
+            case Right<L, R> right -> Optional.of(right.value());
+            case Left<L, R> _      -> Optional.empty();
+        };
+    }
+
+    /**
+     * Returns this {@code Either} as a single-element or empty {@link Stream}.
+     *
+     * <p>{@link Right Right(r)} produces {@code Stream.of(r)};
+     * {@link Left} produces {@code Stream.empty()}.
+     * Useful for integrating into stream pipelines without an explicit filter.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Stream<Either<String, Integer>> eithers = ...;
+     * List<Integer> rights = eithers
+     *     .flatMap(Either::stream)
+     *     .toList();
+     * }</pre>
+     *
+     * @return a one-element stream of the right value, or an empty stream
+     */
+    default Stream<R> stream() {
+        return switch (this) {
+            case Right<L, R> right -> Stream.of(right.value());
+            case Left<L, R> _      -> Stream.empty();
+        };
+    }
+
+    /**
+     * Converts this {@code Either} to a {@link Try}.
+     *
+     * <p>{@link Right Right(r)} maps to {@link Try#success(Object) Try.success(r)};
+     * {@link Left Left(l)} maps to {@link Try#failure(Throwable) Try.failure(leftMapper(l))}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Either.<String, Integer>right(1).toTry(IllegalStateException::new); // Try.success(1)
+     * Either.<String, Integer>left("bad").toTry(IllegalStateException::new); // Try.failure(...)
+     * }</pre>
+     *
+     * @param leftMapper function that converts the left value into a {@link Throwable};
+     *                   must not be {@code null} and must not return {@code null}
+     * @return a {@code Try<R>} equivalent of this {@code Either}
+     * @throws NullPointerException if {@code leftMapper} is {@code null} or returns {@code null}
+     */
+    default Try<R> toTry(Function<? super L, ? extends Throwable> leftMapper) {
+        Objects.requireNonNull(leftMapper, "leftMapper");
+        return switch (this) {
+            case Right<L, R> right -> Try.success(right.value());
+            case Left<L, R> left   -> Try.failure(
+                Objects.requireNonNull(leftMapper.apply(left.value()), "leftMapper returned null")
+            );
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Terminal side effects
+    // -------------------------------------------------------------------------
+
+    /**
+     * Executes one of the provided consumers depending on whether this is a {@link Left}
+     * or a {@link Right}, then discards the result. This is the terminal, side-effecting
+     * counterpart to {@link #fold(Function, Function)}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * either.match(
+     *     left  -> log.warn("Left: {}", left),
+     *     right -> process(right)
+     * );
+     * }</pre>
+     *
+     * @param onLeft  consumer executed when this is {@code Left}; must not be {@code null}
+     * @param onRight consumer executed when this is {@code Right}; must not be {@code null}
+     * @throws NullPointerException if {@code onLeft} or {@code onRight} is {@code null}
+     */
+    default void match(Consumer<? super L> onLeft, Consumer<? super R> onRight) {
+        Objects.requireNonNull(onLeft, "onLeft");
+        Objects.requireNonNull(onRight, "onRight");
+        switch (this) {
+            case Left<L, R> left   -> onLeft.accept(left.value());
+            case Right<L, R> right -> onRight.accept(right.value());
+        }
     }
 }

--- a/core/lib/src/test/java/dmx/fun/EitherTest.java
+++ b/core/lib/src/test/java/dmx/fun/EitherTest.java
@@ -1,6 +1,8 @@
 package dmx.fun;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -366,6 +368,120 @@ class EitherTest {
         var e = err.toEither();
         assertThat(e.isLeft()).isTrue();
         assertThat(e.getLeft()).isEqualTo("fail");
+    }
+
+    // -------------------------------------------------------------------------
+    // toOptional
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toOptional_shouldReturnPresent_whenRight() {
+        Optional<Integer> opt = Either.<String, Integer>right(42).toOptional();
+        assertThat(opt).isPresent().hasValue(42);
+    }
+
+    @Test
+    void toOptional_shouldReturnEmpty_whenLeft() {
+        Optional<Integer> opt = Either.<String, Integer>left("err").toOptional();
+        assertThat(opt).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // stream
+    // -------------------------------------------------------------------------
+
+    @Test
+    void stream_shouldReturnSingleElementStream_whenRight() {
+        List<Integer> collected = Either.<String, Integer>right(7).stream().toList();
+        assertThat(collected).containsExactly(7);
+    }
+
+    @Test
+    void stream_shouldReturnEmptyStream_whenLeft() {
+        List<Integer> collected = Either.<String, Integer>left("err").stream().toList();
+        assertThat(collected).isEmpty();
+    }
+
+    @Test
+    void stream_shouldIntegrateIntoStreamPipeline() {
+        List<Either<String, Integer>> eithers = List.of(
+            Either.right(1), Either.left("err"), Either.right(3));
+        List<Integer> rights = eithers.stream()
+            .flatMap(Either::stream)
+            .toList();
+        assertThat(rights).containsExactly(1, 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // toTry
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toTry_shouldReturnSuccess_whenRight() {
+        Try<Integer> t = Either.<String, Integer>right(42)
+            .toTry(IllegalArgumentException::new);
+        assertThat(t.isSuccess()).isTrue();
+        assertThat(t.get()).isEqualTo(42);
+    }
+
+    @Test
+    void toTry_shouldReturnFailure_whenLeft() {
+        Try<Integer> t = Either.<String, Integer>left("bad")
+            .toTry(IllegalArgumentException::new);
+        assertThat(t.isFailure()).isTrue();
+        assertThat(t.getCause())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("bad");
+    }
+
+    @Test
+    void toTry_shouldThrowNPE_whenLeftMapperIsNull() {
+        var e = Either.<String, Integer>left("x");
+        assertThatThrownBy(() -> e.toTry(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("leftMapper");
+    }
+
+    @Test
+    void toTry_shouldThrowNPE_whenLeftMapperReturnsNull() {
+        var e = Either.<String, Integer>left("x");
+        assertThatThrownBy(() -> e.toTry(_ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("leftMapper returned null");
+    }
+
+    // -------------------------------------------------------------------------
+    // match
+    // -------------------------------------------------------------------------
+
+    @Test
+    void match_shouldExecuteOnLeft_whenLeft() {
+        var seen = new ArrayList<String>();
+        Either.<String, Integer>left("err").match(seen::add, v -> seen.add("right:" + v));
+        assertThat(seen).containsExactly("err");
+    }
+
+    @Test
+    void match_shouldExecuteOnRight_whenRight() {
+        var seen = new ArrayList<String>();
+        Either.<String, Integer>right(42).match(seen::add, v -> seen.add("right:" + v));
+        assertThat(seen).containsExactly("right:42");
+    }
+
+    @Test
+    void match_shouldThrowNPE_whenOnLeftIsNull() {
+        var e = Either.<String, Integer>left("x");
+        assertThatThrownBy(() -> e.match(null, v -> {}))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onLeft");
+    }
+
+    @Test
+    void match_shouldThrowNPE_whenOnRightIsNull() {
+        var e = Either.<String, Integer>right(1);
+        assertThatThrownBy(() -> e.match(l -> {}, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onRight");
     }
 
     // -------------------------------------------------------------------------

--- a/site/src/data/code/guide/either/interop-conversions.mdx
+++ b/site/src/data/code/guide/either/interop-conversions.mdx
@@ -5,19 +5,40 @@ fileName: 'Demo.java'
 ```java
 Either<String, Integer> e = compute();
 
-// Either → Option (Right → Some, Left → None — left value discarded)
+// ── Either → other types ────────────────────────────────────────────────────
+
+// → Option  (Right → Some, Left → None — left value discarded)
 Option<Integer> opt = e.toOption();
 
-// Either → Result (Right → Ok, Left → Err)
+// → Result  (Right → Ok, Left → Err)
 Result<Integer, String> result = e.toResult();
 
-// Either → Validated (Right → Valid, Left → Invalid)
+// → Validated  (Right → Valid, Left → Invalid)
 Validated<String, Integer> validated = e.toValidated();
 
-// Other types → Either
-Either<Throwable, String> fromTry       = Try.of(() -> fetch()).toEither();
-Either<String, Integer>   fromResult    = Result.<Integer, String>ok(1).toEither();
-Either<String, Integer>   fromValidated = Validated.<String, Integer>valid(1).toEither();
-Either<String, Integer>   fromOption    = Option.some(42)
-    .toEither(() -> "value absent");
+// → Optional  (Right(r) → Optional.of(r), Left → Optional.empty())
+Optional<Integer> optional = e.toOptional();
+
+// → Try  (Right → Success, Left mapped to Throwable → Failure)
+Try<Integer> tried = e.toTry(IllegalArgumentException::new);
+
+// → Stream  (Right(r) → Stream.of(r), Left → Stream.empty())
+//   Useful for flatMap pipelines that collect only the right values
+List<Integer> rights = Stream.of(Either.right(1), Either.left("err"), Either.right(3))
+    .flatMap(Either::stream)
+    .toList(); // [1, 3]
+
+// ── Other types → Either ────────────────────────────────────────────────────
+
+// Try → Either  (Success → Right, Failure → Left with the exception)
+Either<Throwable, String> fromTry = Try.of(() -> fetch()).toEither();
+
+// Result → Either  (Ok → Right, Err → Left)
+Either<String, Integer> fromResult = Result.<Integer, String>ok(1).toEither();
+
+// Validated → Either  (Valid → Right, Invalid → Left)
+Either<String, Integer> fromValidated = Validated.<String, Integer>valid(1).toEither();
+
+// Option → Either  (Some(v) → Right(v), None → Left(leftIfNone))
+Either<String, Integer> fromOption = Option.some(42).toEither("value absent");
 ```

--- a/site/src/data/guide/either.mdx
+++ b/site/src/data/guide/either.mdx
@@ -83,17 +83,23 @@ Prefer exhaustive switch patterns — the compiler enforces that both sides are 
 `peek` runs an action on the `Right` value and returns `this` unchanged.
 `peekLeft` does the same for the `Left` value. Both are chainable.
 
+`match(onLeft, onRight)` is the terminal, side-effecting counterpart to `fold`:
+it executes exactly one consumer and returns `void`.
+
 ## Interoperability
 
-| Conversion                   | Method / Factory                           | Notes                                  |
-|------------------------------|--------------------------------------------|----------------------------------------|
-| `Either` → `Option`          | `e.toOption()`                             | Right → Some; Left → None (discarded). |
-| `Either` → `Result`          | `e.toResult()`                             | Right → Ok; Left → Err.                |
-| `Either` → `Validated`       | `e.toValidated()`                          | Right → Valid; Left → Invalid.         |
-| `Try` → `Either`             | `tryVal.toEither()`                        | Success → Right; Failure → Left.       |
-| `Result` → `Either`          | `result.toEither()`                        | Ok → Right; Err → Left.                |
-| `Validated` → `Either`       | `validated.toEither()`                     | Valid → Right; Invalid → Left.         |
-| `Option` → `Either`          | `option.toEither(leftSupplier)`            | Some → Right; None → Left.             |
+| Conversion                   | Method / Factory                           | Notes                                                   |
+|------------------------------|--------------------------------------------|---------------------------------------------------------|
+| `Either` → `Option`          | `e.toOption()`                             | Right → Some; Left → None (discarded).                  |
+| `Either` → `Result`          | `e.toResult()`                             | Right → Ok; Left → Err.                                 |
+| `Either` → `Validated`       | `e.toValidated()`                          | Right → Valid; Left → Invalid.                          |
+| `Either` → `Optional`        | `e.toOptional()`                           | Right(r) → Optional.of(r); Left → Optional.empty().     |
+| `Either` → `Try`             | `e.toTry(leftMapper)`                      | Right → Success; Left mapped to `Throwable` → Failure.  |
+| `Either` → `Stream`          | `e.stream()`                               | Right(r) → Stream.of(r); Left → Stream.empty().         |
+| `Try` → `Either`             | `tryVal.toEither()`                        | Success → Right; Failure → Left.                        |
+| `Result` → `Either`          | `result.toEither()`                        | Ok → Right; Err → Left.                                 |
+| `Validated` → `Either`       | `validated.toEither()`                     | Valid → Right; Invalid → Left.                          |
+| `Option` → `Either`          | `option.toEither(leftIfNone)`              | Some → Right; None → Left(leftIfNone).                  |
 
 <InteropConversions/>
 


### PR DESCRIPTION
  Add four missing interoperability methods to bring Either to full parity
  with Option, Result, and Try:
  - toOptional(): Right(r) → Optional.of(r), Left → Optional.empty()
  - stream(): Right(r) → Stream.of(r), Left → Stream.empty()
  - toTry(leftMapper): Right → Success, Left → Failure via mapper
  - match(onLeft, onRight): terminal void fold counterpart

  Add 11 tests covering all branches and null-guard cases; Either reaches 100% coverage.
  Fix doc bug in either.mdx (toEither(leftSupplier) → toEither(leftIfNone)).
  Update interop-conversions.mdx with the full conversion matrix.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #288

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversion methods to transform data between related types: `Optional`, `Stream`, and `Try`.
  * Added pattern matching method for conditional operations based on value state.

* **Documentation**
  * Updated guides with examples demonstrating new conversion and pattern matching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->