### PR TITLE
feat(Resource): add useAsEither — Either-integrated use variant (#295)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Resource.java
+++ b/core/lib/src/main/java/dmx/fun/Resource.java
@@ -227,6 +227,55 @@ public final class Resource<T> {
         return Result.err(onError.apply(tryResult.getCause()));
     }
 
+    /**
+     * Acquires the resource, applies {@code body} to produce an {@link Either}, releases the
+     * resource, and returns an {@code Either<E, R>}.
+     *
+     * <p>This is the {@code Either}-integrated variant of {@link #use(CheckedFunction) use()},
+     * symmetric with {@link #useAsResult(Function, Function) useAsResult()}. Use it when the
+     * domain layer models results as neutral two-track {@code Either} values rather than
+     * typed {@code Result} errors.
+     *
+     * <ul>
+     *   <li>If acquire or release throws a {@code Throwable}, it is mapped to {@code E} via
+     *       {@code onError} and returned as {@code Either.left(e)}.</li>
+     *   <li>If the body returns {@code Either.left(e)}, that value is returned as-is.</li>
+     *   <li>If both body and release fail, the release exception is suppressed onto the body
+     *       exception and the combined throwable is passed to {@code onError}.</li>
+     * </ul>
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Either<DbError, List<User>> users = connResource.useAsEither(
+     *     conn -> fetchUsers(conn),
+     *     ex   -> new DbError.ConnectionFailed(ex.getMessage())
+     * );
+     * }</pre>
+     *
+     * @param <R>     the right (success) type
+     * @param <E>     the left (error) type
+     * @param body    function applied to the live resource; returns an {@code Either}
+     * @param onError maps any {@code Throwable} from acquire/release/body to {@code E}
+     * @return {@code Either.right(value)} on success, or {@code Either.left(error)} on any failure
+     * @throws NullPointerException if {@code body} or {@code onError} is {@code null}
+     */
+    public <R, E> Either<E, R> useAsEither(
+            Function<? super T, ? extends Either<? extends E, ? extends R>> body,
+            Function<? super Throwable, ? extends E> onError) {
+        Objects.requireNonNull(body, "body");
+        Objects.requireNonNull(onError, "onError");
+        var tryResult = use(t -> {
+            @SuppressWarnings("unchecked")
+            Either<E, R> r = (Either<E, R>) Objects.requireNonNull(
+                body.apply(t), "useAsEither body must not return null");
+            return r;
+        });
+        if (tryResult.isSuccess()) {
+            return tryResult.get();
+        }
+        return Either.left(onError.apply(tryResult.getCause()));
+    }
+
     // -------------------------------------------------------------------------
     // Transformations
     // -------------------------------------------------------------------------

--- a/core/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -598,6 +598,34 @@ class ResourceTest {
     }
 
     @Test
+    void useAsEither_shouldSuppressReleaseException_whenBothBodyAndReleaseThrow() {
+        var bodyEx    = new RuntimeException("body");
+        var releaseEx = new RuntimeException("release");
+        var r = Resource.of(() -> "hello", _ -> { throw releaseEx; });
+        var captured = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+
+        var result = r.useAsEither(
+            _ -> { throw bodyEx; },
+            t -> { captured.set(t); return t.getMessage(); }
+        );
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("body");
+        assertThat(captured.get()).isSameAs(bodyEx);
+        assertThat(captured.get().getSuppressed()).containsExactly(releaseEx);
+    }
+
+    @Test
+    void useAsEither_shouldReturnLeft_whenBodyReturnsNull() {
+        var r = Resource.of(() -> "hello", _ -> {});
+
+        var result = r.useAsEither(_ -> null, Throwable::getMessage);
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).contains("body");
+    }
+
+    @Test
     void useAsEither_shouldThrowNPE_whenBodyIsNull() {
         var r = Resource.of(() -> "hello", _ -> {
         });

--- a/core/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -1,7 +1,6 @@
 package dmx.fun;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -15,21 +14,34 @@ class ResourceTest {
     // Helpers
     // -------------------------------------------------------------------------
 
-    /** Tracks open/close events for a resource in tests. */
+    /**
+     * Tracks open/close events for a resource in tests.
+     */
     static class Tracked {
         final String name;
         boolean open = false;
         boolean closed = false;
 
-        Tracked(String name) { this.name = name; }
+        Tracked(String name) {
+            this.name = name;
+        }
 
-        void open() { open = true; }
-        void close() { closed = true; }
+        void open() {
+            open = true;
+        }
+
+        void close() {
+            closed = true;
+        }
     }
 
     static Resource<Tracked> tracked(String name) {
         return Resource.of(
-            () -> { Tracked t = new Tracked(name); t.open(); return t; },
+            () -> {
+                Tracked t = new Tracked(name);
+                t.open();
+                return t;
+            },
             r -> r.close()
         );
     }
@@ -40,26 +52,31 @@ class ResourceTest {
 
     @Test
     void use_shouldReturnSuccess_whenBodyAndReleaseSucceed() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Try<Integer> result = r.use(String::length);
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.use(String::length);
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo(5);
     }
 
     @Test
     void use_shouldAlwaysCallRelease_whenBodySucceeds() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
+        var released = new AtomicBoolean(false);
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+
         r.use(String::length);
         assertThat(released.get()).isTrue();
     }
 
     @Test
     void use_shouldAlwaysCallRelease_whenBodyThrows() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        RuntimeException bodyEx = new RuntimeException("body");
-        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
-        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        var released = new AtomicBoolean(false);
+        var bodyEx = new RuntimeException("body");
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+        var result = r.use(_ -> {
+            throw bodyEx;
+        });
+
         assertThat(released.get()).isTrue();
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(bodyEx);
@@ -71,19 +88,27 @@ class ResourceTest {
 
     @Test
     void use_shouldReturnReleaseException_whenBodySucceedsButReleaseThrows() {
-        RuntimeException releaseEx = new RuntimeException("release");
-        Resource<String> r = Resource.of(() -> "hello", s -> { throw releaseEx; });
-        Try<Integer> result = r.use(String::length);
+        var releaseEx = new RuntimeException("release");
+        var r = Resource.of(() -> "hello", _ -> {
+            throw releaseEx;
+        });
+        var result = r.use(String::length);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(releaseEx);
     }
 
     @Test
     void use_shouldSuppressReleaseException_whenBothBodyAndReleaseThrow() {
-        RuntimeException bodyEx    = new RuntimeException("body");
-        RuntimeException releaseEx = new RuntimeException("release");
-        Resource<String> r = Resource.of(() -> "hello", s -> { throw releaseEx; });
-        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        var bodyEx = new RuntimeException("body");
+        var releaseEx = new RuntimeException("release");
+        var r = Resource.of(() -> "hello", _ -> {
+            throw releaseEx;
+        });
+        var result = r.use(_ -> {
+            throw bodyEx;
+        });
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(bodyEx);
         assertThat(result.getCause().getSuppressed()).containsExactly(releaseEx);
@@ -91,9 +116,13 @@ class ResourceTest {
 
     @Test
     void use_shouldReturnFailure_whenAcquireThrows() {
-        RuntimeException acquireEx = new RuntimeException("acquire");
-        Resource<String> r = Resource.of(() -> { throw acquireEx; }, s -> {});
-        Try<Integer> result = r.use(String::length);
+        var acquireEx = new RuntimeException("acquire");
+        var r = Resource.<String>of(() -> {
+            throw acquireEx;
+        }, _ -> {
+        });
+        var result = r.use(String::length);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(acquireEx);
     }
@@ -104,19 +133,23 @@ class ResourceTest {
 
     @Test
     void fromAutoCloseable_shouldCloseResource_afterUse() {
-        AtomicBoolean closed = new AtomicBoolean(false);
+        var closed = new AtomicBoolean(false);
         AutoCloseable ac = () -> closed.set(true);
-        Resource<AutoCloseable> r = Resource.fromAutoCloseable(() -> ac);
+        var r = Resource.fromAutoCloseable(() -> ac);
+
         r.use(a -> "ok");
         assertThat(closed.get()).isTrue();
     }
 
     @Test
     void fromAutoCloseable_shouldCloseResource_whenBodyThrows() {
-        AtomicBoolean closed = new AtomicBoolean(false);
+        var closed = new AtomicBoolean(false);
         AutoCloseable ac = () -> closed.set(true);
-        Resource<AutoCloseable> r = Resource.fromAutoCloseable(() -> ac);
-        r.use(a -> { throw new RuntimeException("oops"); });
+        var r = Resource.fromAutoCloseable(() -> ac);
+
+        r.use(_ -> {
+            throw new RuntimeException("oops");
+        });
         assertThat(closed.get()).isTrue();
     }
 
@@ -126,11 +159,16 @@ class ResourceTest {
 
     @Test
     void map_shouldTransformValue_andReleaseOriginalResource() {
-        Tracked t = new Tracked("db");
-        Resource<Tracked> base = Resource.of(() -> { t.open(); return t; }, Tracked::close);
-        Resource<String> mapped = base.map(tr -> tr.name.toUpperCase());
-
-        Try<Integer> result = mapped.use(String::length);
+        var t = new Tracked("db");
+        var base = Resource.of(
+            () -> {
+                t.open();
+                return t;
+            },
+            Tracked::close
+        );
+        var mapped = base.map(tr -> tr.name.toUpperCase());
+        var result = mapped.use(String::length);
 
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo(2); // "DB".length()
@@ -140,11 +178,17 @@ class ResourceTest {
 
     @Test
     void map_shouldReleaseResource_whenMapperThrows() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        RuntimeException mapEx = new RuntimeException("map");
-        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
-        Resource<String> mapped = r.map(s -> { throw mapEx; });
-        Try<Integer> result = mapped.use(String::length);
+        var released = new AtomicBoolean(false);
+        var mapEx = new RuntimeException("map");
+        var r = Resource.of(
+            () -> "hello",
+            _ -> released.set(true)
+        );
+        var mapped = r.<String>map(_ -> {
+            throw mapEx;
+        });
+        var result = mapped.use(String::length);
+
         assertThat(released.get()).isTrue();
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(mapEx);
@@ -152,7 +196,9 @@ class ResourceTest {
 
     @Test
     void map_shouldThrowNPE_whenMapperIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+
         assertThatThrownBy(() -> r.map(null))
             .isInstanceOf(NullPointerException.class);
     }
@@ -163,20 +209,29 @@ class ResourceTest {
 
     @Test
     void flatMap_shouldComposeResources_andReleaseInReverseOrder() {
-        List<String> events = new ArrayList<>();
+        var events = new ArrayList<String>();
 
-        Resource<String> outer = Resource.of(
-            () -> { events.add("outer-acquire"); return "conn"; },
-            s  -> events.add("outer-release")
+        var outer = Resource.of(
+            () -> {
+                events.add("outer-acquire");
+                return "conn";
+            },
+            _ -> events.add("outer-release")
         );
-        Resource<String> composed = outer.flatMap(conn ->
+        var composed = outer.flatMap(conn ->
             Resource.of(
-                () -> { events.add("inner-acquire"); return conn + "+stmt"; },
-                s  -> events.add("inner-release")
+                () -> {
+                    events.add("inner-acquire");
+                    return conn + "+stmt";
+                },
+                _ -> events.add("inner-release")
             )
         );
 
-        Try<Integer> result = composed.use(s -> { events.add("body"); return s.length(); });
+        var result = composed.use(s -> {
+            events.add("body");
+            return s.length();
+        });
 
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo("conn+stmt".length());
@@ -186,21 +241,28 @@ class ResourceTest {
 
     @Test
     void flatMap_shouldReleaseOuterResource_whenInnerBodyThrows() {
-        List<String> events = new ArrayList<>();
-        RuntimeException bodyEx = new RuntimeException("body");
+        var events = new ArrayList<String>();
+        var bodyEx = new RuntimeException("body");
 
-        Resource<String> outer = Resource.of(
-            () -> { events.add("outer-acquire"); return "conn"; },
-            s  -> events.add("outer-release")
+        var outer = Resource.of(
+            () -> {
+                events.add("outer-acquire");
+                return "conn";
+            },
+            _ -> events.add("outer-release")
         );
-        Resource<String> composed = outer.flatMap(conn ->
+        var composed = outer.flatMap(conn ->
             Resource.of(
-                () -> { events.add("inner-acquire"); return conn + "+stmt"; },
-                s  -> events.add("inner-release")
+                () -> {
+                    events.add("inner-acquire");
+                    return conn + "+stmt";
+                },
+                _ -> events.add("inner-release")
             )
         );
-
-        Try<Integer> result = composed.use(s -> { throw bodyEx; });
+        var result = composed.use(_ -> {
+            throw bodyEx;
+        });
 
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(bodyEx);
@@ -210,14 +272,19 @@ class ResourceTest {
 
     @Test
     void flatMap_shouldSuppressOuterReleaseException_ontoBodyException() {
-        RuntimeException bodyEx       = new RuntimeException("body");
-        RuntimeException outerRelease = new RuntimeException("outer-release");
+        var bodyEx = new RuntimeException("body");
+        var outerRelease = new RuntimeException("outer-release");
 
-        Resource<String> outer = Resource.of(() -> "outer", s -> { throw outerRelease; });
-        Resource<String> composed = outer.flatMap(s ->
-            Resource.of(() -> "inner", i -> {}));
-
-        Try<Integer> result = composed.use(s -> { throw bodyEx; });
+        var outer = Resource.of(() -> "outer", _ -> {
+            throw outerRelease;
+        });
+        var composed = outer.flatMap(
+            _ -> Resource.of(() -> "inner", _ -> {
+            })
+        );
+        var result = composed.use(_ -> {
+            throw bodyEx;
+        });
 
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(bodyEx);
@@ -226,15 +293,18 @@ class ResourceTest {
 
     @Test
     void flatMap_shouldThrowNPE_whenFnIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
         assertThatThrownBy(() -> r.flatMap(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void flatMap_shouldThrowNPE_whenFnReturnsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Try<Integer> result = r.<String>flatMap(s -> null).use(String::length);
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.<String>flatMap(_ -> null).use(String::length);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(NullPointerException.class);
     }
@@ -245,7 +315,8 @@ class ResourceTest {
 
     @Test
     void use_shouldThrowNPE_whenBodyIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
         assertThatThrownBy(() -> r.use(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("body");
@@ -253,7 +324,8 @@ class ResourceTest {
 
     @Test
     void of_shouldThrowNPE_whenAcquireIsNull() {
-        assertThatThrownBy(() -> Resource.of(null, s -> {}))
+        assertThatThrownBy(() -> Resource.of(null, _ -> {
+        }))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("acquire");
     }
@@ -278,11 +350,14 @@ class ResourceTest {
 
     @Test
     void resource_shouldBeReusable_eachUseAcquiresAndReleases() {
-        AtomicInteger acquireCount = new AtomicInteger(0);
-        AtomicInteger releaseCount = new AtomicInteger(0);
-        Resource<String> r = Resource.of(
-            () -> { acquireCount.incrementAndGet(); return "hello"; },
-            s  -> releaseCount.incrementAndGet()
+        var acquireCount = new AtomicInteger(0);
+        var releaseCount = new AtomicInteger(0);
+        var r = Resource.of(
+            () -> {
+                acquireCount.incrementAndGet();
+                return "hello";
+            },
+            _ -> releaseCount.incrementAndGet()
         );
 
         r.use(String::length);
@@ -298,9 +373,10 @@ class ResourceTest {
 
     @Test
     void eval_shouldRunBodyAndRelease_whenTryIsSuccess() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        Resource<String> r = Resource.eval(Try.success("hello"), s -> released.set(true));
-        Try<Integer> result = r.use(String::length);
+        var released = new AtomicBoolean(false);
+        var r = Resource.eval(Try.success("hello"), _ -> released.set(true));
+        var result = r.use(String::length);
+
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo(5);
         assertThat(released.get()).isTrue();
@@ -308,10 +384,14 @@ class ResourceTest {
 
     @Test
     void eval_shouldReturnFailure_andSkipRelease_whenTryIsFailure() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        RuntimeException acquireEx = new RuntimeException("acquire failed");
-        Resource<String> r = Resource.eval(Try.failure(acquireEx), s -> released.set(true));
-        Try<Integer> result = r.use(String::length);
+        var released = new AtomicBoolean(false);
+        var acquireEx = new RuntimeException("acquire failed");
+        var r = Resource.<String>eval(
+            Try.failure(acquireEx),
+            _ -> released.set(true)
+        );
+        var result = r.use(String::length);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(acquireEx);
         assertThat(released.get()).isFalse();
@@ -319,17 +399,24 @@ class ResourceTest {
 
     @Test
     void eval_shouldAlwaysCallRelease_whenBodyThrows() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        RuntimeException bodyEx = new RuntimeException("body");
-        Resource<String> r = Resource.eval(Try.success("hello"), s -> released.set(true));
-        Try<Integer> result = r.use(s -> { throw bodyEx; });
+        var released = new AtomicBoolean(false);
+        var bodyEx = new RuntimeException("body");
+        var r = Resource.eval(
+            Try.success("hello"),
+            _ -> released.set(true)
+        );
+        var result = r.use(_ -> {
+            throw bodyEx;
+        });
+
         assertThat(released.get()).isTrue();
         assertThat(result.getCause()).isSameAs(bodyEx);
     }
 
     @Test
     void eval_shouldThrowNPE_whenAcquiredIsNull() {
-        assertThatThrownBy(() -> Resource.eval(null, s -> {}))
+        assertThatThrownBy(() -> Resource.eval(null, _ -> {
+        }))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("acquired");
     }
@@ -347,61 +434,79 @@ class ResourceTest {
 
     @Test
     void useAsResult_shouldReturnOk_whenBodyReturnsOk() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Result<Integer, String> result = r.useAsResult(
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsResult(
             s -> Result.ok(s.length()),
             Throwable::getMessage
         );
+
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo(5);
     }
 
     @Test
     void useAsResult_shouldReturnErr_whenBodyReturnsErr() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Result<Integer, String> result = r.useAsResult(
-            s -> Result.err("domain error"),
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsResult(
+            _ -> Result.err("domain error"),
             Throwable::getMessage
         );
+
         assertThat(result.isError()).isTrue();
         assertThat(result.getError()).isEqualTo("domain error");
     }
 
     @Test
     void useAsResult_shouldMapToErr_whenAcquireThrows() {
-        RuntimeException acquireEx = new RuntimeException("acquire");
-        Resource<String> r = Resource.of(() -> { throw acquireEx; }, s -> {});
-        Result<Integer, String> result = r.useAsResult(
+        var acquireEx = new RuntimeException("acquire");
+        var r = Resource.<String>of(() -> {
+            throw acquireEx;
+        }, _ -> {
+        });
+        var result = r.useAsResult(
             s -> Result.ok(s.length()),
             Throwable::getMessage
         );
+
         assertThat(result.isError()).isTrue();
         assertThat(result.getError()).isEqualTo("acquire");
     }
 
     @Test
     void useAsResult_shouldMapToErr_whenBodyThrowsUnexpectedly() {
-        RuntimeException bodyEx = new RuntimeException("unexpected");
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Result<Integer, String> result = r.useAsResult(
-            s -> { throw bodyEx; },
+        var bodyEx = new RuntimeException("unexpected");
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsResult(
+            _ -> {
+                throw bodyEx;
+            },
             Throwable::getMessage
         );
+
         assertThat(result.isError()).isTrue();
         assertThat(result.getError()).isEqualTo("unexpected");
     }
 
     @Test
     void useAsResult_shouldAlwaysRelease_whenBodyThrowsUnexpectedly() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
-        r.useAsResult(s -> { throw new RuntimeException("oops"); }, Throwable::getMessage);
+        var released = new AtomicBoolean(false);
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+        r.useAsResult(
+            _ -> {
+                throw new RuntimeException("oops");
+            },
+            Throwable::getMessage
+        );
         assertThat(released.get()).isTrue();
     }
 
     @Test
     void useAsResult_shouldThrowNPE_whenBodyIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
         assertThatThrownBy(() -> r.useAsResult(null, Throwable::getMessage))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("body");
@@ -409,8 +514,105 @@ class ResourceTest {
 
     @Test
     void useAsResult_shouldThrowNPE_whenOnErrorIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
         assertThatThrownBy(() -> r.useAsResult(s -> Result.ok(s.length()), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onError");
+    }
+
+    // -------------------------------------------------------------------------
+    // useAsEither — Either-integrated use
+    // -------------------------------------------------------------------------
+
+    @Test
+    void useAsEither_shouldReturnRight_whenBodyReturnsRight() {
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsEither(
+            s -> Either.right(s.length()),
+            Throwable::getMessage
+        );
+
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight()).isEqualTo(5);
+    }
+
+    @Test
+    void useAsEither_shouldReturnLeft_whenBodyReturnsLeft() {
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsEither(
+            _ -> Either.left("domain error"),
+            Throwable::getMessage
+        );
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("domain error");
+    }
+
+    @Test
+    void useAsEither_shouldMapToLeft_whenAcquireThrows() {
+        var acquireEx = new RuntimeException("acquire");
+        var r = Resource.<String>of(() -> {
+            throw acquireEx;
+        }, _ -> {
+        });
+        var result = r.useAsEither(
+            s -> Either.right(s.length()),
+            Throwable::getMessage
+        );
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("acquire");
+    }
+
+    @Test
+    void useAsEither_shouldMapToLeft_whenBodyThrowsUnexpectedly() {
+        var bodyEx = new RuntimeException("unexpected");
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.useAsEither(
+            _ -> {
+                throw bodyEx;
+            },
+            Throwable::getMessage
+        );
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("unexpected");
+    }
+
+    @Test
+    void useAsEither_shouldAlwaysRelease_whenBodyThrowsUnexpectedly() {
+        var released = new AtomicBoolean(false);
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+        r.useAsEither(
+            _ -> {
+                throw new RuntimeException("oops");
+            },
+            Throwable::getMessage
+        );
+
+        assertThat(released.get()).isTrue();
+    }
+
+    @Test
+    void useAsEither_shouldThrowNPE_whenBodyIsNull() {
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+
+        assertThatThrownBy(() -> r.useAsEither(null, Throwable::getMessage))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("body");
+    }
+
+    @Test
+    void useAsEither_shouldThrowNPE_whenOnErrorIsNull() {
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+
+        assertThatThrownBy(() -> r.useAsEither(s -> Either.right(s.length()), null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("onError");
     }
@@ -421,42 +623,54 @@ class ResourceTest {
 
     @Test
     void mapTry_shouldApplyBody_whenFnReturnsSuccess() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Resource<Integer> mapped = r.mapTry(s -> Try.success(s.length()));
-        Try<String> result = mapped.use(n -> "len=" + n);
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var mapped = r.mapTry(s -> Try.success(s.length()));
+        var result = mapped.use(n -> "len=" + n);
+
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo("len=5");
     }
 
     @Test
     void mapTry_shouldReturnFailure_whenFnReturnsFailure() {
-        RuntimeException parseEx = new RuntimeException("parse failed");
-        Resource<String> r = Resource.of(() -> "bad", s -> {});
-        Resource<Integer> mapped = r.mapTry(s -> Try.failure(parseEx));
-        Try<String> result = mapped.use(n -> "len=" + n);
+        var parseEx = new RuntimeException("parse failed");
+        var r = Resource.of(() -> "bad", _ -> {
+        });
+        var mapped = r.mapTry(_ -> Try.failure(parseEx));
+        var result = mapped.use(n -> "len=" + n);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(parseEx);
     }
 
     @Test
     void mapTry_shouldReleaseResource_whenFnReturnsFailure() {
-        AtomicBoolean released = new AtomicBoolean(false);
-        Resource<String> r = Resource.of(() -> "hello", s -> released.set(true));
-        r.mapTry(s -> Try.failure(new RuntimeException("fail"))).use(n -> n);
+        var released = new AtomicBoolean(false);
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+        r.mapTry(
+            _ -> Try.failure(new RuntimeException("fail"))
+        ).use(n -> n);
+
         assertThat(released.get()).isTrue();
     }
 
     @Test
     void mapTry_shouldThrowNPE_whenFnIsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+
         assertThatThrownBy(() -> r.mapTry(null))
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void mapTry_shouldThrowNPE_whenFnReturnsNull() {
-        Resource<String> r = Resource.of(() -> "hello", s -> {});
-        Try<Integer> result = r.<Integer>mapTry(s -> null).use(n -> n);
+        var r = Resource.of(() -> "hello", _ -> {
+        });
+        var result = r.<Integer>mapTry(_ -> null)
+            .use(n -> n);
+
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(NullPointerException.class);
     }

--- a/site/src/data/code/guide/resource/use-as-either.mdx
+++ b/site/src/data/code/guide/resource/use-as-either.mdx
@@ -1,0 +1,27 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+sealed interface DbError {
+    record QueryFailed(String message) implements DbError {}
+    record ConnectionFailed(String message) implements DbError {}
+}
+
+Resource<Connection> connResource = Resource.of(
+    () -> dataSource.getConnection(),
+    Connection::close
+);
+
+// Body returns Either<E, R> — acquire/release Throwables are mapped to E via onError
+Either<DbError, List<User>> users = connResource.useAsEither(
+    conn  -> fetchUsers(conn),                              // returns Either<DbError, List<User>>
+    ex    -> new DbError.ConnectionFailed(ex.getMessage())
+);
+
+// Both branches are explicit — no Try wrapping needed
+users.match(
+    err  -> System.err.println("DB error: " + err),
+    list -> list.forEach(System.out::println)
+);
+```

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -13,6 +13,7 @@ import {Content as MapTry}            from '../code/guide/resource/map-try.mdx';
 import {Content as FlatMap}           from '../code/guide/resource/flat-map.mdx';
 import {Content as Eval}              from '../code/guide/resource/eval.mdx';
 import {Content as UseAsResult}       from '../code/guide/resource/use-as-result.mdx';
+import {Content as UseAsEither}       from '../code/guide/resource/use-as-either.mdx';
 import {Content as RealWorldExample}  from '../code/guide/resource/real-world-example.mdx';
 
 > **Runnable example:** [`ResourceSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResourceSample.java)
@@ -116,6 +117,15 @@ Any `Throwable` from acquire, release, or an unexpected body exception is mapped
 `onError`, eliminating the `Try<Result<R, E>>` nesting.
 
 <UseAsResult/>
+
+### `useAsEither(body, onError)` — Either-integrated execution
+
+The `Either`-counterpart of `use()`, symmetric with `useAsResult`. Use it when the domain
+layer models results as neutral two-track `Either<E, R>` values. The body returns an
+`Either<E, R>` directly; any `Throwable` from acquire, release, or an unexpected body
+exception is mapped to `E` via `onError`.
+
+<UseAsEither/>
 
 ## Real-world example
 


### PR DESCRIPTION
  Add useAsEither(body, onError) as the Either-counterpart of useAsResult:
  the body returns Either<E, R> directly and any Throwable from acquire,
  release, or an unexpected body exception is mapped to E via onError,
  eliminating Try<Either<E, R>> nesting.

  Add 7 tests covering Right, Left, acquire failure, unexpected body throw,
  guaranteed release, and null-guard cases.

  Add use-as-either.mdx snippet and update resource.mdx with the new section
  under Interoperability.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #295

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Resource API with a new method enabling explicit error type mapping and alternative error handling patterns.

* **Documentation**
  * Added guide and code examples demonstrating the new error handling capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->