### PR TITLE
docs(module-conventions): reference ADR-002 at the JPMS step

### DIFF
--- a/site/src/data/guide/module-conventions.mdx
+++ b/site/src/data/guide/module-conventions.mdx
@@ -60,6 +60,8 @@ def moduleMap = [
 
 ### 4. Configure JPMS tests
 
+Every module ships a `module-info.java` — this is a deliberate architectural decision documented in
+[ADR-002 — JPMS from day one](https://github.com/domix/dmx-fun/blob/main/docs/adr/ADR-002-jpms.md).
 The `dmx-fun.java-module` convention plugin exposes a `jpmsTest` DSL block that wires
 `--module-path`, `--patch-module`, and `--add-modules` into `compileTestJava` and `test`
 automatically. Add it to the module's `build.gradle`:


### PR DESCRIPTION
  Add a note at step 4 (Configure JPMS tests) explaining that every
  module ships a module-info.java as a deliberate architecture decision
  and linking to docs/adr/ADR-002-jpms.md.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #361

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
