### PR TITLE
feat(NonEmptySet): add interop methods, tests, and site docs (#293)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonEmptySet.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptySet.java
@@ -8,9 +8,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -101,6 +104,48 @@ public final class NonEmptySet<T> implements Iterable<T> {
         return Option.some(fromSetUnsafe(set));
     }
 
+    /**
+     * Attempts to construct a singleton {@code NonEmptySet} from a JDK {@link Optional}.
+     *
+     * @param optional the source optional; must not be {@code null}
+     * @param <T>      the element type
+     * @return {@link Option#some(Object)} wrapping a singleton {@code NonEmptySet} if the
+     *         optional is present, or {@link Option#none()} if the optional is empty
+     * @throws NullPointerException if {@code optional} is {@code null}
+     */
+    public static <T> Option<NonEmptySet<T>> fromOptional(Optional<? extends T> optional) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        return optional.isPresent()
+            ? Option.some(NonEmptySet.singleton(optional.get()))
+            : Option.none();
+    }
+
+    /**
+     * Returns a {@link Collector} that accumulates a {@code Stream<T>} into an
+     * {@code Option<NonEmptySet<T>>}.
+     *
+     * <p>Produces {@link Option#some(Object)} for a non-empty stream and {@link Option#none()}
+     * for an empty stream. Duplicate elements are automatically deduplicated (set semantics).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Option<NonEmptySet<String>> roles =
+     *     userRoles.stream()
+     *         .collect(NonEmptySet.collector());
+     * }</pre>
+     *
+     * @param <T> the element type
+     * @return a collector producing {@code Option<NonEmptySet<T>>}
+     */
+    public static <T> Collector<T, ?, Option<NonEmptySet<T>>> collector() {
+        return Collector.of(
+            LinkedHashSet<T>::new,
+            (set, t) -> set.add(Objects.requireNonNull(t, "stream elements must not be null")),
+            (a, b) -> { a.addAll(b); return a; },
+            set -> set.isEmpty() ? Option.none() : Option.some(fromSetUnsafe(set))
+        );
+    }
+
     /** Internal: builds from a known-non-empty set without Option wrapping. */
     private static <T> NonEmptySet<T> fromSetUnsafe(Set<? extends T> set) {
         Iterator<? extends T> it = set.iterator();
@@ -167,6 +212,19 @@ public final class NonEmptySet<T> implements Iterable<T> {
             }
         }
         return s;
+    }
+
+    /**
+     * Returns a sequential {@link Stream} of all elements in insertion order.
+     *
+     * <p>The stream always contains at least one element (the head). Use it to bridge
+     * {@code NonEmptySet} into the standard Java stream API without going through
+     * {@link #toSet()}.
+     *
+     * @return a non-empty stream of elements in insertion order
+     */
+    public Stream<T> toStream() {
+        return toSet().stream();
     }
 
     // -------------------------------------------------------------------------
@@ -282,6 +340,115 @@ public final class NonEmptySet<T> implements Iterable<T> {
             tailMap.put(element, val);
         }
         return NonEmptyMap.of(head, headVal, tailMap);
+    }
+
+    // -------------------------------------------------------------------------
+    // Interoperability — sequence
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sequences a {@code NonEmptySet<Option<T>>} into an {@code Option<NonEmptySet<T>>}.
+     *
+     * <p>Returns {@link Option#some(Object)} containing all unwrapped values if every element
+     * is {@code Some}; returns {@link Option#none()} as soon as any element is {@code None}
+     * (fail-fast in inspection — the method stops iterating after the first {@code None};
+     * elements are already materialized in the set before sequencing, so later elements are
+     * not inspected but were already evaluated).
+     *
+     * @param <T> the unwrapped element type
+     * @param nes a {@code NonEmptySet<Option<T>>}; must not be {@code null}
+     * @return {@code Some(NonEmptySet<T>)} if all elements are present, {@code None} otherwise
+     * @throws NullPointerException if {@code nes} is {@code null}
+     */
+    public static <T> Option<NonEmptySet<T>> sequenceOption(NonEmptySet<Option<T>> nes) {
+        Objects.requireNonNull(nes, "nes must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        for (Option<T> opt : nes) {
+            switch (opt) {
+                case Option.None<T> ignored -> { return Option.none(); }
+                case Option.Some<T>(T v)   -> result.add(v);
+            }
+        }
+        return Option.some(fromSetUnsafe(result)); // always non-empty since nes.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptySet<Try<T>>} into a {@code Try<NonEmptySet<T>>}.
+     *
+     * <p>Returns {@link Try#success(Object)} if all elements succeed; returns
+     * {@link Try#failure(Throwable)} from the first failing element (fail-fast in inspection —
+     * the method stops iterating after the first failure; elements are already materialized in
+     * the set before sequencing, so later elements are not inspected but were already evaluated).
+     *
+     * @param <T> the success value type
+     * @param nes a {@code NonEmptySet<Try<T>>}; must not be {@code null}
+     * @return {@code Success(NonEmptySet<T>)} if all succeed, {@code Failure} otherwise
+     * @throws NullPointerException if {@code nes} is {@code null}
+     */
+    public static <T> Try<NonEmptySet<T>> sequenceTry(NonEmptySet<Try<T>> nes) {
+        Objects.requireNonNull(nes, "nes must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        for (Try<T> t : nes) {
+            switch (t) {
+                case Try.Failure<T> f -> { return Try.failure(f.cause()); }
+                case Try.Success<T> s -> result.add(s.value());
+            }
+        }
+        return Try.success(fromSetUnsafe(result)); // always non-empty since nes.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptySet<Either<E, T>>} into an
+     * {@code Either<E, NonEmptySet<T>>}.
+     *
+     * <p>Returns {@link Either#right(Object)} if all elements are right; returns
+     * {@link Either#left(Object)} from the first left element (fail-fast in inspection —
+     * the method stops iterating after the first left; elements are already materialized in
+     * the set before sequencing, so later elements are not inspected but were already evaluated).
+     *
+     * @param <E> the left (error) type
+     * @param <T> the right (success) type
+     * @param nes a {@code NonEmptySet<Either<E, T>>}; must not be {@code null}
+     * @return {@code right(NonEmptySet<T>)} if all are right, {@code left(E)} otherwise
+     * @throws NullPointerException if {@code nes} is {@code null}
+     */
+    public static <E, T> Either<E, NonEmptySet<T>> sequenceEither(NonEmptySet<Either<E, T>> nes) {
+        Objects.requireNonNull(nes, "nes must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        for (Either<E, T> e : nes) {
+            switch (e) {
+                case Either.Left<E, T> l  -> { return Either.left(l.value()); }
+                case Either.Right<E, T> r -> result.add(r.value());
+            }
+        }
+        return Either.right(fromSetUnsafe(result)); // always non-empty since nes.size() >= 1
+    }
+
+    /**
+     * Sequences a {@code NonEmptySet<Result<T, E>>} into a
+     * {@code Result<NonEmptySet<T>, E>}.
+     *
+     * <p>Returns {@link Result#ok(Object)} if all elements are ok; returns
+     * {@link Result#err(Object)} from the first error element (fail-fast in inspection —
+     * the method stops iterating after the first err; elements are already materialized in
+     * the set before sequencing, so later elements are not inspected but were already evaluated).
+     *
+     * @param <T> the ok value type
+     * @param <E> the error type
+     * @param nes a {@code NonEmptySet<Result<T, E>>}; must not be {@code null}
+     * @return {@code ok(NonEmptySet<T>)} if all succeed, {@code err(E)} otherwise
+     * @throws NullPointerException if {@code nes} is {@code null}
+     */
+    public static <T, E> Result<NonEmptySet<T>, E> sequenceResult(NonEmptySet<Result<T, E>> nes) {
+        Objects.requireNonNull(nes, "nes must not be null");
+        Set<T> result = new LinkedHashSet<>();
+        for (Result<T, E> r : nes) {
+            switch (r) {
+                case Result.Err<T, E> err -> { return Result.err(err.error()); }
+                case Result.Ok<T, E> ok   -> result.add(ok.value());
+            }
+        }
+        return Result.ok(fromSetUnsafe(result)); // always non-empty since nes.size() >= 1
     }
 
     // -------------------------------------------------------------------------

--- a/core/lib/src/test/java/dmx/fun/NonEmptySetTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptySetTest.java
@@ -369,6 +369,14 @@ class NonEmptySetTest {
         assertThat(result.isEmpty()).isTrue();
     }
 
+    @Test
+    void collector_shouldThrowNPE_whenStreamElementIsNull() {
+        assertThatThrownBy(() ->
+            Stream.<String>of("a", null).collect(NonEmptySet.collector()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("stream elements must not be null");
+    }
+
     // -------------------------------------------------------------------------
     // toStream()
     // -------------------------------------------------------------------------

--- a/core/lib/src/test/java/dmx/fun/NonEmptySetTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptySetTest.java
@@ -1,6 +1,8 @@
 package dmx.fun;
 
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -318,5 +320,213 @@ class NonEmptySetTest {
     void toString_shouldIncludeElements() {
         NonEmptySet<String> nes = NonEmptySet.singleton("admin");
         assertThat(nes.toString()).contains("admin");
+    }
+
+    // -------------------------------------------------------------------------
+    // fromOptional()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromOptional_shouldReturnSome_whenPresent() {
+        Option<NonEmptySet<String>> result = NonEmptySet.fromOptional(Optional.of("admin"));
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(1);
+        assertThat(result.get().head()).isEqualTo("admin");
+    }
+
+    @Test
+    void fromOptional_shouldReturnNone_whenEmpty() {
+        Option<NonEmptySet<String>> result = NonEmptySet.fromOptional(Optional.empty());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void fromOptional_shouldThrowNPE_whenOptionalIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.fromOptional(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("optional");
+    }
+
+    // -------------------------------------------------------------------------
+    // collector()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void collector_shouldReturnSome_whenStreamIsNonEmpty() {
+        Option<NonEmptySet<String>> result =
+            Stream.of("admin", "user", "admin")
+                .collect(NonEmptySet.collector());
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().size()).isEqualTo(2); // "admin" deduplicated
+        assertThat(result.get().contains("admin")).isTrue();
+        assertThat(result.get().contains("user")).isTrue();
+    }
+
+    @Test
+    void collector_shouldReturnNone_whenStreamIsEmpty() {
+        Option<NonEmptySet<String>> result =
+            Stream.<String>empty().collect(NonEmptySet.collector());
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // toStream()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toStream_shouldYieldAllElementsInOrder() {
+        NonEmptySet<String> nes = NonEmptySet.of("admin", new java.util.LinkedHashSet<>(java.util.List.of("user", "editor")));
+        var elements = nes.toStream().toList();
+        assertThat(elements).containsExactly("admin", "user", "editor");
+    }
+
+    @Test
+    void toStream_singleton_shouldYieldOneElement() {
+        NonEmptySet<String> nes = NonEmptySet.singleton("admin");
+        assertThat(nes.toStream().count()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceOption()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceOption_allSome_shouldReturnSome() {
+        NonEmptySet<Option<String>> nes = NonEmptySet.of(
+            Option.some("admin"), Set.of(Option.some("user")));
+        Option<NonEmptySet<String>> result = NonEmptySet.sequenceOption(nes);
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.get().contains("admin")).isTrue();
+        assertThat(result.get().contains("user")).isTrue();
+    }
+
+    @Test
+    void sequenceOption_withNone_shouldReturnNone() {
+        NonEmptySet<Option<String>> nes = NonEmptySet.of(
+            Option.some("admin"), Set.of(Option.none()));
+        Option<NonEmptySet<String>> result = NonEmptySet.sequenceOption(nes);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void sequenceOption_shouldThrowNPE_whenNesIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.sequenceOption(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceTry()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceTry_allSuccess_shouldReturnSuccess() {
+        NonEmptySet<Try<String>> nes = NonEmptySet.of(
+            Try.success("admin"), Set.of(Try.success("user")));
+        Try<NonEmptySet<String>> result = NonEmptySet.sequenceTry(nes);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get().contains("admin")).isTrue();
+        assertThat(result.get().contains("user")).isTrue();
+    }
+
+    @Test
+    void sequenceTry_withHeadFailure_shouldReturnFailure() {
+        var boom = new RuntimeException("boom");
+        NonEmptySet<Try<String>> nes = NonEmptySet.of(
+            Try.failure(boom), Set.of(Try.success("user")));
+        Try<NonEmptySet<String>> result = NonEmptySet.sequenceTry(nes);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
+    void sequenceTry_withTailFailure_shouldReturnFailure() {
+        var boom = new RuntimeException("boom");
+        NonEmptySet<Try<String>> nes = NonEmptySet.of(
+            Try.success("admin"), Set.of(Try.failure(boom)));
+        Try<NonEmptySet<String>> result = NonEmptySet.sequenceTry(nes);
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isSameAs(boom);
+    }
+
+    @Test
+    void sequenceTry_shouldThrowNPE_whenNesIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.sequenceTry(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceEither()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceEither_allRight_shouldReturnRight() {
+        NonEmptySet<Either<String, Integer>> nes = NonEmptySet.of(
+            Either.right(1), Set.of(Either.right(2)));
+        Either<String, NonEmptySet<Integer>> result = NonEmptySet.sequenceEither(nes);
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight().contains(1)).isTrue();
+        assertThat(result.getRight().contains(2)).isTrue();
+    }
+
+    @Test
+    void sequenceEither_withHeadLeft_shouldReturnLeft() {
+        NonEmptySet<Either<String, Integer>> nes = NonEmptySet.of(
+            Either.left("invalid"), Set.of(Either.right(2)));
+        Either<String, NonEmptySet<Integer>> result = NonEmptySet.sequenceEither(nes);
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("invalid");
+    }
+
+    @Test
+    void sequenceEither_withTailLeft_shouldReturnLeft() {
+        NonEmptySet<Either<String, Integer>> nes = NonEmptySet.of(
+            Either.right(1), Set.of(Either.left("invalid")));
+        Either<String, NonEmptySet<Integer>> result = NonEmptySet.sequenceEither(nes);
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("invalid");
+    }
+
+    @Test
+    void sequenceEither_shouldThrowNPE_whenNesIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.sequenceEither(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // sequenceResult()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void sequenceResult_allOk_shouldReturnOk() {
+        NonEmptySet<Result<Integer, String>> nes = NonEmptySet.of(
+            Result.ok(1), Set.of(Result.ok(2)));
+        Result<NonEmptySet<Integer>, String> result = NonEmptySet.sequenceResult(nes);
+        assertThat(result.isOk()).isTrue();
+        assertThat(result.get().contains(1)).isTrue();
+        assertThat(result.get().contains(2)).isTrue();
+    }
+
+    @Test
+    void sequenceResult_withHeadErr_shouldReturnErr() {
+        NonEmptySet<Result<Integer, String>> nes = NonEmptySet.of(
+            Result.err("not found"), Set.of(Result.ok(2)));
+        Result<NonEmptySet<Integer>, String> result = NonEmptySet.sequenceResult(nes);
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getError()).isEqualTo("not found");
+    }
+
+    @Test
+    void sequenceResult_withTailErr_shouldReturnErr() {
+        NonEmptySet<Result<Integer, String>> nes = NonEmptySet.of(
+            Result.ok(1), Set.of(Result.err("not found")));
+        Result<NonEmptySet<Integer>, String> result = NonEmptySet.sequenceResult(nes);
+        assertThat(result.isOk()).isFalse();
+        assertThat(result.getError()).isEqualTo("not found");
+    }
+
+    @Test
+    void sequenceResult_shouldThrowNPE_whenNesIsNull() {
+        assertThatThrownBy(() -> NonEmptySet.sequenceResult(null))
+            .isInstanceOf(NullPointerException.class);
     }
 }

--- a/site/src/data/code/guide/non-empty-set/creating-instances.mdx
+++ b/site/src/data/code/guide/non-empty-set/creating-instances.mdx
@@ -18,4 +18,22 @@ NonEmptySet<String> single = NonEmptySet.singleton("admin");
 // fromSet — safe conversion from a plain Set; empty set returns None
 Option<NonEmptySet<String>> fromSet = NonEmptySet.fromSet(someSet);
 // Some([...])  or  None
+
+// fromOptional — bridge from Optional<T>; wraps the value as a singleton NonEmptySet
+Optional<String> present = Optional.of("admin");
+Option<NonEmptySet<String>> fromPresent = NonEmptySet.fromOptional(present);
+// Some([admin])
+
+Option<NonEmptySet<String>> fromEmpty = NonEmptySet.fromOptional(Optional.empty());
+// None
+
+// collector() — build NonEmptyMap from a Stream; None if the stream is empty
+List<String> roles = List.of("admin", "editor", "viewer", "editor"); // duplicate dropped
+Option<NonEmptySet<String>> collected =
+    roles.stream().collect(NonEmptySet.collector());
+// Some([admin, editor, viewer])
+
+Option<NonEmptySet<String>> emptyCollected =
+    Stream.<String>empty().collect(NonEmptySet.collector());
+// None
 ```

--- a/site/src/data/code/guide/non-empty-set/creating-instances.mdx
+++ b/site/src/data/code/guide/non-empty-set/creating-instances.mdx
@@ -27,7 +27,7 @@ Option<NonEmptySet<String>> fromPresent = NonEmptySet.fromOptional(present);
 Option<NonEmptySet<String>> fromEmpty = NonEmptySet.fromOptional(Optional.empty());
 // None
 
-// collector() — build NonEmptyMap from a Stream; None if the stream is empty
+// collector() — build NonEmptySet from a Stream; None if the stream is empty
 List<String> roles = List.of("admin", "editor", "viewer", "editor"); // duplicate dropped
 Option<NonEmptySet<String>> collected =
     roles.stream().collect(NonEmptySet.collector());

--- a/site/src/data/code/guide/non-empty-set/interop-option.mdx
+++ b/site/src/data/code/guide/non-empty-set/interop-option.mdx
@@ -1,0 +1,19 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequenceOption: NonEmptySet<Option<T>> → Option<NonEmptySet<T>>
+// Some if every element is Some; None as soon as any element is None (fail-fast in inspection).
+NonEmptySet<Option<String>> allPresent = NonEmptySet.of(
+    Option.some("admin"), Set.of(Option.some("editor"), Option.some("viewer")));
+
+Option<NonEmptySet<String>> result = NonEmptySet.sequenceOption(allPresent);
+// Some([admin, editor, viewer])
+
+NonEmptySet<Option<String>> withAbsent = NonEmptySet.of(
+    Option.some("admin"), Set.of(Option.none(), Option.some("viewer")));
+
+Option<NonEmptySet<String>> missing = NonEmptySet.sequenceOption(withAbsent);
+// None
+```

--- a/site/src/data/code/guide/non-empty-set/interop-sequences.mdx
+++ b/site/src/data/code/guide/non-empty-set/interop-sequences.mdx
@@ -1,0 +1,47 @@
+---
+fileName: 'Demo.java'
+---
+
+```java
+// sequenceTry: NonEmptySet<Try<T>> → Try<NonEmptySet<T>>
+// Success if every element succeeds; Failure from the first failing element.
+NonEmptySet<Try<String>> tries = NonEmptySet.of(
+    Try.success("admin"), Set.of(Try.success("editor"), Try.success("viewer")));
+
+Try<NonEmptySet<String>> allOk = NonEmptySet.sequenceTry(tries);
+// Success([admin, editor, viewer])
+
+NonEmptySet<Try<String>> withFailure = NonEmptySet.of(
+    Try.failure(new RuntimeException("boom")), Set.of(Try.success("editor")));
+
+Try<NonEmptySet<String>> failed = NonEmptySet.sequenceTry(withFailure);
+// Failure(RuntimeException("boom"))
+
+// sequenceEither: NonEmptySet<Either<E, T>> → Either<E, NonEmptySet<T>>
+// Right if every element is Right; Left from the first Left element.
+NonEmptySet<Either<String, Integer>> eithers = NonEmptySet.of(
+    Either.right(10), Set.of(Either.right(20), Either.right(30)));
+
+Either<String, NonEmptySet<Integer>> allRight = NonEmptySet.sequenceEither(eithers);
+// Right([10, 20, 30])
+
+NonEmptySet<Either<String, Integer>> withLeft = NonEmptySet.of(
+    Either.left("invalid"), Set.of(Either.right(20)));
+
+Either<String, NonEmptySet<Integer>> firstLeft = NonEmptySet.sequenceEither(withLeft);
+// Left("invalid")
+
+// sequenceResult: NonEmptySet<Result<T, E>> → Result<NonEmptySet<T>, E>
+// Ok if every element is Ok; Err from the first error element.
+NonEmptySet<Result<Integer, String>> results = NonEmptySet.of(
+    Result.ok(10), Set.of(Result.ok(20), Result.ok(30)));
+
+Result<NonEmptySet<Integer>, String> allOkResult = NonEmptySet.sequenceResult(results);
+// Ok([10, 20, 30])
+
+NonEmptySet<Result<Integer, String>> withErr = NonEmptySet.of(
+    Result.err("not found"), Set.of(Result.ok(20)));
+
+Result<NonEmptySet<Integer>, String> firstErr = NonEmptySet.sequenceResult(withErr);
+// Err("not found")
+```

--- a/site/src/data/code/guide/non-empty-set/interop.mdx
+++ b/site/src/data/code/guide/non-empty-set/interop.mdx
@@ -22,8 +22,33 @@ Set<String> javaSet = nes.toSet();
 NonEmptyList<String> nel = nes.toNonEmptyList();
 // NonEmptyList["admin", "editor", "viewer"]
 
+// toStream() — bridge to java.util.stream.Stream for pipeline operations
+nes.toStream()
+   .filter(role -> !role.equals("viewer"))
+   .forEach(System.out::println);
+// admin
+// editor
+
 // fromSet() — bridge from plain Set (e.g. from external source)
 Set<String> external = fetchRolesFromDatabase();
 Option<NonEmptySet<String>> safe = NonEmptySet.fromSet(external);
 safe.peek(roles -> processRoles(roles));
+
+// fromOptional() — bridge from Optional<T>; wraps the value as a singleton NonEmptySet
+Optional<String> maybeRole = Optional.of("admin");
+Option<NonEmptySet<String>> fromOpt = NonEmptySet.fromOptional(maybeRole);
+// Some([admin])
+
+Option<NonEmptySet<String>> fromEmptyOpt = NonEmptySet.fromOptional(Optional.empty());
+// None
+
+// collector() — build NonEmptySet from a Stream; None if the stream is empty
+List<String> permissions = List.of("read", "write", "read"); // duplicate "read" dropped
+Option<NonEmptySet<String>> perms =
+    permissions.stream().collect(NonEmptySet.collector());
+// Some([read, write])
+
+Option<NonEmptySet<String>> emptyPerms =
+    Stream.<String>empty().collect(NonEmptySet.collector());
+// None
 ```

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: "NonEmptySet<T> — Developer Guide"
-description: "Comprehensive guide to NonEmptySet<T>: construction, element access, transformations, filter, set operations (union, intersection), and cross-type conversions (toNonEmptyMap, toNonEmptyList)."
+description: "Comprehensive guide to NonEmptySet<T>: construction, element access, transformations, filter, set operations (union, intersection), cross-type conversions, and interoperability with Option, Try, Either, and Result."
 order: 10
 h1: "NonEmptySet<T>"
 ---
@@ -11,6 +11,8 @@ import {Content as Transformations}    from '../code/guide/non-empty-set/transfo
 import {Content as Filter}             from '../code/guide/non-empty-set/filter.mdx';
 import {Content as SetOperations}      from '../code/guide/non-empty-set/set-operations.mdx';
 import {Content as Interop}            from '../code/guide/non-empty-set/interop.mdx';
+import {Content as InteropOption}      from '../code/guide/non-empty-set/interop-option.mdx';
+import {Content as InteropSequences}   from '../code/guide/non-empty-set/interop-sequences.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-set/real-world-example.mdx';
 
 > **Runnable example:** [`NonEmptySetSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java)
@@ -43,11 +45,13 @@ Use it when:
 
 ## Creating instances
 
-| Factory                       | When input is empty?          |
-|-------------------------------|-------------------------------|
-| `NonEmptySet.of(head, rest)`  | N/A — head is always required |
-| `NonEmptySet.singleton(head)` | N/A — always one element      |
-| `NonEmptySet.fromSet(set)`    | Returns `None`                |
+| Factory                          | When input is empty?          |
+|----------------------------------|-------------------------------|
+| `NonEmptySet.of(head, rest)`     | N/A — head is always required |
+| `NonEmptySet.singleton(head)`    | N/A — always one element      |
+| `NonEmptySet.fromSet(set)`       | Returns `None`                |
+| `NonEmptySet.fromOptional(opt)`  | Returns `None`                |
+| `NonEmptySet.collector()`        | Returns `None`                |
 
 <CreatingInstances/>
 
@@ -88,14 +92,31 @@ not just `NonEmptySet`.
 Cross-type conversions bridge `NonEmptySet` with `NonEmptyMap`, `NonEmptyList`, and the
 standard Java collections.
 
-| Method                       | Returns                  | Notes                                                 |
-|------------------------------|--------------------------|-------------------------------------------------------|
-| `toNonEmptyMap(valueMapper)` | `NonEmptyMap<T, V>`      | Elements become keys; mapper produces values          |
-| `toNonEmptyList()`           | `NonEmptyList<T>`        | Ordered snapshot; head element preserved              |
-| `toSet()`                    | `Set<T>`                 | Unmodifiable `java.util.Set` for standard API interop |
-| `fromSet(set)`               | `Option<NonEmptySet<T>>` | Safe bridge from a plain `Set`; `None` if empty       |
+| Method                         | Returns                  | Notes                                                         |
+|--------------------------------|--------------------------|---------------------------------------------------------------|
+| `toNonEmptyMap(valueMapper)`   | `NonEmptyMap<T, V>`      | Elements become keys; mapper produces values                  |
+| `toNonEmptyList()`             | `NonEmptyList<T>`        | Ordered snapshot; head element preserved                      |
+| `toSet()`                      | `Set<T>`                 | Unmodifiable `java.util.Set` for standard API interop         |
+| `toStream()`                   | `Stream<T>`              | Bridge to `java.util.stream.Stream` for pipeline operations   |
+| `fromSet(set)`                 | `Option<NonEmptySet<T>>` | Safe bridge from a plain `Set`; `None` if empty               |
+| `fromOptional(optional)`       | `Option<NonEmptySet<T>>` | Wraps the present value as singleton; `None` if empty         |
+| `collector()`                  | `Collector<T, ?, Option<NonEmptySet<T>>>` | Build from a `Stream`; `None` if stream is empty |
 
 <Interop/>
+
+## Interoperability — Option
+
+`sequenceOption` turns a `NonEmptySet<Option<T>>` into an `Option<NonEmptySet<T>>`.
+It returns `Some` only when every element is `Some`; the first `None` short-circuits and returns `None`.
+
+<InteropOption/>
+
+## Interoperability — Try, Either, Result
+
+`sequenceTry`, `sequenceEither`, and `sequenceResult` follow the same fail-fast-in-inspection
+pattern: the method stops iterating as soon as it encounters a failure, `Left`, or `Err`.
+
+<InteropSequences/>
 
 ## `equals`, `hashCode`, and `toString`
 


### PR DESCRIPTION
  Add fromOptional, collector, toStream, sequenceOption, sequenceTry,
  sequenceEither, and sequenceResult to NonEmptySet; cover all branches
  with 22 new tests; update guide with expanded interop table and new
  Option/Try/Either/Result sequence sections.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #293

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * NonEmptySet now supports construction from `Optional` and `Stream` via new factory methods.
  * Added `toStream()` for exposing stream operations.
  * Introduced sequence interoperability methods for composing wrapped values (`Option`, `Try`, `Either`, `Result`) into wrapped NonEmptySets with fail-fast semantics.

* **Documentation**
  * Added comprehensive examples for all new NonEmptySet construction and interoperability features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->