### PR TITLE
feat(NonEmptyMap): add interop methods and reach full interoperability with dmx-fun and Java types

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -7,10 +7,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -115,6 +118,68 @@ public final class NonEmptyMap<K, V> {
             Objects.requireNonNull(v, "map values must not be null");
         });
         return Option.some(fromMapUnsafe(map));
+    }
+
+    /**
+     * Attempts to construct a {@code NonEmptyMap} from a JDK {@link Optional} wrapping a
+     * plain {@link Map}.
+     *
+     * <p>If the optional is present and the wrapped map is non-empty, returns
+     * {@link Option#some(Object)} wrapping the {@code NonEmptyMap}. If the optional is empty,
+     * or if the wrapped map is itself empty, returns {@link Option#none()}.
+     *
+     * @param optional the source optional; must not be {@code null}
+     * @param <K>      the key type
+     * @param <V>      the value type
+     * @return {@link Option#some(Object)} if the optional is present and the map is non-empty,
+     *         {@link Option#none()} otherwise
+     * @throws NullPointerException if {@code optional} is {@code null}
+     */
+    public static <K, V> Option<NonEmptyMap<K, V>> fromOptional(
+            Optional<? extends Map<? extends K, ? extends V>> optional) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        return optional.isPresent() ? fromMap(optional.get()) : Option.none();
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<T>} into an
+     * {@code Option<NonEmptyMap<K, V>>} using the provided key and value extractor functions.
+     *
+     * <p>Produces {@link Option#some(Object)} for a non-empty stream and {@link Option#none()}
+     * for an empty stream. If multiple stream elements map to the same key, later elements
+     * overwrite earlier ones (last-write-wins semantics).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Option<NonEmptyMap<String, Integer>> result =
+     *     employees.stream()
+     *         .collect(NonEmptyMap.collector(Employee::name, Employee::score));
+     * }</pre>
+     *
+     * @param <T>         the stream element type
+     * @param <K>         the key type
+     * @param <V>         the value type
+     * @param keyMapper   extracts the key from each element; must not be {@code null} or return
+     *                    {@code null}
+     * @param valueMapper extracts the value from each element; must not be {@code null} or return
+     *                    {@code null}
+     * @return a collector producing {@code Option<NonEmptyMap<K, V>>}
+     * @throws NullPointerException if {@code keyMapper} or {@code valueMapper} is {@code null}
+     */
+    public static <T, K, V> Collector<T, ?, Option<NonEmptyMap<K, V>>> collector(
+            Function<? super T, ? extends K> keyMapper,
+            Function<? super T, ? extends V> valueMapper) {
+        Objects.requireNonNull(keyMapper,   "keyMapper must not be null");
+        Objects.requireNonNull(valueMapper, "valueMapper must not be null");
+        return Collector.of(
+            LinkedHashMap<K, V>::new,
+            (map, t) -> map.put(
+                Objects.requireNonNull(keyMapper.apply(t),   "keyMapper must not return null"),
+                Objects.requireNonNull(valueMapper.apply(t), "valueMapper must not return null")
+            ),
+            (a, b) -> { a.putAll(b); return a; },
+            map -> NonEmptyMap.fromMap(map)
+        );
     }
 
     /** Internal: builds from a known-non-empty map without Option wrapping. */
@@ -231,6 +296,18 @@ public final class NonEmptyMap<K, V> {
         return m;
     }
 
+    /**
+     * Returns a sequential {@link Stream} of all entries in insertion order.
+     *
+     * <p>The stream always contains at least one element (the head entry). Use it to bridge
+     * {@code NonEmptyMap} into the standard Java stream API.
+     *
+     * @return a non-empty stream of {@link Map.Entry} elements in insertion order
+     */
+    public Stream<Map.Entry<K, V>> toStream() {
+        return toMap().entrySet().stream();
+    }
+
     // -------------------------------------------------------------------------
     // Transformations
     // -------------------------------------------------------------------------
@@ -250,6 +327,28 @@ public final class NonEmptyMap<K, V> {
         Map<K, R> newTail = new LinkedHashMap<>();
         tail.forEach((k, v) ->
             newTail.put(k, Objects.requireNonNull(mapper.apply(v), "mapper must not return null")));
+        return new NonEmptyMap<>(headKey, newHead, Collections.unmodifiableMap(newTail));
+    }
+
+    /**
+     * Applies {@code mapper} to every key-value pair and returns a new {@code NonEmptyMap}
+     * with the same keys and mapped values.
+     *
+     * <p>Unlike {@link #mapValues(Function)}, the mapper receives both the key and the value,
+     * enabling value transformations that depend on the key.
+     *
+     * @param mapper a non-null function to apply to each key-value pair; must not return
+     *               {@code null}
+     * @param <R>    the result value type
+     * @return a new {@code NonEmptyMap} with mapped values
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    public <R> NonEmptyMap<K, R> mapValuesWithKey(BiFunction<? super K, ? super V, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        R newHead = Objects.requireNonNull(mapper.apply(headKey, headValue), "mapper must not return null");
+        Map<K, R> newTail = new LinkedHashMap<>();
+        tail.forEach((k, v) ->
+            newTail.put(k, Objects.requireNonNull(mapper.apply(k, v), "mapper must not return null")));
         return new NonEmptyMap<>(headKey, newHead, Collections.unmodifiableMap(newTail));
     }
 
@@ -328,6 +427,121 @@ public final class NonEmptyMap<K, V> {
         Map.Entry<K, V> head = entries.get(0);
         List<Map.Entry<K, V>> tailList = entries.subList(1, entries.size());
         return NonEmptyList.of(head, List.copyOf(tailList));
+    }
+
+    // -------------------------------------------------------------------------
+    // Interoperability — sequence
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sequences a {@code NonEmptyMap<K, Option<V>>} into an {@code Option<NonEmptyMap<K, V>>}.
+     *
+     * <p>Returns {@link Option#some(Object)} containing all unwrapped values if every entry's
+     * value is {@code Some}; returns {@link Option#none()} as soon as any entry's value is
+     * {@code None} (fail-fast in inspection — the method stops iterating after the first
+     * {@code None}; entries are already materialized in the map before sequencing, so later
+     * entries are not inspected but were already evaluated).
+     *
+     * @param <K> the key type
+     * @param <V> the unwrapped value type
+     * @param nem a {@code NonEmptyMap<K, Option<V>>}; must not be {@code null}
+     * @return {@code Some(NonEmptyMap<K, V>)} if all values are present, {@code None} otherwise
+     * @throws NullPointerException if {@code nem} is {@code null}
+     */
+    public static <K, V> Option<NonEmptyMap<K, V>> sequenceOption(NonEmptyMap<K, Option<V>> nem) {
+        Objects.requireNonNull(nem, "nem must not be null");
+        Map<K, V> result = new LinkedHashMap<>();
+        for (Map.Entry<K, Option<V>> entry : nem.toMap().entrySet()) {
+            switch (entry.getValue()) {
+                case Option.None<V> ignored -> { return Option.none(); }
+                case Option.Some<V>(V v)   -> result.put(entry.getKey(), v);
+            }
+        }
+        return fromMap(result); // always Some since nem.size() >= 1 and all values are present
+    }
+
+    /**
+     * Sequences a {@code NonEmptyMap<K, Try<V>>} into a {@code Try<NonEmptyMap<K, V>>}.
+     *
+     * <p>Returns {@link Try#success(Object)} if all values succeed; returns
+     * {@link Try#failure(Throwable)} from the first failing entry (fail-fast in inspection —
+     * the method stops iterating after the first failure; entries are already materialized in
+     * the map before sequencing, so later entries are not inspected but were already evaluated).
+     *
+     * @param <K> the key type
+     * @param <V> the success value type
+     * @param nem a {@code NonEmptyMap<K, Try<V>>}; must not be {@code null}
+     * @return {@code Success(NonEmptyMap<K, V>)} if all succeed, {@code Failure} otherwise
+     * @throws NullPointerException if {@code nem} is {@code null}
+     */
+    public static <K, V> Try<NonEmptyMap<K, V>> sequenceTry(NonEmptyMap<K, Try<V>> nem) {
+        Objects.requireNonNull(nem, "nem must not be null");
+        Map<K, V> result = new LinkedHashMap<>();
+        for (Map.Entry<K, Try<V>> entry : nem.toMap().entrySet()) {
+            switch (entry.getValue()) {
+                case Try.Failure<V> f -> { return Try.failure(f.cause()); }
+                case Try.Success<V> s -> result.put(entry.getKey(), s.value());
+            }
+        }
+        return Try.success(fromMapUnsafe(result)); // always non-empty since nem.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptyMap<K, Either<E, V>>} into an
+     * {@code Either<E, NonEmptyMap<K, V>>}.
+     *
+     * <p>Returns {@link Either#right(Object)} if all values are right; returns
+     * {@link Either#left(Object)} from the first left entry (fail-fast in inspection —
+     * the method stops iterating after the first left; entries are already materialized in
+     * the map before sequencing, so later entries are not inspected but were already evaluated).
+     *
+     * @param <K> the key type
+     * @param <E> the left (error) type
+     * @param <V> the right (success) type
+     * @param nem a {@code NonEmptyMap<K, Either<E, V>>}; must not be {@code null}
+     * @return {@code right(NonEmptyMap<K, V>)} if all are right, {@code left(E)} otherwise
+     * @throws NullPointerException if {@code nem} is {@code null}
+     */
+    public static <K, E, V> Either<E, NonEmptyMap<K, V>> sequenceEither(
+            NonEmptyMap<K, Either<E, V>> nem) {
+        Objects.requireNonNull(nem, "nem must not be null");
+        Map<K, V> result = new LinkedHashMap<>();
+        for (Map.Entry<K, Either<E, V>> entry : nem.toMap().entrySet()) {
+            switch (entry.getValue()) {
+                case Either.Left<E, V> l  -> { return Either.left(l.value()); }
+                case Either.Right<E, V> r -> result.put(entry.getKey(), r.value());
+            }
+        }
+        return Either.right(fromMapUnsafe(result)); // always non-empty since nem.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptyMap<K, Result<V, E>>} into a
+     * {@code Result<NonEmptyMap<K, V>, E>}.
+     *
+     * <p>Returns {@link Result#ok(Object)} if all values are ok; returns
+     * {@link Result#err(Object)} from the first error entry (fail-fast in inspection —
+     * the method stops iterating after the first err; entries are already materialized in
+     * the map before sequencing, so later entries are not inspected but were already evaluated).
+     *
+     * @param <K> the key type
+     * @param <V> the ok value type
+     * @param <E> the error type
+     * @param nem a {@code NonEmptyMap<K, Result<V, E>>}; must not be {@code null}
+     * @return {@code ok(NonEmptyMap<K, V>)} if all succeed, {@code err(E)} otherwise
+     * @throws NullPointerException if {@code nem} is {@code null}
+     */
+    public static <K, V, E> Result<NonEmptyMap<K, V>, E> sequenceResult(
+            NonEmptyMap<K, Result<V, E>> nem) {
+        Objects.requireNonNull(nem, "nem must not be null");
+        Map<K, V> result = new LinkedHashMap<>();
+        for (Map.Entry<K, Result<V, E>> entry : nem.toMap().entrySet()) {
+            switch (entry.getValue()) {
+                case Result.Err<V, E> err -> { return Result.err(err.error()); }
+                case Result.Ok<V, E> ok   -> result.put(entry.getKey(), ok.value());
+            }
+        }
+        return Result.ok(fromMapUnsafe(result)); // always non-empty since nem.size() >= 1
     }
 
     // -------------------------------------------------------------------------

--- a/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -457,7 +457,7 @@ public final class NonEmptyMap<K, V> {
                 case Option.Some<V>(V v)   -> result.put(entry.getKey(), v);
             }
         }
-        return fromMap(result); // always Some since nem.size() >= 1 and all values are present
+        return Option.some(fromMapUnsafe(result)); // always non-empty since nem.size() >= 1
     }
 
     /**

--- a/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -17,7 +17,11 @@ class NonEmptyMapTest {
 
     @Test
     void of_shouldCreateMapWithHeadAndRest() {
-        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20));
+        var nem = NonEmptyMap.of(
+            "alice", 10,
+            Map.of("bob", 20)
+        );
+
         assertThat(nem.headKey()).isEqualTo("alice");
         assertThat(nem.headValue()).isEqualTo(10);
         assertThat(nem.size()).isEqualTo(2);
@@ -512,6 +516,22 @@ class NonEmptyMapTest {
     }
 
     @Test
+    void sequenceTry_withFailureInTail_shouldReturnFailure() {
+        var boom = new RuntimeException("boom");
+        var nem = NonEmptyMap
+            .<String, Try<Integer>>of(
+                "a", Try.success(1),
+                Map.of(
+                    "b", Try.failure(boom)
+                )
+        );
+        var result = NonEmptyMap.sequenceTry(nem);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
     void sequenceTry_shouldThrowNPE_whenNemIsNull() {
         assertThatThrownBy(() -> NonEmptyMap.sequenceTry(null))
             .isInstanceOf(NullPointerException.class);
@@ -540,6 +560,21 @@ class NonEmptyMapTest {
     }
 
     @Test
+    void sequenceEither_withLeftInTail_shouldReturnLeft() {
+        var nem = NonEmptyMap
+            .<String, Either<String, Integer>>of(
+                "a", Either.right(1),
+                Map.of(
+                    "b", Either.left("invalid")
+                )
+            );
+        var result = NonEmptyMap.sequenceEither(nem);
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("invalid");
+    }
+
+    @Test
     void sequenceEither_shouldThrowNPE_whenNemIsNull() {
         assertThatThrownBy(() -> NonEmptyMap.sequenceEither(null))
             .isInstanceOf(NullPointerException.class);
@@ -560,9 +595,30 @@ class NonEmptyMapTest {
 
     @Test
     void sequenceResult_withErr_shouldReturnErr() {
-        NonEmptyMap<String, Result<Integer, String>> nem = NonEmptyMap.of(
-            "a", Result.err("not found"), Map.of("b", Result.ok(2)));
-        Result<NonEmptyMap<String, Integer>, String> result = NonEmptyMap.sequenceResult(nem);
+        var nem = NonEmptyMap
+            .<String, Result<Integer, String>>of(
+                "a", Result.err("not found"),
+                Map.of(
+                    "b", Result.ok(2)
+                )
+            );
+        var result = NonEmptyMap.sequenceResult(nem);
+
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getError()).isEqualTo("not found");
+    }
+
+    @Test
+    void sequenceResult_withErrInTail_shouldReturnErr() {
+        var nem = NonEmptyMap
+            .<String, Result<Integer, String>>of(
+                "a", Result.ok(1),
+                Map.of(
+                    "b", Result.err("not found")
+                )
+            );
+        var result = NonEmptyMap.sequenceResult(nem);
+
         assertThat(result.isOk()).isFalse();
         assertThat(result.getError()).isEqualTo("not found");
     }

--- a/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -404,6 +404,20 @@ class NonEmptyMapTest {
         assertThat(result.get().get("a").get()).isEqualTo(99);
     }
 
+    @Test
+    void collector_shouldThrowNPE_whenKeyMapperIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.collector(null, java.util.function.Function.identity()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("keyMapper");
+    }
+
+    @Test
+    void collector_shouldThrowNPE_whenValueMapperIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.collector(java.util.function.Function.identity(), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("valueMapper");
+    }
+
     // -------------------------------------------------------------------------
     // toStream()
     // -------------------------------------------------------------------------

--- a/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyMapTest.java
@@ -1,7 +1,9 @@
 package dmx.fun;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -334,5 +336,226 @@ class NonEmptyMapTest {
     void toString_shouldIncludeEntries() {
         NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("alice", 10);
         assertThat(nem.toString()).contains("alice").contains("10");
+    }
+
+    // -------------------------------------------------------------------------
+    // fromOptional()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromOptional_shouldReturnSome_whenPresentAndNonEmpty() {
+        Option<NonEmptyMap<String, Integer>> result =
+            NonEmptyMap.fromOptional(Optional.of(Map.of("a", 1)));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+        assertThat(result.get().containsKey("a")).isTrue();
+    }
+
+    @Test
+    void fromOptional_shouldReturnNone_whenPresentButEmpty() {
+        Option<NonEmptyMap<String, Integer>> result =
+            NonEmptyMap.fromOptional(Optional.of(Map.of()));
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromOptional_shouldReturnNone_whenEmpty() {
+        Option<NonEmptyMap<String, Integer>> result =
+            NonEmptyMap.fromOptional(Optional.empty());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromOptional_shouldThrowNPE_whenOptionalIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.fromOptional(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("optional");
+    }
+
+    // -------------------------------------------------------------------------
+    // collector()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void collector_shouldReturnSome_whenStreamIsNonEmpty() {
+        Option<NonEmptyMap<String, Integer>> result =
+            Stream.of(Map.entry("a", 1), Map.entry("b", 2))
+                .collect(NonEmptyMap.collector(Map.Entry::getKey, Map.Entry::getValue));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(2);
+        assertThat(result.get().get("a").get()).isEqualTo(1);
+        assertThat(result.get().get("b").get()).isEqualTo(2);
+    }
+
+    @Test
+    void collector_shouldReturnNone_whenStreamIsEmpty() {
+        Option<NonEmptyMap<String, Integer>> result =
+            Stream.<Map.Entry<String, Integer>>empty()
+                .collect(NonEmptyMap.collector(Map.Entry::getKey, Map.Entry::getValue));
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void collector_lastWriteWins_onDuplicateKeys() {
+        Option<NonEmptyMap<String, Integer>> result =
+            Stream.of(Map.entry("a", 1), Map.entry("a", 99))
+                .collect(NonEmptyMap.collector(Map.Entry::getKey, Map.Entry::getValue));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().get("a").get()).isEqualTo(99);
+    }
+
+    // -------------------------------------------------------------------------
+    // toStream()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toStream_shouldYieldAllEntriesInOrder() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("a", 1, Map.of("b", 2));
+        var keys = nem.toStream().map(Map.Entry::getKey).toList();
+        assertThat(keys).containsExactly("a", "b");
+    }
+
+    @Test
+    void toStream_singleton_shouldYieldOneEntry() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.singleton("x", 42);
+        assertThat(nem.toStream().count()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // mapValuesWithKey()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapValuesWithKey_shouldPassKeyAndValueToMapper() {
+        NonEmptyMap<String, Integer> nem = NonEmptyMap.of("a", 1, Map.of("b", 2));
+        NonEmptyMap<String, String> result = nem.mapValuesWithKey((k, v) -> k + "=" + v);
+        assertThat(result.get("a").get()).isEqualTo("a=1");
+        assertThat(result.get("b").get()).isEqualTo("b=2");
+    }
+
+    @Test
+    void mapValuesWithKey_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.singleton("a", 1).mapValuesWithKey(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapValuesWithKey_shouldThrowNPE_whenMapperReturnsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.singleton("a", 1).mapValuesWithKey((k, v) -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceOption()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceOption_allSome_shouldReturnSome() {
+        NonEmptyMap<String, Option<Integer>> nem = NonEmptyMap.of(
+            "a", Option.some(1), Map.of("b", Option.some(2)));
+        Option<NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceOption(nem);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().get("a").get()).isEqualTo(1);
+        assertThat(result.get().get("b").get()).isEqualTo(2);
+    }
+
+    @Test
+    void sequenceOption_withNone_shouldReturnNone() {
+        NonEmptyMap<String, Option<Integer>> nem = NonEmptyMap.of(
+            "a", Option.some(1), Map.of("b", Option.none()));
+        Option<NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceOption(nem);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void sequenceOption_shouldThrowNPE_whenNemIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.sequenceOption(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceTry()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceTry_allSuccess_shouldReturnSuccess() {
+        NonEmptyMap<String, Try<Integer>> nem = NonEmptyMap.of(
+            "a", Try.success(1), Map.of("b", Try.success(2)));
+        Try<NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceTry(nem);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get().get("a").get()).isEqualTo(1);
+        assertThat(result.get().get("b").get()).isEqualTo(2);
+    }
+
+    @Test
+    void sequenceTry_withFailure_shouldReturnFailure() {
+        var boom = new RuntimeException("boom");
+        NonEmptyMap<String, Try<Integer>> nem = NonEmptyMap.of(
+            "a", Try.failure(boom), Map.of("b", Try.success(2)));
+        Try<NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceTry(nem);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
+    void sequenceTry_shouldThrowNPE_whenNemIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.sequenceTry(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceEither()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceEither_allRight_shouldReturnRight() {
+        NonEmptyMap<String, Either<String, Integer>> nem = NonEmptyMap.of(
+            "a", Either.right(1), Map.of("b", Either.right(2)));
+        Either<String, NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceEither(nem);
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight().get("a").get()).isEqualTo(1);
+    }
+
+    @Test
+    void sequenceEither_withLeft_shouldReturnLeft() {
+        NonEmptyMap<String, Either<String, Integer>> nem = NonEmptyMap.of(
+            "a", Either.left("invalid"), Map.of("b", Either.right(2)));
+        Either<String, NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceEither(nem);
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("invalid");
+    }
+
+    @Test
+    void sequenceEither_shouldThrowNPE_whenNemIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.sequenceEither(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceResult()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceResult_allOk_shouldReturnOk() {
+        NonEmptyMap<String, Result<Integer, String>> nem = NonEmptyMap.of(
+            "a", Result.ok(1), Map.of("b", Result.ok(2)));
+        Result<NonEmptyMap<String, Integer>, String> result = NonEmptyMap.sequenceResult(nem);
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get().get("a").get()).isEqualTo(1);
+    }
+
+    @Test
+    void sequenceResult_withErr_shouldReturnErr() {
+        NonEmptyMap<String, Result<Integer, String>> nem = NonEmptyMap.of(
+            "a", Result.err("not found"), Map.of("b", Result.ok(2)));
+        Result<NonEmptyMap<String, Integer>, String> result = NonEmptyMap.sequenceResult(nem);
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getError()).isEqualTo("not found");
+    }
+
+    @Test
+    void sequenceResult_shouldThrowNPE_whenNemIsNull() {
+        assertThatThrownBy(() -> NonEmptyMap.sequenceResult(null))
+            .isInstanceOf(NullPointerException.class);
     }
 }

--- a/site/src/data/code/guide/non-empty-map/interop-option.mdx
+++ b/site/src/data/code/guide/non-empty-map/interop-option.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequenceOption: NonEmptyMap<K, Option<V>> → Option<NonEmptyMap<K, V>>
+// Some if every value is Some; None as soon as any value is None (fail-fast in inspection).
+NonEmptyMap<String, Option<Integer>> allPresent = NonEmptyMap.of(
+    "alice", Option.some(10), Map.of("bob", Option.some(20)));
+
+Option<NonEmptyMap<String, Integer>> result = NonEmptyMap.sequenceOption(allPresent);
+// Some({alice=10, bob=20})
+
+NonEmptyMap<String, Option<Integer>> withAbsent = NonEmptyMap.of(
+    "alice", Option.some(10), Map.of("bob", Option.none()));
+
+Option<NonEmptyMap<String, Integer>> missing = NonEmptyMap.sequenceOption(withAbsent);
+// None
+```

--- a/site/src/data/code/guide/non-empty-map/interop-sequences.mdx
+++ b/site/src/data/code/guide/non-empty-map/interop-sequences.mdx
@@ -1,0 +1,47 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequenceTry: NonEmptyMap<K, Try<V>> → Try<NonEmptyMap<K, V>>
+// Success if every value succeeds; Failure from the first failing entry.
+NonEmptyMap<String, Try<Integer>> tries = NonEmptyMap.of(
+    "alice", Try.success(10), Map.of("bob", Try.success(20)));
+
+Try<NonEmptyMap<String, Integer>> allOk = NonEmptyMap.sequenceTry(tries);
+// Success({alice=10, bob=20})
+
+NonEmptyMap<String, Try<Integer>> withFailure = NonEmptyMap.of(
+    "alice", Try.failure(new RuntimeException("boom")), Map.of("bob", Try.success(20)));
+
+Try<NonEmptyMap<String, Integer>> failed = NonEmptyMap.sequenceTry(withFailure);
+// Failure(RuntimeException("boom"))
+
+// sequenceEither: NonEmptyMap<K, Either<E, V>> → Either<E, NonEmptyMap<K, V>>
+// right if every value is right; left from the first left entry.
+NonEmptyMap<String, Either<String, Integer>> eithers = NonEmptyMap.of(
+    "alice", Either.right(10), Map.of("bob", Either.right(20)));
+
+Either<String, NonEmptyMap<String, Integer>> allRight = NonEmptyMap.sequenceEither(eithers);
+// right({alice=10, bob=20})
+
+NonEmptyMap<String, Either<String, Integer>> withLeft = NonEmptyMap.of(
+    "alice", Either.left("invalid"), Map.of("bob", Either.right(20)));
+
+Either<String, NonEmptyMap<String, Integer>> firstLeft = NonEmptyMap.sequenceEither(withLeft);
+// left("invalid")
+
+// sequenceResult: NonEmptyMap<K, Result<V, E>> → Result<NonEmptyMap<K, V>, E>
+// ok if every value is ok; err from the first error entry.
+NonEmptyMap<String, Result<Integer, String>> results = NonEmptyMap.of(
+    "alice", Result.ok(10), Map.of("bob", Result.ok(20)));
+
+Result<NonEmptyMap<String, Integer>, String> allOkResult = NonEmptyMap.sequenceResult(results);
+// ok({alice=10, bob=20})
+
+NonEmptyMap<String, Result<Integer, String>> withErr = NonEmptyMap.of(
+    "alice", Result.err("not found"), Map.of("bob", Result.ok(20)));
+
+Result<NonEmptyMap<String, Integer>, String> firstErr = NonEmptyMap.sequenceResult(withErr);
+// err("not found")
+```

--- a/site/src/data/code/guide/non-empty-map/interop.mdx
+++ b/site/src/data/code/guide/non-empty-map/interop.mdx
@@ -24,8 +24,37 @@ Map<String, Integer> javaMap = nem.toMap();
 NonEmptyList<Map.Entry<String, Integer>> entries = nem.toNonEmptyList();
 // [alice=10, bob=20, carol=30]
 
+// toStream() — bridge to java.util.stream.Stream for pipeline operations
+nem.toStream()
+   .filter(e -> e.getValue() >= 20)
+   .forEach(e -> System.out.println(e.getKey() + " → " + e.getValue()));
+// bob → 20
+// carol → 30
+
 // fromMap() — bridge from plain Map (e.g. from external source)
 Map<String, Integer> external = fetchScoresFromDatabase();
 Option<NonEmptyMap<String, Integer>> safe = NonEmptyMap.fromMap(external);
 safe.peek(scores -> processScores(scores));
+
+// fromOptional() — bridge from Optional<Map<K,V>>
+Optional<Map<String, Integer>> maybeMap = Optional.of(Map.of("alice", 10));
+Option<NonEmptyMap<String, Integer>> fromOpt = NonEmptyMap.fromOptional(maybeMap);
+// Some({alice=10})
+
+Option<NonEmptyMap<String, Integer>> fromEmptyOpt = NonEmptyMap.fromOptional(Optional.empty());
+// None
+
+// collector(keyMapper, valueMapper) — build NonEmptyMap from a Stream
+record Employee(String name, int score) {}
+List<Employee> employees = List.of(new Employee("alice", 90), new Employee("bob", 75));
+
+Option<NonEmptyMap<String, Integer>> scores =
+    employees.stream()
+        .collect(NonEmptyMap.collector(Employee::name, Employee::score));
+// Some({alice=90, bob=75})
+
+Option<NonEmptyMap<String, Integer>> emptyResult =
+    Stream.<Employee>empty()
+        .collect(NonEmptyMap.collector(Employee::name, Employee::score));
+// None
 ```

--- a/site/src/data/code/guide/non-empty-map/transformations.mdx
+++ b/site/src/data/code/guide/non-empty-map/transformations.mdx
@@ -9,6 +9,10 @@ NonEmptyMap<String, Integer> nem = NonEmptyMap.of("alice", 10, Map.of("bob", 20)
 NonEmptyMap<String, String> labeled = nem.mapValues(v -> v + " pts");
 // {alice="10 pts", bob="20 pts"}
 
+// mapValuesWithKey — transform every value with access to both the key and value
+NonEmptyMap<String, String> annotated = nem.mapValuesWithKey((k, v) -> k + "=" + v);
+// {alice="alice=10", bob="bob=20"}
+
 // mapKeys — transform every key; values follow their original key
 NonEmptyMap<String, Integer> upper = nem.mapKeys(String::toUpperCase);
 // {ALICE=10, BOB=20}

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -1,6 +1,6 @@
 ---
 title: "NonEmptyMap<K, V> — Developer Guide"
-description: "Comprehensive guide to NonEmptyMap<K, V>: construction, entry access, transformations, filter, merge, interoperability, and cross-type conversions (keySet, values)."
+description: "Comprehensive guide to NonEmptyMap<K, V>: construction, entry access, transformations, filter, merge, interoperability with Option/Try/Either/Result, and cross-type conversions."
 order: 9
 h1: "NonEmptyMap<K, V>"
 ---
@@ -11,6 +11,8 @@ import {Content as Transformations}    from '../code/guide/non-empty-map/transfo
 import {Content as Filter}             from '../code/guide/non-empty-map/filter.mdx';
 import {Content as Merge}              from '../code/guide/non-empty-map/merge.mdx';
 import {Content as Interop}            from '../code/guide/non-empty-map/interop.mdx';
+import {Content as InteropOption}      from '../code/guide/non-empty-map/interop-option.mdx';
+import {Content as InteropSequences}   from '../code/guide/non-empty-map/interop-sequences.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-map/real-world-example.mdx';
 
 > **Runnable example:** [`NonEmptyMapSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java)
@@ -39,11 +41,13 @@ Use it when:
 
 ## Creating instances
 
-| Factory                             | When input is empty?                |
-|-------------------------------------|-------------------------------------|
-| `NonEmptyMap.of(key, value, rest)`  | N/A — head entry is always required |
-| `NonEmptyMap.singleton(key, value)` | N/A — always one entry              |
-| `NonEmptyMap.fromMap(map)`          | Returns `None`                      |
+| Factory                                              | When input is empty?                |
+|------------------------------------------------------|-------------------------------------|
+| `NonEmptyMap.of(key, value, rest)`                   | N/A — head entry is always required |
+| `NonEmptyMap.singleton(key, value)`                  | N/A — always one entry              |
+| `NonEmptyMap.fromMap(map)`                           | Returns `None`                      |
+| `NonEmptyMap.fromOptional(optional)`                 | Returns `None`                      |
+| `stream.collect(NonEmptyMap.collector(keyFn, valFn))`| Returns `None`                      |
 
 <CreatingInstances/>
 
@@ -59,9 +63,10 @@ null-safe access to the first entry. `get(key)` returns `Option<V>` — no nulls
 
 <Transformations/>
 
-`mapValues` and `mapKeys` always return a **new `NonEmptyMap`** — the original is
-unchanged. When `mapKeys` produces collisions, the head key takes priority and
-conflicting tail entries are dropped.
+`mapValues`, `mapValuesWithKey`, and `mapKeys` always return a **new `NonEmptyMap`** —
+the original is unchanged. `mapValuesWithKey` is preferred over `mapValues` when the
+mapped value needs the corresponding key. When `mapKeys` produces collisions, the head
+key takes priority and conflicting tail entries are dropped.
 
 ## Filter
 
@@ -78,20 +83,47 @@ result. The predicate receives both the key and the value via `BiPredicate<K, V>
 conflicts. Because both inputs are non-empty, the result is guaranteed non-empty —
 no `Option` wrapping needed.
 
-## Interoperability
+## Interoperability — Java standard types
 
 Cross-type conversions bridge `NonEmptyMap` with `NonEmptySet`, `NonEmptyList`, and the
 standard Java collections.
 
-| Method             | Returns                        | Notes                                                  |
-|--------------------|--------------------------------|--------------------------------------------------------|
-| `keySet()`         | `NonEmptySet<K>`               | All keys as a non-empty set; head key becomes set head |
-| `values()`         | `NonEmptyList<V>`              | All values in insertion order; duplicates preserved    |
-| `toMap()`          | `Map<K, V>`                    | Unmodifiable `java.util.Map` for standard API interop  |
-| `toNonEmptyList()` | `NonEmptyList<Map.Entry<K,V>>` | All entries in insertion order                         |
-| `fromMap(map)`     | `Option<NonEmptyMap<K,V>>`     | Safe bridge from a plain `Map`; `None` if empty        |
+| Method / Factory                                      | Returns                        | Notes                                                      |
+|-------------------------------------------------------|--------------------------------|------------------------------------------------------------|
+| `keySet()`                                            | `NonEmptySet<K>`               | All keys as a non-empty set; head key becomes set head     |
+| `values()`                                            | `NonEmptyList<V>`              | All values in insertion order; duplicates preserved        |
+| `toMap()`                                             | `Map<K, V>`                    | Unmodifiable `java.util.Map` for standard API interop      |
+| `toStream()`                                          | `Stream<Map.Entry<K,V>>`       | Bridge to Java stream pipelines; always at least one entry |
+| `toNonEmptyList()`                                    | `NonEmptyList<Map.Entry<K,V>>` | All entries in insertion order                             |
+| `fromMap(map)`                                        | `Option<NonEmptyMap<K,V>>`     | Safe bridge from a plain `Map`; `None` if empty            |
+| `fromOptional(optional)`                              | `Option<NonEmptyMap<K,V>>`     | Bridge from `Optional<Map<K,V>>`; `None` if absent/empty   |
+| `collector(keyMapper, valueMapper)`                   | `Option<NonEmptyMap<K,V>>`     | Stream collector; `None` for an empty stream               |
 
 <Interop/>
+
+## Interoperability — `Option`
+
+`sequenceOption` converts a `NonEmptyMap<K, Option<V>>` into an
+`Option<NonEmptyMap<K, V>>`. It is fail-fast in inspection: it stops iterating after
+the first `None`.
+
+<InteropOption/>
+
+## Interoperability — `Try`, `Either`, `Result`
+
+`sequenceTry`, `sequenceEither`, and `sequenceResult` each convert a
+`NonEmptyMap` of wrapped values into a single wrapped `NonEmptyMap`.
+All three are **fail-fast in inspection**: they stop iterating after the first
+failure/left/err.
+
+| Method                               | Input                            | Returns                           |
+|--------------------------------------|----------------------------------|-----------------------------------|
+| `NonEmptyMap.sequenceOption(nem)`    | `NonEmptyMap<K, Option<V>>`      | `Option<NonEmptyMap<K, V>>`       |
+| `NonEmptyMap.sequenceTry(nem)`       | `NonEmptyMap<K, Try<V>>`         | `Try<NonEmptyMap<K, V>>`          |
+| `NonEmptyMap.sequenceEither(nem)`    | `NonEmptyMap<K, Either<E, V>>`   | `Either<E, NonEmptyMap<K, V>>`    |
+| `NonEmptyMap.sequenceResult(nem)`    | `NonEmptyMap<K, Result<V, E>>`   | `Result<NonEmptyMap<K, V>, E>`    |
+
+<InteropSequences/>
 
 ## `equals`, `hashCode`, and `toString`
 
@@ -102,13 +134,15 @@ ignored). `hashCode` delegates to `toMap().hashCode()`. `toString` prints in
 
 ## When to use `NonEmptyMap` vs plain `Map`
 
-| Scenario                                               | Recommendation                               |
-|--------------------------------------------------------|----------------------------------------------|
-| At least one entry required by contract                | `NonEmptyMap<K, V>`                          |
-| Map may legitimately be empty                          | `Map<K, V>`                                  |
-| Reading from an external source that may be empty      | `NonEmptyMap.fromMap(map)` → handle `None`   |
-| Merging two registries — result is always non-empty    | `nem1.merge(nem2, mergeFunction)`            |
-| Filtering entries — result may be empty                | `nem.filter(predicate)` → handle `None`      |
+| Scenario                                               | Recommendation                                        |
+|--------------------------------------------------------|-------------------------------------------------------|
+| At least one entry required by contract                | `NonEmptyMap<K, V>`                                   |
+| Map may legitimately be empty                          | `Map<K, V>`                                           |
+| Reading from an external source that may be empty      | `NonEmptyMap.fromMap(map)` → handle `None`            |
+| Building from a stream                                 | `.collect(NonEmptyMap.collector(keyFn, valFn))`       |
+| Merging two registries — result is always non-empty    | `nem1.merge(nem2, mergeFunction)`                     |
+| Filtering entries — result may be empty                | `nem.filter(predicate)` → handle `None`               |
+| All values must be present before processing           | `NonEmptyMap.sequenceOption(nem)` → handle `None`     |
 
 ## Real-world example
 


### PR DESCRIPTION
  - Add `fromOptional(Optional<Map<K,V>>)` → `Option<NonEmptyMap<K,V>>`
  - Add `collector(keyMapper, valueMapper)` — stream collector returning
    `Option<NonEmptyMap<K,V>>`; `None` for an empty stream
  - Add `toStream()` → `Stream<Map.Entry<K,V>>` for Java stream pipeline interop
  - Add `mapValuesWithKey(BiFunction<K,V,R>)` — value transformation with key context
  - Add `sequenceOption`, `sequenceTry`, `sequenceEither`, `sequenceResult` —
    fail-fast sequencing over map values (stop iterating on first None/Failure/left/err)
  - Add 28 new tests covering all new methods including NPE guards, edge cases,
    and fail-fast behaviour; all 62 tests pass
  - Update guide: expanded creating-instances and interop tables, new
    "Interoperability — Option" and "Interoperability — Try, Either, Result" sections,
    new `interop-option.mdx` and `interop-sequences.mdx` code snippets,
    `transformations.mdx` updated with `mapValuesWithKey` example

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #292

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NonEmptyMap gains Optional-to-map conversion, Stream integration (stream view and stream-to-map collector), value transformation with access to keys, and sequence-style conversions for Option/Try/Either/Result.

* **Tests**
  * Expanded tests covering factories, collector behavior, streaming order, map-value/key transforms, and sequence conversions (success and fail-fast cases).

* **Documentation**
  * Guides updated with examples for Optional conversion, stream usage, value-key mapping, and sequencing interop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->