### PR TITLE
docs(contributing): use internal site links for ADR references

### DIFF
--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -9,6 +9,8 @@ import {Content as CloneAndBuild} from '../code/guide/contributing/clone-and-bui
 import {Content as RunTests}      from '../code/guide/contributing/run-tests.mdx';
 import {Content as RunSite}       from '../code/guide/contributing/run-site.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 Contributions are welcome — bug reports, documentation improvements, and new features alike.
 This page covers everything you need to go from a fresh clone to a passing build and an open PR.
 
@@ -26,7 +28,7 @@ No other global tools are required.
 > **Why Java 25?** The Java 25 minimum is an explicit architecture decision: it enables `Gatherer`
 > (finalized in Java 24) for true short-circuit `sequence`/`traverse`, stable virtual threads
 > (Java 21+) for `Try.withTimeout`, and exhaustive sealed-interface pattern matching (Java 21+).
-> See [ADR-001 — Java 25 as the minimum required version](https://github.com/domix/dmx-fun/blob/main/docs/adr/ADR-001-java-version.md).
+> See <a href={`${base}adr/adr-001-java-version`}>ADR-001 — Java 25 as the minimum required version</a>.
 
 ## Clone and build
 
@@ -60,7 +62,8 @@ meaningful to the implementation.
 
 ### Sealed interfaces and records
 
-Every sum type in the library is a sealed interface with record implementations.
+Every sum type in the library is a sealed interface with record implementations —
+a deliberate design decision documented in <a href={`${base}adr/adr-003-sealed-interfaces-records`}>ADR-003 — Sealed interfaces + records as ADT representation.</a>
 This enables exhaustive pattern matching for callers and removes the need for `instanceof` chains.
 
 ```java


### PR DESCRIPTION
  Export base URL and replace GitHub raw links with internal <a> JSX
  links for ADR-001 and ADR-003, so they resolve correctly via the
  site's own ADR pages.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #359

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
