### PR TITLE
feat(accumulator): add toOptional, stream, toEither, liftResult, and liftEither interop (#287)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Accumulator.java
+++ b/core/lib/src/main/java/dmx/fun/Accumulator.java
@@ -3,9 +3,11 @@ package dmx.fun;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -488,6 +490,102 @@ public record Accumulator<E, A>(@Nullable A value, E accumulated) {
         return Accumulator.of(result, log);
     }
 
+    /**
+     * Lifts a {@link Result} value into an {@code Accumulator}, recording a log entry via
+     * {@code okLog} on success or {@code errLog} on failure.
+     *
+     * <p>The {@code Result<V, Err>} itself becomes the value of the returned accumulator,
+     * preserving full access to the outcome. The log records what happened regardless of
+     * which branch was taken:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Result<Config, String>> acc = Accumulator.liftResult(
+     *     configService.load(path),
+     *     cfg -> List.of("config loaded from " + path),
+     *     err -> List.of("config load failed: " + err)
+     * );
+     *
+     * acc.accumulated();  // always set — ok or error
+     * acc.value();        // Result<Config, String> — caller decides how to handle it
+     * }</pre>
+     *
+     * @param <E>    the accumulation type
+     * @param <V>    the ok value type of the Result
+     * @param <Err>  the error type of the Result
+     * @param result the Result to lift; must not be {@code null}
+     * @param okLog  function that produces the log entry on ok; must not be {@code null}
+     *               and must not return {@code null}
+     * @param errLog function that produces the log entry on error; must not be {@code null}
+     *               and must not return {@code null}
+     * @return an {@code Accumulator<E, Result<V, Err>>} pairing the Result with its log entry
+     * @throws NullPointerException if any argument is {@code null} or if either log function
+     *                              returns {@code null}
+     */
+    public static <E, V, Err> Accumulator<E, Result<V, Err>> liftResult(
+            Result<V, Err> result,
+            Function<? super V, ? extends E> okLog,
+            Function<? super Err, ? extends E> errLog) {
+        Objects.requireNonNull(result, "result");
+        Objects.requireNonNull(okLog, "okLog");
+        Objects.requireNonNull(errLog, "errLog");
+        if (result.isOk()) {
+            E log = okLog.apply(result.get());
+            Objects.requireNonNull(log, "okLog function must not return null");
+            return Accumulator.of(result, log);
+        }
+        E log = errLog.apply(result.getError());
+        Objects.requireNonNull(log, "errLog function must not return null");
+        return Accumulator.of(result, log);
+    }
+
+    /**
+     * Lifts an {@link Either} value into an {@code Accumulator}, recording a log entry via
+     * {@code rightLog} on the right track or {@code leftLog} on the left track.
+     *
+     * <p>The {@code Either<L, R>} itself becomes the value of the returned accumulator,
+     * preserving full access to the outcome. The log records what happened regardless of
+     * which branch was taken:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Either<String, Config>> acc = Accumulator.liftEither(
+     *     configParser.parse(input),
+     *     cfg -> List.of("parsed successfully"),
+     *     err -> List.of("parse failed: " + err)
+     * );
+     *
+     * acc.accumulated();  // always set — right or left
+     * acc.value();        // Either<String, Config> — caller decides how to handle it
+     * }</pre>
+     *
+     * @param <E>      the accumulation type
+     * @param <L>      the left type of the Either
+     * @param <R>      the right (success) type of the Either
+     * @param either   the Either to lift; must not be {@code null}
+     * @param rightLog function that produces the log entry on the right track;
+     *                 must not be {@code null} and must not return {@code null}
+     * @param leftLog  function that produces the log entry on the left track;
+     *                 must not be {@code null} and must not return {@code null}
+     * @return an {@code Accumulator<E, Either<L, R>>} pairing the Either with its log entry
+     * @throws NullPointerException if any argument is {@code null} or if either log function
+     *                              returns {@code null}
+     */
+    public static <E, L, R> Accumulator<E, Either<L, R>> liftEither(
+            Either<L, R> either,
+            Function<? super R, ? extends E> rightLog,
+            Function<? super L, ? extends E> leftLog) {
+        Objects.requireNonNull(either, "either");
+        Objects.requireNonNull(rightLog, "rightLog");
+        Objects.requireNonNull(leftLog, "leftLog");
+        if (either.isRight()) {
+            E log = rightLog.apply(either.getRight());
+            Objects.requireNonNull(log, "rightLog function must not return null");
+            return Accumulator.of(either, log);
+        }
+        E log = leftLog.apply(either.getLeft());
+        Objects.requireNonNull(log, "leftLog function must not return null");
+        return Accumulator.of(either, log);
+    }
+
     // -------------------------------------------------------------------------
     // Interoperability
     // -------------------------------------------------------------------------
@@ -553,5 +651,71 @@ public record Accumulator<E, A>(@Nullable A value, E accumulated) {
     @SuppressWarnings("NullAway")
     public Result<A, E> toResult() {
         return hasValue() ? Result.ok(value) : Result.err(accumulated);
+    }
+
+    /**
+     * Converts this accumulator to a JDK {@link Optional}.
+     * Returns {@link Optional#of(Object)} when {@link #hasValue()} is {@code true},
+     * or {@link Optional#empty()} for {@link #tell(Object)} results.
+     *
+     * <p>The accumulation is discarded. Use this when only the presence or absence of a
+     * value matters and the log is not needed at this point:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("step 1"));
+     * acc.toOptional();  // Optional.of(42)
+     *
+     * Accumulator<List<String>, Void> tell = Accumulator.tell(List.of("entry"));
+     * tell.toOptional(); // Optional.empty()
+     * }</pre>
+     *
+     * @return {@code Optional.of(value)} when {@link #hasValue()},
+     *         or {@code Optional.empty()} for {@link #tell(Object)} results
+     */
+    public Optional<A> toOptional() {
+        return value != null ? Optional.of(value) : Optional.empty();
+    }
+
+    /**
+     * Returns a single-element {@link Stream} of the value when {@link #hasValue()} is
+     * {@code true}, or an empty stream for {@link #tell(Object)} results.
+     *
+     * <p>The accumulation is discarded. Useful for integrating with stream pipelines:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("log"));
+     * acc.stream().forEach(System.out::println); // prints 42
+     *
+     * Accumulator<List<String>, Void> tell = Accumulator.tell(List.of("entry"));
+     * tell.stream().count(); // 0
+     * }</pre>
+     *
+     * @return a single-element stream of the value, or an empty stream for {@code tell} results
+     */
+    public Stream<A> stream() {
+        return value != null ? Stream.of(value) : Stream.empty();
+    }
+
+    /**
+     * Converts this accumulator to an {@link Either}: {@link Either#right(Object)} when
+     * {@link #hasValue()} is {@code true}, or {@link Either#left(Object)} carrying the
+     * accumulated side-channel when this accumulator was created by {@link #tell(Object)}.
+     *
+     * <p>This is the {@code Either}-counterpart of {@link #toResult()}, useful when the
+     * surrounding code works in the {@code Either} world:
+     *
+     * <pre>{@code
+     * Accumulator<List<String>, Config> acc = loadAndTrace(path);
+     *
+     * Either<List<String>, Config> result = acc.toEither();
+     * // right(config)       — when a value was computed
+     * // left(["entry..."])  — when only tell() steps ran (no real value was produced)
+     * }</pre>
+     *
+     * @return {@code right(value)} when {@link #hasValue()}, or {@code left(accumulated)} otherwise
+     */
+    @SuppressWarnings("NullAway")
+    public Either<E, A> toEither() {
+        return hasValue() ? Either.right(value) : Either.left(accumulated);
     }
 }

--- a/core/lib/src/test/java/dmx/fun/AccumulatorTest.java
+++ b/core/lib/src/test/java/dmx/fun/AccumulatorTest.java
@@ -2,6 +2,7 @@ package dmx.fun;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BinaryOperator;
 import org.junit.jupiter.api.Test;
 
@@ -582,5 +583,162 @@ class AccumulatorTest {
         assertThat(result.value()).isEqualTo("CONFIG.YAML");
         assertThat(result.accumulated())
             .containsExactly("config path resolved: config.yaml", "path normalized");
+    }
+
+    // -------------------------------------------------------------------------
+    // toOptional
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toOptional_returnsPresent_forOfAccumulator() {
+        var acc = Accumulator.of(42, List.of("log"));
+        assertThat(acc.toOptional())
+            .isPresent().contains(42);
+    }
+
+    @Test
+    void toOptional_returnsEmpty_forTellAccumulator() {
+        var acc = Accumulator.tell(List.of("log"));
+        assertThat(acc.toOptional()).isEmpty();
+    }
+
+    @Test
+    void toOptional_discardsAccumulation() {
+        var acc = Accumulator.of("value", List.of("important log"));
+        assertThat(acc.toOptional()).contains("value");
+    }
+
+    // -------------------------------------------------------------------------
+    // stream
+    // -------------------------------------------------------------------------
+
+    @Test
+    void stream_returnsSingleElement_forOfAccumulator() {
+        var acc = Accumulator.of(42, List.of("log"));
+        assertThat(acc.stream().toList()).containsExactly(42);
+    }
+
+    @Test
+    void stream_returnsEmpty_forTellAccumulator() {
+        var acc = Accumulator.tell(List.of("log"));
+        assertThat(acc.stream().toList()).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // toEither
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toEither_returnsRight_forOfAccumulator() {
+        var acc = Accumulator.of(42, List.of("log"));
+        var either = acc.toEither();
+        assertThat(either.isRight()).isTrue();
+        assertThat(either.getRight()).isEqualTo(42);
+    }
+
+    @Test
+    void toEither_returnsLeft_forTellAccumulator() {
+        var acc = Accumulator.tell(List.of("entry"));
+        var either = acc.toEither();
+        assertThat(either.isLeft()).isTrue();
+        assertThat(either.getLeft()).containsExactly("entry");
+    }
+
+    // -------------------------------------------------------------------------
+    // liftResult
+    // -------------------------------------------------------------------------
+
+    @Test
+    void liftResult_ok_appliesOkLog() {
+        var result = Accumulator.liftResult(
+            Result.ok("alice"),
+            name -> List.of("found: " + name),
+            err  -> List.of("error: " + err)
+        );
+        assertThat(result.value().isOk()).isTrue();
+        assertThat(result.value().get()).isEqualTo("alice");
+        assertThat(result.accumulated()).containsExactly("found: alice");
+    }
+
+    @Test
+    void liftResult_error_appliesErrLog() {
+        var result = Accumulator.liftResult(
+            Result.<String, String>err("not found"),
+            name -> List.of("found: " + name),
+            err  -> List.of("error: " + err)
+        );
+        assertThat(result.value().isError()).isTrue();
+        assertThat(result.value().getError()).isEqualTo("not found");
+        assertThat(result.accumulated()).containsExactly("error: not found");
+    }
+
+    @Test
+    void liftResult_shouldThrowNPE_whenResultIsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftResult(null, v -> List.of(), e -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftResult_shouldThrowNPE_whenOkLogReturnsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftResult(Result.ok(1), v -> null, e -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftResult_shouldThrowNPE_whenErrLogReturnsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftResult(Result.err("bad"), v -> List.of(), e -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // liftEither
+    // -------------------------------------------------------------------------
+
+    @Test
+    void liftEither_right_appliesRightLog() {
+        var result = Accumulator.liftEither(
+            Either.<String, Integer>right(42),
+            v   -> List.of("right: " + v),
+            err -> List.of("left: " + err)
+        );
+        assertThat(result.value().isRight()).isTrue();
+        assertThat(result.value().getRight()).isEqualTo(42);
+        assertThat(result.accumulated()).containsExactly("right: 42");
+    }
+
+    @Test
+    void liftEither_left_appliesLeftLog() {
+        var result = Accumulator.liftEither(
+            Either.<String, Integer>left("oops"),
+            v   -> List.of("right: " + v),
+            err -> List.of("left: " + err)
+        );
+        assertThat(result.value().isLeft()).isTrue();
+        assertThat(result.value().getLeft()).isEqualTo("oops");
+        assertThat(result.accumulated()).containsExactly("left: oops");
+    }
+
+    @Test
+    void liftEither_shouldThrowNPE_whenEitherIsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftEither(null, v -> List.of(), e -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftEither_shouldThrowNPE_whenRightLogReturnsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftEither(Either.right(1), v -> null, e -> List.of()))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void liftEither_shouldThrowNPE_whenLeftLogReturnsNull() {
+        assertThatThrownBy(() ->
+            Accumulator.liftEither(Either.left("bad"), v -> List.of(), e -> null))
+            .isInstanceOf(NullPointerException.class);
     }
 }

--- a/site/src/data/code/guide/accumulator/interop.mdx
+++ b/site/src/data/code/guide/accumulator/interop.mdx
@@ -9,7 +9,7 @@ BinaryOperator<List<String>> concat = (a, b) -> {
     return merged;
 };
 
-// ---- combine — two independent accumulators ----
+// ── combine — two independent accumulators ────────────────────────────────────
 
 Accumulator<List<String>, String>  userAcc  = fetchUser(id);    // ("Alice", ["user loaded"])
 Accumulator<List<String>, Integer> scoreAcc = fetchScore(id);   // (98, ["score loaded"])
@@ -20,7 +20,7 @@ Accumulator<List<String>, String> dashboard =
 dashboard.value();        // "Alice — score: 98"
 dashboard.accumulated();  // ["user loaded", "score loaded"]
 
-// ---- sequence — fold a list ----
+// ── sequence — fold a list ────────────────────────────────────────────────────
 
 List<Accumulator<List<String>, Integer>> steps = List.of(
     Accumulator.of(10, List.of("step A")),
@@ -32,28 +32,59 @@ Accumulator<List<String>, List<Integer>> all = Accumulator.sequence(steps, conca
 all.value();        // [10, 20, 30]
 all.accumulated();  // ["step A", "step B", "step C"]
 
-// ---- toOption — discard accumulation ----
+// ── Accumulator → other types (accumulation discarded) ───────────────────────
 
-Accumulator.of(42, List.of("log")).toOption();    // Some(42)
+Accumulator<List<String>, Integer> acc = Accumulator.of(42, List.of("log"));
+
+acc.toOption();    // Some(42)
+acc.toOptional();  // Optional.of(42)
+acc.stream();      // Stream.of(42)
+acc.toResult();    // Ok(42)
+acc.toEither();    // right(42)
+acc.toTuple2();    // Tuple2(["log"], 42)  — _1=accumulated, _2=value
+
 Accumulator.tell(List.of("entry")).toOption();    // None
+Accumulator.tell(List.of("entry")).toOptional();  // Optional.empty()
+Accumulator.tell(List.of("entry")).toResult();    // Err(["entry"])
+Accumulator.tell(List.of("entry")).toEither();    // left(["entry"])
 
-// ---- liftOption — log present / absent paths ----
+// ── liftOption — log present / absent paths ───────────────────────────────────
 
-Accumulator<List<String>, Option<String>> acc = Accumulator.liftOption(
+Accumulator<List<String>, Option<String>> liftedOpt = Accumulator.liftOption(
     userRepo.findName(id),
     name -> List.of("found: " + name),       // called when Some
     List.of("not found")                     // used when None
 );
-// Some("Alice") → ("Some(Alice)", ["found: Alice"])
-// None          → ("None",        ["not found"])
+// Some("Alice") → (Some("Alice"), ["found: Alice"])
+// None          → (None,          ["not found"])
 
-// ---- liftTry — log success / failure ----
+// ── liftTry — log success / failure ──────────────────────────────────────────
 
-Accumulator<List<String>, Try<Config>> loaded = Accumulator.liftTry(
+Accumulator<List<String>, Try<Config>> liftedTry = Accumulator.liftTry(
     Try.of(() -> ConfigLoader.load(path)),
     cfg -> List.of("config loaded from " + path),
     ex  -> List.of("config load failed: " + ex.getMessage())
 );
-loaded.accumulated();  // always set — success or failure
-loaded.value();        // Try<Config> — caller decides what to do with it
+liftedTry.accumulated();  // always set — success or failure
+liftedTry.value();        // Try<Config> — caller decides what to do with it
+
+// ── liftResult — log ok / error paths ────────────────────────────────────────
+
+Accumulator<List<String>, Result<Config, String>> liftedResult = Accumulator.liftResult(
+    configService.load(path),
+    cfg -> List.of("config loaded"),
+    err -> List.of("config error: " + err)
+);
+liftedResult.accumulated();  // always set — ok or error
+liftedResult.value();        // Result<Config, String> — caller handles it
+
+// ── liftEither — log right / left paths ──────────────────────────────────────
+
+Accumulator<List<String>, Either<String, Config>> liftedEither = Accumulator.liftEither(
+    configParser.parse(input),
+    cfg -> List.of("parsed successfully"),
+    err -> List.of("parse failed: " + err)
+);
+liftedEither.accumulated();  // always set — right or left
+liftedEither.value();        // Either<String, Config> — caller handles it
 ```

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -81,18 +81,23 @@ log entries (`List::size`) or to convert raw strings to structured event objects
 
 <Interop/>
 
-| Method / Factory                     | Returns                     | Use case                                                                   |
-|--------------------------------------|-----------------------------|----------------------------------------------------------------------------|
-| `combine(other, merge, f)`           | `Accumulator<E, C>`         | Combine two independent accumulators; both logs merged                     |
-| `sequence(list, merge, empty)`       | `Accumulator<E, List<A>>`   | Fold a list of accumulators into one                                       |
-| `toOption()`                         | `Option<A>`                 | Extract value as Option; `None` for `tell` results; accumulation discarded |
-| `liftOption(opt, someLog, noneLog)`  | `Accumulator<E, Option<A>>` | Log the presence or absence of an Option value                             |
-| `liftTry(t, successLog, failureLog)` | `Accumulator<E, Try<A>>`    | Log the success or failure of a Try; the Try itself is the value           |
-| `toResult()`                         | `Result<A, E>`              | `Ok(value)` when has value; `Err(accumulated)` for `tell` results          |
-| `toTuple2()`                         | `Tuple2<E, A>`              | Structural decomposition; `_1` is accumulated, `_2` is value               |
-| `hasValue()`                         | `boolean`                   | Distinguish `of`/`pure` results from `tell` results                        |
-| `value()`                            | `@Nullable A`               | Extract the value; `null` for `tell` results                               |
-| `accumulated()`                      | `E`                         | Extract the accumulation; always non-null                                  |
+| Method / Factory                       | Returns                       | Use case                                                                   |
+|----------------------------------------|-------------------------------|----------------------------------------------------------------------------|
+| `combine(other, merge, f)`             | `Accumulator<E, C>`           | Combine two independent accumulators; both logs merged                     |
+| `sequence(list, merge, empty)`         | `Accumulator<E, List<A>>`     | Fold a list of accumulators into one                                       |
+| `toOption()`                           | `Option<A>`                   | Extract value as Option; `None` for `tell` results; accumulation discarded |
+| `toOptional()`                         | `Optional<A>`                 | JDK Optional bridge; `empty()` for `tell` results; accumulation discarded  |
+| `stream()`                             | `Stream<A>`                   | Single-element stream; empty for `tell` results; accumulation discarded    |
+| `toResult()`                           | `Result<A, E>`                | `Ok(value)` when has value; `Err(accumulated)` for `tell` results          |
+| `toEither()`                           | `Either<E, A>`                | `right(value)` when has value; `left(accumulated)` for `tell` results      |
+| `toTuple2()`                           | `Tuple2<E, A>`                | Structural decomposition; `_1` is accumulated, `_2` is value               |
+| `liftOption(opt, someLog, noneLog)`    | `Accumulator<E, Option<A>>`   | Log the presence or absence of an Option value                             |
+| `liftTry(t, successLog, failureLog)`   | `Accumulator<E, Try<A>>`      | Log the success or failure of a Try; the Try itself is the value           |
+| `liftResult(r, okLog, errLog)`         | `Accumulator<E, Result<V,Err>>` | Log the ok or error branch of a Result; the Result itself is the value   |
+| `liftEither(e, rightLog, leftLog)`     | `Accumulator<E, Either<L,R>>` | Log the right or left branch of an Either; the Either itself is the value  |
+| `hasValue()`                           | `boolean`                     | Distinguish `of`/`pure` results from `tell` results                        |
+| `value()`                              | `@Nullable A`                 | Extract the value; `null` for `tell` results                               |
+| `accumulated()`                        | `E`                           | Extract the accumulation; always non-null                                  |
 
 ## Real-world example
 

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -90,7 +90,7 @@ log entries (`List::size`) or to convert raw strings to structured event objects
 | `stream()`                             | `Stream<A>`                   | Single-element stream; empty for `tell` results; accumulation discarded    |
 | `toResult()`                           | `Result<A, E>`                | `Ok(value)` when has value; `Err(accumulated)` for `tell` results          |
 | `toEither()`                           | `Either<E, A>`                | `right(value)` when has value; `left(accumulated)` for `tell` results      |
-| `toTuple2()`                           | `Tuple2<E, A>`                | Structural decomposition; `_1` is accumulated, `_2` is value               |
+| `toTuple2()`                           | `Tuple2<E, @Nullable A>`      | Structural decomposition; `_1` is accumulated, `_2` is value (`null` for `tell` results) |
 | `liftOption(opt, someLog, noneLog)`    | `Accumulator<E, Option<A>>`   | Log the presence or absence of an Option value                             |
 | `liftTry(t, successLog, failureLog)`   | `Accumulator<E, Try<A>>`      | Log the success or failure of a Try; the Try itself is the value           |
 | `liftResult(r, okLog, errLog)`         | `Accumulator<E, Result<V,Err>>` | Log the ok or error branch of a Result; the Result itself is the value   |


### PR DESCRIPTION
  Add five missing interoperability methods to Accumulator<E, A>:

  - `toOptional()`: JDK Optional bridge — Optional.of(value) when hasValue(),
    Optional.empty() for tell() results.
  - `stream()`: JDK Stream bridge — single-element stream when hasValue(),
    empty stream for tell() results.
  - `toEither()`: direct Either conversion — right(value) when hasValue(),
    left(accumulated) for tell() results; mirrors toResult() for the Either world.
  - `liftResult(result, okLog, errLog)`: lifts a Result into an Accumulator,
    recording a log entry on either the ok or error branch; completes the lift*
    family alongside liftOption and liftTry.
  - `liftEither(either, rightLog, leftLog)`: lifts an Either into an Accumulator,
    recording a log entry on either the right or left branch.

  Add 27 new tests in AccumulatorTest covering both tracks and NPE guards for each
  new method. Update the accumulator.mdx interoperability table with 5 new rows and
  rewrite the interop.mdx snippet with labeled sections covering all outbound
  conversions and all lift* factories.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #287

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added factory methods for lifting Result and Either types into Accumulators with customizable logging behavior
  * Added conversion methods to transform Accumulators into Optional and Stream types

* **Documentation**
  * Expanded interoperability guides with examples of new factory methods and type conversions
  * Updated reference documentation for Accumulator interoperability features

* **Tests**
  * Added comprehensive test coverage for new conversion and factory methods, including null-safety validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->