### PR TITLE
docs(contributing): reference ADR-001 for Java 25 version requirement

### DIFF
--- a/docs/adr/ADR-001-java-version.md
+++ b/docs/adr/ADR-001-java-version.md
@@ -16,7 +16,7 @@ Require **Java 25** as the minimum version.
 ## Consequences
 
 **Positive:**
-- Access to `Gatherer` (Java 22+) to implement `sequence`/`traverse` with true short-circuit.
+- Access to `Gatherer` (Java 24+) to implement `sequence`/`traverse` with true short-circuit.
 - Stable virtual threads (Java 21+) used in `Try.withTimeout`.
 - Exhaustive pattern matching in `switch` over sealed interfaces.
 - Record patterns, unnamed variables (`_`), and other post-17 features.

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -23,6 +23,11 @@ This page covers everything you need to go from a fresh clone to a passing build
 
 No other global tools are required.
 
+> **Why Java 25?** The Java 25 minimum is an explicit architecture decision: it enables `Gatherer`
+> (Java 22+) for true short-circuit `sequence`/`traverse`, stable virtual threads (Java 21+) for
+> `Try.withTimeout`, and exhaustive sealed-interface pattern matching.
+> See [ADR-001 — Java 25 as the minimum required version](https://github.com/domix/dmx-fun/blob/main/docs/adr/ADR-001-java-version.md).
+
 ## Clone and build
 
 <CloneAndBuild/>

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -24,8 +24,8 @@ This page covers everything you need to go from a fresh clone to a passing build
 No other global tools are required.
 
 > **Why Java 25?** The Java 25 minimum is an explicit architecture decision: it enables `Gatherer`
-> (Java 22+) for true short-circuit `sequence`/`traverse`, stable virtual threads (Java 21+) for
-> `Try.withTimeout`, and exhaustive sealed-interface pattern matching.
+> (finalized in Java 24) for true short-circuit `sequence`/`traverse`, stable virtual threads
+> (Java 21+) for `Try.withTimeout`, and exhaustive sealed-interface pattern matching (Java 21+).
 > See [ADR-001 — Java 25 as the minimum required version](https://github.com/domix/dmx-fun/blob/main/docs/adr/ADR-001-java-version.md).
 
 ## Clone and build


### PR DESCRIPTION
  Add a callout in the Prerequisites section explaining why Java 25 is
  the minimum version and linking to docs/adr/ADR-001-java-version.md.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #358

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide with a new section clarifying Java 25 as the minimum required version for contributors. The update provides detailed information on the specific features and compatibility expectations that establish this requirement, helping contributors understand the technical rationale and version specifications necessary for participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->