### PR TITLE
feat(Lazy): add toOptional, toEither, toEither(errorMapper) — expand interop and docs (#290)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Lazy.java
+++ b/core/lib/src/main/java/dmx/fun/Lazy.java
@@ -1,6 +1,7 @@
 package dmx.fun;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -211,6 +212,51 @@ public final class Lazy<T> {
     public <E> Result<T, E> toResult(Function<? super Throwable, ? extends E> errorMapper) {
         return toTry()
             .toResult(errorMapper);
+    }
+
+    /**
+     * Evaluates this {@code Lazy} and returns the value wrapped in a
+     * {@link java.util.Optional Optional}.
+     *
+     * <p>Unlike {@link #toTry()}, this method does <em>not</em> capture exceptions —
+     * if the supplier throws, the exception propagates to the caller.
+     * Use {@code toTry().toOptional()} if you need exception-safe conversion.
+     *
+     * @return {@code Optional.of(value)}; never {@code Optional.empty()}
+     * @throws RuntimeException if the supplier throws (same semantics as {@link #get()})
+     */
+    public Optional<T> toOptional() {
+        return Optional.of(get());
+    }
+
+    /**
+     * Evaluates this {@code Lazy} inside an {@link Either}, capturing any exception thrown by the
+     * supplier as {@code Left(Throwable)}.
+     *
+     * @return {@code Either.right(value)} if the supplier completes normally,
+     *         or {@code Either.left(exception)} if it throws
+     */
+    public Either<Throwable, T> toEither() {
+        return toTry().toEither();
+    }
+
+    /**
+     * Evaluates this {@code Lazy} inside an {@link Either}, converting any exception thrown by the
+     * supplier into a typed left value using {@code errorMapper}.
+     *
+     * @param <E>         the left (error) type
+     * @param errorMapper a function that converts the thrown exception to the left value;
+     *                    must not be {@code null} and must not return {@code null}
+     * @return {@code Either.right(value)} if the supplier completes normally,
+     *         or {@code Either.left(errorMapper.apply(exception))} if it throws
+     * @throws NullPointerException if {@code errorMapper} is {@code null} or returns {@code null}
+     */
+    public <E> Either<E, T> toEither(Function<? super Throwable, ? extends E> errorMapper) {
+        Objects.requireNonNull(errorMapper, "errorMapper must not be null");
+        var t = toTry();
+        return t.isSuccess()
+            ? Either.right(t.get())
+            : Either.left(Objects.requireNonNull(errorMapper.apply(t.getCause()), "errorMapper returned null"));
     }
 
     /**

--- a/core/lib/src/test/java/dmx/fun/LazyTest.java
+++ b/core/lib/src/test/java/dmx/fun/LazyTest.java
@@ -1,5 +1,7 @@
 package dmx.fun;
 
+import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -366,5 +368,76 @@ class LazyTest {
         var lazy = Lazy.<String>of(() -> { throw new RuntimeException("x"); });
         assertThatThrownBy(lazy::get).isInstanceOf(RuntimeException.class);
         assertThat(lazy.toString()).isEqualTo("Lazy[!]");
+    }
+
+    // ---------- get: checked exception wrapping ----------
+
+    @Test
+    void get_throwingCheckedException_wrapsInRuntimeException() {
+        var cause = new IOException("checked");
+        var lazy = Lazy.<String>of(() -> sneakyThrow(cause));
+        assertThatThrownBy(lazy::get)
+            .isInstanceOf(RuntimeException.class)
+            .hasCause(cause);
+    }
+
+    // ---------- toOptional ----------
+
+    @Test
+    void toOptional_successfulSupplier_returnsPresent() {
+        Optional<Integer> opt = Lazy.of(() -> 42).toOptional();
+        assertThat(opt).isPresent().hasValue(42);
+    }
+
+    @Test
+    void toOptional_throwingSupplier_propagatesException() {
+        var lazy = Lazy.<String>of(() -> { throw new IllegalStateException("boom"); });
+        assertThatThrownBy(lazy::toOptional).isInstanceOf(IllegalStateException.class);
+    }
+
+    // ---------- toEither ----------
+
+    @Test
+    void toEither_successfulSupplier_returnsRight() {
+        Either<Throwable, Integer> e = Lazy.of(() -> 42).toEither();
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void toEither_throwingSupplier_returnsLeft() {
+        var lazy = Lazy.<Integer>of(() -> { throw new IllegalStateException("boom"); });
+        Either<Throwable, Integer> e = lazy.toEither();
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("boom");
+    }
+
+    @Test
+    void toEither_withMapper_successfulSupplier_returnsRight() {
+        Either<String, Integer> e = Lazy.of(() -> 7).toEither(Throwable::getMessage);
+        assertThat(e.isRight()).isTrue();
+        assertThat(e.getRight()).isEqualTo(7);
+    }
+
+    @Test
+    void toEither_withMapper_throwingSupplier_appliesMapper() {
+        var lazy = Lazy.<Integer>of(() -> { throw new IllegalArgumentException("bad"); });
+        Either<String, Integer> e = lazy.toEither(Throwable::getMessage);
+        assertThat(e.isLeft()).isTrue();
+        assertThat(e.getLeft()).isEqualTo("bad");
+    }
+
+    @Test
+    void toEither_withMapper_nullMapper_throwsNullPointerException() {
+        assertThatThrownBy(() -> Lazy.of(() -> "x").toEither(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorMapper");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable, T> T sneakyThrow(Throwable t) throws E {
+        throw (E) t;
     }
 }

--- a/site/src/data/code/guide/combining-types/conversion-cheat-sheet.mdx
+++ b/site/src/data/code/guide/combining-types/conversion-cheat-sheet.mdx
@@ -3,13 +3,24 @@ fileName: 'Demo.java'
 ---
 
 ```java
+// ── Option conversions ──────────────────────────────────────────────────────
+
 // Option<T> → Result<T, E>
 Result<String, String> r1 = option.toResult("value was absent");
-// or with a computed error:
-Result<String, AppError> r2 = option.fold(Result::ok, () -> Result.err(AppError.MISSING));
 
 // Option<T> → Try<T>
 Try<String> t1 = option.toTry(() -> new NoSuchElementException("absent"));
+
+// Option<T> → Either<L, T>  (Some → Right, None → Left)
+Either<String, Integer> e1 = option.toEither("value absent");
+
+// Option<T> → Optional<T>
+Optional<String> opt1 = option.toOptional();
+
+// Try<Optional<T>> → Option<T>  (flattens both layers — common with JPA repositories)
+Option<Item> o2 = Option.fromTryOptional(Try.of(() -> repository.findById(id)));
+
+// ── Try conversions ─────────────────────────────────────────────────────────
 
 // Try<T> → Result<T, Throwable>
 Result<String, Throwable> r3 = tryValue.toResult();
@@ -20,15 +31,45 @@ Result<String, AppError> r4 = tryValue.toResult(ex -> AppError.from(ex));
 // Try<T> → Option<T>
 Option<String> o1 = tryValue.toOption(); // Some on success, None on failure
 
-// Try<Optional<T>> → Option<T>  (flattens both layers — common with JPA repositories)
-Option<Item> o2 = Option.fromTryOptional(Try.of(() -> repository.findById(id)));
+// Try<T> → Either<Throwable, T>  (Success → Right, Failure → Left)
+Either<Throwable, String> e2 = tryValue.toEither();
+
+// Try<T> → Optional<T>
+Optional<String> opt2 = tryValue.toOptional(); // empty on failure or null success
+
+// ── Result conversions ──────────────────────────────────────────────────────
 
 // Result<T, E> → Option<T>  (discards the error)
-Option<String> o3 = result.toOption();   // Some(value) or None
+Option<String> o3 = result.toOption();
 
 // Result<T, E> → Try<T>
 Try<String> t2 = result.toTry(AppError::toException);
 
+// Result<T, E> → Either<E, T>  (Ok → Right, Err → Left)
+Either<String, Integer> e3 = result.toEither();
+
+// Result<T, E> → Optional<T>
+Optional<String> opt3 = result.toOptional();
+
+// ── Either conversions ──────────────────────────────────────────────────────
+
+// Either<L, R> → Option<R>  (Right → Some, Left → None)
+Option<Integer> o4 = either.toOption();
+
+// Either<L, R> → Result<R, L>  (Right → Ok, Left → Err)
+Result<Integer, String> r5 = either.toResult();
+
+// Either<L, R> → Try<R>  (Right → Success, Left mapped to Throwable)
+Try<Integer> t3 = either.toTry(IllegalArgumentException::new);
+
+// Either<L, R> → Optional<R>  (Right → present, Left → empty)
+Optional<Integer> opt4 = either.toOptional();
+
+// ── Validated conversions ────────────────────────────────────────────────────
+
 // Validated<E, A> → Result<A, E>
-Result<UserForm, List<String>> r5 = validated.toResult();
+Result<UserForm, List<String>> r6 = validated.toResult();
+
+// Validated<E, A> → Either<E, A>  (Valid → Right, Invalid → Left)
+Either<List<String>, UserForm> e4 = validated.toEither();
 ```

--- a/site/src/data/code/guide/lazy/interop-conversions.mdx
+++ b/site/src/data/code/guide/lazy/interop-conversions.mdx
@@ -30,7 +30,7 @@ Option<Config> opt = config.toOption();
 // toOptional() — forces evaluation; wraps value in Optional.of (throws if supplier throws)
 //   Use toTry().toOptional() for a safe, exception-capturing alternative
 Optional<Config> optional = config.toOptional();
-Optional<Config> safeOptional = config.toTry().toOptional(); // None on failure
+Optional<Config> safeOptional = config.toTry().toOptional(); // Optional.empty() on failure
 
 // ── Async interop ────────────────────────────────────────────────────────────
 

--- a/site/src/data/code/guide/lazy/interop-conversions.mdx
+++ b/site/src/data/code/guide/lazy/interop-conversions.mdx
@@ -5,6 +5,8 @@ fileName: 'Demo.java'
 ```java
 Lazy<Config> config = Lazy.of(() -> Config.loadFromDisk());
 
+// ── Safe conversions (capture exceptions) ───────────────────────────────────
+
 // toTry() — forces evaluation; captures any exception as Failure (result is memoized)
 Try<Config> t = config.toTry();
 
@@ -14,8 +16,23 @@ Result<Config, Throwable> r1 = config.toResult();
 // toResult(errorMapper) — forces evaluation; maps the exception to a domain error
 Result<Config, AppError> r2 = config.toResult(ex -> new AppError("Config load failed", ex));
 
+// toEither() — forces evaluation; exception becomes Left(Throwable)
+Either<Throwable, Config> e1 = config.toEither();
+
+// toEither(errorMapper) — forces evaluation; maps the exception to a typed left value
+Either<AppError, Config> e2 = config.toEither(ex -> new AppError("Config load failed", ex));
+
+// ── Unsafe conversions (propagate exceptions) ────────────────────────────────
+
 // toOption() — forces evaluation; wraps value in Some (throws if supplier throws)
 Option<Config> opt = config.toOption();
+
+// toOptional() — forces evaluation; wraps value in Optional.of (throws if supplier throws)
+//   Use toTry().toOptional() for a safe, exception-capturing alternative
+Optional<Config> optional = config.toOptional();
+Optional<Config> safeOptional = config.toTry().toOptional(); // None on failure
+
+// ── Async interop ────────────────────────────────────────────────────────────
 
 // toFuture() — if already evaluated, returns a completed future immediately;
 //              otherwise evaluates asynchronously via CompletableFuture.supplyAsync

--- a/site/src/data/guide/combining-types.mdx
+++ b/site/src/data/guide/combining-types.mdx
@@ -27,12 +27,24 @@ and the anti-patterns to avoid.
 |-----------------------|---------------------------|-------------------------------------------------|
 | `Option<T>`           | `Result<T, E>`            | `option.toResult(errorIfNone)`                  |
 | `Option<T>`           | `Try<T>`                  | `option.toTry(exceptionSupplier)`               |
+| `Option<T>`           | `Either<L, T>`            | `option.toEither(leftIfNone)`                   |
+| `Option<T>`           | `Optional<T>`             | `option.toOptional()`                           |
 | `Try<T>`              | `Result<T, Throwable>`    | `tryValue.toResult()`                           |
 | `Try<T>`              | `Result<T, E>`            | `tryValue.toResult(errorMapper)`                |
 | `Try<T>`              | `Option<T>`               | `tryValue.toOption()`                           |
+| `Try<T>`              | `Either<Throwable, T>`    | `tryValue.toEither()`                           |
+| `Try<T>`              | `Optional<T>`             | `tryValue.toOptional()`                         |
 | `Result<T, E>`        | `Option<T>`               | `result.toOption()`                             |
 | `Result<T, E>`        | `Try<T>`                  | `result.toTry(errorToThrowable)`                |
+| `Result<T, E>`        | `Either<E, T>`            | `result.toEither()`                             |
+| `Result<T, E>`        | `Optional<T>`             | `result.toOptional()`                           |
+| `Either<L, R>`        | `Option<R>`               | `either.toOption()`                             |
+| `Either<L, R>`        | `Result<R, L>`            | `either.toResult()`                             |
+| `Either<L, R>`        | `Validated<L, R>`         | `either.toValidated()`                          |
+| `Either<L, R>`        | `Try<R>`                  | `either.toTry(leftMapper)`                      |
+| `Either<L, R>`        | `Optional<R>`             | `either.toOptional()`                           |
 | `Validated<E, A>`     | `Result<A, E>`            | `validated.toResult()`                          |
+| `Validated<E, A>`     | `Either<E, A>`            | `validated.toEither()`                          |
 
 <ConversionCheatSheet/>
 

--- a/site/src/data/guide/lazy.mdx
+++ b/site/src/data/guide/lazy.mdx
@@ -68,7 +68,7 @@ until the terminal `get()` is invoked on the result.
 | `toEither(errorMapper)`   | Yes                | `Either<E, T>`             | Maps exception to a typed left value; safe (no throw).            |
 | `toOption()`              | Yes                | `Option<T>`                | Throws if supplier throws.                                        |
 | `toOptional()`            | Yes                | `Optional<T>`              | JDK interop; throws if supplier throws. Use `toTry().toOptional()` for safe conversion. |
-| `toFuture()`              | If already cached  | `CompletableFuture<T>`     | Returns completed future if cached; async otherwise.              |
+| `toFuture()`              | No (async if not cached) | `CompletableFuture<T>` | Returns already-completed future if cached; async via `supplyAsync` otherwise. |
 | `Lazy.fromFuture(future)` | No                 | `Lazy<T>`                  | Defers the blocking join to `get()` time.                         |
 
 <InteropConversions/>

--- a/site/src/data/guide/lazy.mdx
+++ b/site/src/data/guide/lazy.mdx
@@ -58,15 +58,18 @@ until the terminal `get()` is invoked on the result.
 
 ## Interoperability
 
-| Method / Factory          | Forces evaluation? | Returns                | Notes                                                |
-|---------------------------|--------------------|------------------------|------------------------------------------------------|
-| `get()`                   | Yes                | `T`                    | Rethrows supplier exceptions.                        |
-| `toTry()`                 | Yes                | `Try<T>`               | Captures exceptions as `Failure`; result memoized.   |
-| `toResult()`              | Yes                | `Result<T, Throwable>` | Exception becomes `Err`.                             |
-| `toResult(errorMapper)`   | Yes                | `Result<T, E>`         | Maps exception to a domain error.                    |
-| `toOption()`              | Yes                | `Option<T>`            | Throws if supplier throws.                           |
-| `toFuture()`              | If already cached  | `CompletableFuture<T>` | Returns completed future if cached; async otherwise. |
-| `Lazy.fromFuture(future)` | No                 | `Lazy<T>`              | Defers the blocking join to `get()` time.            |
+| Method / Factory          | Forces evaluation? | Returns                    | Notes                                                             |
+|---------------------------|--------------------|----------------------------|-------------------------------------------------------------------|
+| `get()`                   | Yes                | `T`                        | Rethrows supplier exceptions.                                     |
+| `toTry()`                 | Yes                | `Try<T>`                   | Captures exceptions as `Failure`; result memoized.                |
+| `toResult()`              | Yes                | `Result<T, Throwable>`     | Exception becomes `Err`.                                          |
+| `toResult(errorMapper)`   | Yes                | `Result<T, E>`             | Maps exception to a domain error.                                 |
+| `toEither()`              | Yes                | `Either<Throwable, T>`     | Exception becomes `Left`; safe (no throw).                        |
+| `toEither(errorMapper)`   | Yes                | `Either<E, T>`             | Maps exception to a typed left value; safe (no throw).            |
+| `toOption()`              | Yes                | `Option<T>`                | Throws if supplier throws.                                        |
+| `toOptional()`            | Yes                | `Optional<T>`              | JDK interop; throws if supplier throws. Use `toTry().toOptional()` for safe conversion. |
+| `toFuture()`              | If already cached  | `CompletableFuture<T>`     | Returns completed future if cached; async otherwise.              |
+| `Lazy.fromFuture(future)` | No                 | `Lazy<T>`                  | Defers the blocking join to `get()` time.                         |
 
 <InteropConversions/>
 


### PR DESCRIPTION
  Add three missing interoperability methods to bring Lazy closer to parity
  with other dmx-fun types:
  - toOptional(): forces evaluation, returns Optional.of(value); throws on failure
  - toEither(): safe conversion to Either<Throwable, T>, captures exceptions as Left
  - toEither(errorMapper): safe conversion to Either<E, T>, maps exception to typed left

  Add 8 tests covering success/failure branches, null-guard cases, and the
  previously uncovered checked-exception wrapping path in get().

  Update lazy.mdx interop table with the three new methods and "Forces evaluation?"
  semantics. Rewrite interop-conversions.mdx snippet with safe/unsafe/async sections.
  Update combining-types.mdx conversion cheat sheet with full Either, Optional,
  and Validated rows.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #290

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversion methods for Lazy values: `toOptional()`, `toEither()`, and `toEither(errorMapper)` for flexible type interoperability.

* **Documentation**
  * Expanded conversion guides with comprehensive examples for converting between Option, Try, Result, Either, Validated, and Optional types.
  * Updated Lazy interoperability documentation with detailed conversion semantics and safe/unsafe conversion guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->