### PR TITLE
docs(adr): reference ADR-004 in Try javadoc, try guide, and contributing guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -45,6 +45,11 @@ import org.jspecify.annotations.Nullable;
  * {@link #fold(java.util.function.Function, java.util.function.Function) fold()},
  * or {@link #get()} rather than {@link #getOrNull()}.
  *
+ * <p>This deliberate asymmetry — {@code Try.Success} accepting {@code null} while
+ * {@code Result.Ok} rejects it — is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-004-null-in-try-vs-result/">
+ * ADR-004 — Try&lt;V&gt; allows Success(null); Result.Ok rejects null</a>.
+ *
  * @param <Value> the type of the successful value
  */
 @NullMarked

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -60,6 +60,10 @@ All public methods must be annotated with `@NullMarked` (via the package-info or
 Return `Option<T>` instead of a nullable type; accept `@Nullable` parameters only when the absence is
 meaningful to the implementation.
 
+> **Exception:** `Try.Success` deliberately accepts `null` as a valid value when produced by
+> `Try.run()` (void side-effects — `Void` has no instances in Java). `Result.Ok` rejects `null`.
+> This asymmetry is documented in <a href={`${base}adr/adr-004-null-in-try-vs-result`}>ADR-004 — Try allows Success(null); Result.Ok rejects null</a>.
+
 ### Sealed interfaces and records
 
 Every sum type in the library is a sealed interface with record implementations —

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -17,6 +17,8 @@ import {Content as SequenceTraverse}   from '../code/guide/try/sequence-traverse
 import {Content as TryCollectors}      from '../code/guide/try/try-collectors.mdx';
 import {Content as TriesFacade}        from '../code/guide/try/tries-facade.mdx';
 import {Content as NullHandling}       from '../code/guide/try/null-handling.mdx';
+
+export const base = import.meta.env.BASE_URL;
 import {Content as InteropConversions} from '../code/guide/try/interop-conversions.mdx';
 import {Content as PitfallsGet}        from '../code/guide/try/pitfalls-get.mdx';
 import {Content as PitfallsUseResult}  from '../code/guide/try/pitfalls-use-result.mdx';
@@ -156,6 +158,9 @@ for a `Try<Void>`, even on success — use `isSuccess()` or `fold()` instead.
 
 `sequence` uses `Collections.unmodifiableList` internally (not `List.copyOf`),
 so `null` elements in successful results are preserved.
+
+This asymmetry with `Result.Ok` — which rejects `null` — is a deliberate design decision
+documented in <a href={`${base}adr/adr-004-null-in-try-vs-result`}>ADR-004 — Try allows Success(null); Result.Ok rejects null</a>.
 
 <NullHandling/>
 


### PR DESCRIPTION
  Add ADR-004 link to the Try<V> class-level Javadoc (after the Success(null)
  explanation), to the "Null handling" section in the Try guide, and as a
  callout under "No null in the public API" in the contributing guide to make
  the deliberate Try/Result asymmetry discoverable.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #360

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
