### PR TITLE
feat(NonEmptyList): add fromOptional, sequenceTry, sequenceEither, sequenceResult and reach 100% coverage

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SequencedCollection;
 import java.util.Set;
 import java.util.function.Function;
@@ -95,6 +96,22 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
         T head = list.get(0);
         var tail = List.<T>copyOf(list.subList(1, list.size()));
         return Option.some(new NonEmptyList<>(head, tail));
+    }
+
+    /**
+     * Attempts to construct a singleton {@code NonEmptyList} from a JDK {@link Optional}.
+     *
+     * @param optional the source optional; must not be {@code null}
+     * @param <T>      the element type
+     * @return {@link Option#some(Object)} wrapping a singleton {@code NonEmptyList} if the
+     *         optional is present, or {@link Option#none()} if the optional is empty
+     * @throws NullPointerException if {@code optional} is {@code null}
+     */
+    public static <T> Option<NonEmptyList<T>> fromOptional(Optional<? extends T> optional) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        return optional.isPresent()
+            ? Option.some(NonEmptyList.singleton(optional.get()))
+            : Option.none();
     }
 
     // -------------------------------------------------------------------------
@@ -385,6 +402,86 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
         }
         // values.size() == nel.size() >= 1, so fromList always returns Some
         return NonEmptyList.fromList(values);
+    }
+
+    /**
+     * Sequences a {@code NonEmptyList} of {@link Try}s into a {@code Try} of a
+     * {@code NonEmptyList}.
+     *
+     * <p>Returns {@link Try#success(Object)} containing all unwrapped values if every element
+     * is a success; returns {@link Try#failure(Throwable)} from the first failing element
+     * (fail-fast — remaining elements are not evaluated).
+     *
+     * @param <T> the success value type
+     * @param nel a {@code NonEmptyList<Try<T>>}; must not be {@code null}
+     * @return {@code Success(NonEmptyList<T>)} if all succeed, {@code Failure} from the first
+     *         failing element otherwise
+     * @throws NullPointerException if {@code nel} is {@code null}
+     */
+    public static <T> Try<NonEmptyList<T>> sequenceTry(NonEmptyList<Try<T>> nel) {
+        Objects.requireNonNull(nel, "nel must not be null");
+        var values = new ArrayList<T>(nel.size());
+        for (Try<T> t : nel) {
+            switch (t) {
+                case Try.Failure<T> f -> { return Try.failure(f.cause()); }
+                case Try.Success<T> s -> values.add(s.value());
+            }
+        }
+        return Try.success(fromList(values).get()); // always Some since nel.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptyList} of {@link Either}s into an {@code Either} of a
+     * {@code NonEmptyList}.
+     *
+     * <p>Returns {@link Either#right(Object)} containing all unwrapped values if every element
+     * is right; returns {@link Either#left(Object)} from the first left element
+     * (fail-fast — remaining elements are not evaluated).
+     *
+     * @param <E> the left (error) type
+     * @param <T> the right (success) type
+     * @param nel a {@code NonEmptyList<Either<E, T>>}; must not be {@code null}
+     * @return {@code right(NonEmptyList<T>)} if all are right, {@code left(E)} from the first
+     *         left element otherwise
+     * @throws NullPointerException if {@code nel} is {@code null}
+     */
+    public static <E, T> Either<E, NonEmptyList<T>> sequenceEither(NonEmptyList<Either<E, T>> nel) {
+        Objects.requireNonNull(nel, "nel must not be null");
+        var values = new ArrayList<T>(nel.size());
+        for (Either<E, T> e : nel) {
+            switch (e) {
+                case Either.Left<E, T> l  -> { return Either.left(l.value()); }
+                case Either.Right<E, T> r -> values.add(r.value());
+            }
+        }
+        return Either.right(fromList(values).get()); // always Some since nel.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptyList} of {@link Result}s into a {@code Result} of a
+     * {@code NonEmptyList}.
+     *
+     * <p>Returns {@link Result#ok(Object)} containing all unwrapped values if every element
+     * is ok; returns {@link Result#err(Object)} from the first error element
+     * (fail-fast — remaining elements are not evaluated).
+     *
+     * @param <T> the ok value type
+     * @param <E> the error type
+     * @param nel a {@code NonEmptyList<Result<T, E>>}; must not be {@code null}
+     * @return {@code ok(NonEmptyList<T>)} if all succeed, {@code err(E)} from the first
+     *         error element otherwise
+     * @throws NullPointerException if {@code nel} is {@code null}
+     */
+    public static <T, E> Result<NonEmptyList<T>, E> sequenceResult(NonEmptyList<Result<T, E>> nel) {
+        Objects.requireNonNull(nel, "nel must not be null");
+        var values = new ArrayList<T>(nel.size());
+        for (Result<T, E> r : nel) {
+            switch (r) {
+                case Result.Err<T, E> err -> { return Result.err(err.error()); }
+                case Result.Ok<T, E> ok   -> values.add(ok.value());
+            }
+        }
+        return Result.ok(fromList(values).get()); // always Some since nel.size() >= 1
     }
 
     // -------------------------------------------------------------------------

--- a/core/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -410,7 +410,9 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
      *
      * <p>Returns {@link Try#success(Object)} containing all unwrapped values if every element
      * is a success; returns {@link Try#failure(Throwable)} from the first failing element
-     * (fail-fast — remaining elements are not evaluated).
+     * (fail-fast in inspection — the method stops iterating after the first failure; elements
+     * are already materialized in the list before sequencing, so later elements are not inspected
+     * but were already evaluated).
      *
      * @param <T> the success value type
      * @param nel a {@code NonEmptyList<Try<T>>}; must not be {@code null}
@@ -436,7 +438,9 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
      *
      * <p>Returns {@link Either#right(Object)} containing all unwrapped values if every element
      * is right; returns {@link Either#left(Object)} from the first left element
-     * (fail-fast — remaining elements are not evaluated).
+     * (fail-fast in inspection — the method stops iterating after the first left; elements
+     * are already materialized in the list before sequencing, so later elements are not inspected
+     * but were already evaluated).
      *
      * @param <E> the left (error) type
      * @param <T> the right (success) type
@@ -463,7 +467,9 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
      *
      * <p>Returns {@link Result#ok(Object)} containing all unwrapped values if every element
      * is ok; returns {@link Result#err(Object)} from the first error element
-     * (fail-fast — remaining elements are not evaluated).
+     * (fail-fast in inspection — the method stops iterating after the first err; elements
+     * are already materialized in the list before sequencing, so later elements are not inspected
+     * but were already evaluated).
      *
      * @param <T> the ok value type
      * @param <E> the error type

--- a/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -410,7 +410,9 @@ class NonEmptyListTest {
             Stream.iterate(1, n -> n + 1).limit(100).parallel()
                 .collect(NonEmptyList.collector());
         assertThat(result.isDefined()).isTrue();
-        assertThat(result.get().size()).isEqualTo(100);
+        var expected = java.util.stream.IntStream.rangeClosed(1, 100)
+            .boxed().collect(java.util.stream.Collectors.toList());
+        assertThat(result.get().toList()).containsExactlyElementsOf(expected);
     }
 
     // -------------------------------------------------------------------------

--- a/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -1,6 +1,7 @@
 package dmx.fun;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -402,6 +403,16 @@ class NonEmptyListTest {
         assertThat(viaAlias).isEqualTo(viaCollector);
     }
 
+    @Test
+    void collector_combiner_invokedByParallelStream() {
+        // The combiner lambda is only called when splitting/merging parallel stream segments.
+        Option<NonEmptyList<Integer>> result =
+            Stream.iterate(1, n -> n + 1).limit(100).parallel()
+                .collect(NonEmptyList.collector());
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(100);
+    }
+
     // -------------------------------------------------------------------------
     // SequencedCollection — getFirst() / getLast() / reversed()
     // -------------------------------------------------------------------------
@@ -514,5 +525,223 @@ class NonEmptyListTest {
     void clear_throwsUnsupported() {
         assertThatThrownBy(() -> NonEmptyList.singleton(1).clear())
             .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void containsAll_shouldReturnTrue_whenAllPresent() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.containsAll(List.of(1, 3))).isTrue();
+    }
+
+    @Test
+    void containsAll_shouldReturnFalse_whenAnyAbsent() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2));
+        assertThat(nel.containsAll(List.of(1, 99))).isFalse();
+    }
+
+    @Test
+    void toArray_shouldReturnAllElements() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.toArray()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void toArrayTyped_shouldReturnAllElements() {
+        NonEmptyList<String> nel = NonEmptyList.of("a", List.of("b", "c"));
+        assertThat(nel.toArray(new String[0])).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void addAll_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).addAll(List.of(2)))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void removeAll_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).removeAll(List.of(1)))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void retainAll_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).retainAll(List.of(1)))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void removeIf_throwsUnsupported() {
+        assertThatThrownBy(() -> NonEmptyList.singleton(1).removeIf(x -> true))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromOptional()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromOptional_shouldReturnSome_whenPresent() {
+        Option<NonEmptyList<String>> result = NonEmptyList.fromOptional(Optional.of("hello"));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().head()).isEqualTo("hello");
+        assertThat(result.get().size()).isEqualTo(1);
+    }
+
+    @Test
+    void fromOptional_shouldReturnNone_whenEmpty() {
+        Option<NonEmptyList<String>> result = NonEmptyList.fromOptional(Optional.empty());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromOptional_shouldThrowNPE_whenOptionalIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.fromOptional(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("optional");
+    }
+
+    // -------------------------------------------------------------------------
+    // toStream()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toStream_shouldYieldAllElementsInOrder() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(1, List.of(2, 3));
+        assertThat(nel.toStream().toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void toStream_singleton_shouldYieldSingleElement() {
+        assertThat(NonEmptyList.singleton("x").toStream().toList()).containsExactly("x");
+    }
+
+    // -------------------------------------------------------------------------
+    // sequence(NonEmptyList<Option<T>>)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequence_options_allSome_shouldReturnSome() {
+        NonEmptyList<Option<Integer>> nel = NonEmptyList.of(
+            Option.some(1), List.of(Option.some(2), Option.some(3)));
+        Option<NonEmptyList<Integer>> result = NonEmptyList.sequence(nel);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void sequence_options_withNone_shouldReturnNone() {
+        NonEmptyList<Option<Integer>> nel = NonEmptyList.of(
+            Option.some(1), List.of(Option.none(), Option.some(3)));
+        Option<NonEmptyList<Integer>> result = NonEmptyList.sequence(nel);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void sequence_options_singletonSome_shouldReturnSome() {
+        Option<NonEmptyList<String>> result =
+            NonEmptyList.sequence(NonEmptyList.singleton(Option.some("x")));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().head()).isEqualTo("x");
+    }
+
+    @Test
+    void sequence_options_singletonNone_shouldReturnNone() {
+        Option<NonEmptyList<String>> result =
+            NonEmptyList.sequence(NonEmptyList.singleton(Option.<String>none()));
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceTry(NonEmptyList<Try<T>>)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceTry_allSuccess_shouldReturnSuccess() {
+        NonEmptyList<Try<Integer>> nel = NonEmptyList.of(
+            Try.success(1), List.of(Try.success(2), Try.success(3)));
+        Try<NonEmptyList<Integer>> result = NonEmptyList.sequenceTry(nel);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get().toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void sequenceTry_withFailure_shouldReturnFailure() {
+        var ex = new RuntimeException("boom");
+        NonEmptyList<Try<Integer>> nel = NonEmptyList.of(
+            Try.success(1), List.of(Try.failure(ex), Try.success(3)));
+        Try<NonEmptyList<Integer>> result = NonEmptyList.sequenceTry(nel);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(ex);
+    }
+
+    @Test
+    void sequenceTry_firstElementFailure_shouldReturnFailure() {
+        var ex = new RuntimeException("first fails");
+        Try<NonEmptyList<Integer>> result =
+            NonEmptyList.sequenceTry(NonEmptyList.singleton(Try.failure(ex)));
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(ex);
+    }
+
+    @Test
+    void sequenceTry_shouldThrowNPE_whenNelIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.sequenceTry(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceEither(NonEmptyList<Either<E, T>>)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceEither_allRight_shouldReturnRight() {
+        NonEmptyList<Either<String, Integer>> nel = NonEmptyList.of(
+            Either.right(1), List.of(Either.right(2), Either.right(3)));
+        Either<String, NonEmptyList<Integer>> result = NonEmptyList.sequenceEither(nel);
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight().toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void sequenceEither_withLeft_shouldReturnLeft() {
+        NonEmptyList<Either<String, Integer>> nel = NonEmptyList.of(
+            Either.right(1), List.of(Either.left("error"), Either.right(3)));
+        Either<String, NonEmptyList<Integer>> result = NonEmptyList.sequenceEither(nel);
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("error");
+    }
+
+    @Test
+    void sequenceEither_shouldThrowNPE_whenNelIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.sequenceEither(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceResult(NonEmptyList<Result<T, E>>)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceResult_allOk_shouldReturnOk() {
+        NonEmptyList<Result<Integer, String>> nel = NonEmptyList.of(
+            Result.ok(1), List.of(Result.ok(2), Result.ok(3)));
+        Result<NonEmptyList<Integer>, String> result = NonEmptyList.sequenceResult(nel);
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get().toList()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void sequenceResult_withError_shouldReturnErr() {
+        NonEmptyList<Result<Integer, String>> nel = NonEmptyList.of(
+            Result.ok(1), List.of(Result.err("bad"), Result.ok(3)));
+        Result<NonEmptyList<Integer>, String> result = NonEmptyList.sequenceResult(nel);
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("bad");
+    }
+
+    @Test
+    void sequenceResult_shouldThrowNPE_whenNelIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.sequenceResult(null))
+            .isInstanceOf(NullPointerException.class);
     }
 }

--- a/site/src/data/code/guide/non-empty-list/interop-option.mdx
+++ b/site/src/data/code/guide/non-empty-list/interop-option.mdx
@@ -3,6 +3,14 @@ fileName: 'Demo.java'
 ---
 
 ```java
+// fromOptional: Optional<T> → Option<NonEmptyList<T>>
+// Present → Some(singleton); empty → None
+Option<NonEmptyList<String>> fromPresent = NonEmptyList.fromOptional(Optional.of("hello"));
+// Some(["hello"])
+
+Option<NonEmptyList<String>> fromEmpty = NonEmptyList.fromOptional(Optional.empty());
+// None
+
 // sequence: NonEmptyList<Option<T>> → Option<NonEmptyList<T>>
 // Returns Some if every element is Some; None as soon as any element is None.
 NonEmptyList<Option<Integer>> opts =

--- a/site/src/data/code/guide/non-empty-list/interop-sequences.mdx
+++ b/site/src/data/code/guide/non-empty-list/interop-sequences.mdx
@@ -1,0 +1,47 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequenceTry: NonEmptyList<Try<T>> → Try<NonEmptyList<T>>
+// Success if every element succeeds; Failure from the first failing element.
+NonEmptyList<Try<Integer>> tries = NonEmptyList.of(
+    Try.success(1), List.of(Try.success(2), Try.success(3)));
+
+Try<NonEmptyList<Integer>> allOk = NonEmptyList.sequenceTry(tries);
+// Success([1, 2, 3])
+
+NonEmptyList<Try<Integer>> withFailure = NonEmptyList.of(
+    Try.success(1), List.of(Try.failure(new RuntimeException("boom")), Try.success(3)));
+
+Try<NonEmptyList<Integer>> failed = NonEmptyList.sequenceTry(withFailure);
+// Failure(RuntimeException("boom"))
+
+// sequenceEither: NonEmptyList<Either<E, T>> → Either<E, NonEmptyList<T>>
+// right if every element is right; left from the first left element.
+NonEmptyList<Either<String, Integer>> eithers = NonEmptyList.of(
+    Either.right(1), List.of(Either.right(2), Either.right(3)));
+
+Either<String, NonEmptyList<Integer>> allRight = NonEmptyList.sequenceEither(eithers);
+// right([1, 2, 3])
+
+NonEmptyList<Either<String, Integer>> withLeft = NonEmptyList.of(
+    Either.right(1), List.of(Either.left("invalid"), Either.right(3)));
+
+Either<String, NonEmptyList<Integer>> firstLeft = NonEmptyList.sequenceEither(withLeft);
+// left("invalid")
+
+// sequenceResult: NonEmptyList<Result<T, E>> → Result<NonEmptyList<T>, E>
+// ok if every element is ok; err from the first error element.
+NonEmptyList<Result<Integer, String>> results = NonEmptyList.of(
+    Result.ok(1), List.of(Result.ok(2), Result.ok(3)));
+
+Result<NonEmptyList<Integer>, String> allOkResult = NonEmptyList.sequenceResult(results);
+// ok([1, 2, 3])
+
+NonEmptyList<Result<Integer, String>> withErr = NonEmptyList.of(
+    Result.ok(1), List.of(Result.err("not found"), Result.ok(3)));
+
+Result<NonEmptyList<Integer>, String> firstErr = NonEmptyList.sequenceResult(withErr);
+// err("not found")
+```

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -9,6 +9,7 @@ import {Content as CreatingInstances}  from '../code/guide/non-empty-list/creati
 import {Content as AccessingElements}  from '../code/guide/non-empty-list/accessing-elements.mdx';
 import {Content as Transformations}    from '../code/guide/non-empty-list/transformations.mdx';
 import {Content as InteropOption}      from '../code/guide/non-empty-list/interop-option.mdx';
+import {Content as InteropSequences}   from '../code/guide/non-empty-list/interop-sequences.mdx';
 import {Content as InteropValidated}   from '../code/guide/non-empty-list/interop-validated.mdx';
 import {Content as StreamInterop}      from '../code/guide/non-empty-list/stream-interop.mdx';
 import {Content as EqualityToString}       from '../code/guide/non-empty-list/equality-tostring.mdx';
@@ -50,6 +51,7 @@ Use it when:
 | `NonEmptyList.of(head, tail)`                   | N/A — head is always required |
 | `NonEmptyList.singleton(head)`                  | N/A — always one element      |
 | `NonEmptyList.fromList(list)`                   | Returns `None`                |
+| `NonEmptyList.fromOptional(optional)`           | Returns `None`                |
 | `stream.collect(NonEmptyList.collector())`      | Returns `None`                |
 | `stream.collect(NonEmptyList.toNonEmptyList())` | Returns `None`                |
 
@@ -110,6 +112,23 @@ at stream call sites. It returns `Some(NonEmptyList)` for a non-empty stream and
 `sequence` and `collector` bridge between `NonEmptyList` and `Option`.
 
 <InteropOption/>
+
+## Interoperability — `Try`, `Either`, `Result`
+
+`sequenceTry`, `sequenceEither`, and `sequenceResult` each convert a
+`NonEmptyList` of wrapped values into a single wrapped `NonEmptyList`.
+All three are **fail-fast**: they return the first failure and stop processing.
+
+| Method                              | Input                          | Returns                         |
+|-------------------------------------|--------------------------------|---------------------------------|
+| `NonEmptyList.sequenceTry(nel)`     | `NonEmptyList<Try<T>>`         | `Try<NonEmptyList<T>>`          |
+| `NonEmptyList.sequenceEither(nel)`  | `NonEmptyList<Either<E, T>>`   | `Either<E, NonEmptyList<T>>`    |
+| `NonEmptyList.sequenceResult(nel)`  | `NonEmptyList<Result<T, E>>`   | `Result<NonEmptyList<T>, E>`    |
+
+Use `Validated.sequenceNel` when you need **error accumulation** (all errors collected);
+use these when you need **fail-fast** behaviour (stop at the first failure).
+
+<InteropSequences/>
 
 ## Interoperability — `Validated` and error accumulation
 


### PR DESCRIPTION
  - Add `fromOptional(Optional<? extends T>)` → `Option<NonEmptyList<T>>`
  - Add `sequenceTry`, `sequenceEither`, `sequenceResult` (distinct names to
    avoid type-erasure collision with the existing `sequence` overload)
  - Add tests for previously untested methods: `toStream()`,
    `sequence(NonEmptyList<Option<T>>)`, and the new interop methods
  - Add tests for Collection interface methods (`containsAll`, `toArray`,
    `addAll`, `removeAll`, `retainAll`, `removeIf`) and the parallel-stream
    combiner in `collector()` to bring instruction coverage to 100%
  - Update guide: add `fromOptional` row to the creating-instances table,
    new "Interoperability — Try, Either, Result" section with comparison
    table, and new `interop-sequences.mdx` code snippet

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #291

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversion from `Optional` to `NonEmptyList` wrapped in `Option`
  * Added sequencing helpers for `NonEmptyList` containing wrapped types (Try, Either, Result) with fail-fast behavior

* **Documentation**
  * Added interoperability guides with code examples for Optional conversion and effect sequencing

* **Tests**
  * Expanded test coverage for collection operations and new conversion/sequencing methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->