### PR TITLE
docs(adr): reference ADR-005 in Guard javadoc and guard guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -30,6 +30,15 @@ import org.jspecify.annotations.Nullable;
  * username.check("alice"); // Valid("alice")
  * }</pre>
  *
+ * <h2>Error type</h2>
+ * <p>The error type is fixed as {@link NonEmptyList}{@code <String>} — human-readable messages
+ * accumulated across all failing guards. This design avoids requiring a {@code BinaryOperator<E>}
+ * for merging in {@link #and}/{@link #or}, and guarantees at least one error is always present.
+ * The trade-off is that typed domain error objects require working directly with
+ * {@link Validated}{@code <E, A>} instead. This decision is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-005-guard-error-type/">
+ * ADR-005 — Guard&lt;T&gt; accumulates errors as a fixed NonEmptyList&lt;String&gt;</a>.
+ *
  * <h2>Composition semantics</h2>
  * <ul>
  *   <li>{@link #and(Guard) and} — both guards must pass; errors from all failing guards are

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -12,6 +12,8 @@ import {Content as Negate}           from '../code/guide/guard/negate.mdx';
 import {Content as Interop}          from '../code/guide/guard/interop.mdx';
 import {Content as RealWorldExample} from '../code/guide/guard/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`GuardSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/GuardSample.java)
 
 ## What is Guard&lt;T&gt;?
@@ -21,6 +23,10 @@ a predicate over `T` with an associated error message.
 Applying a guard via `check(value)` returns a
 `Validated<NonEmptyList<String>, T>` — `Valid(value)` when the rule passes,
 or `Invalid(errors)` when it fails.
+
+The error type is fixed as `NonEmptyList<String>` — this keeps composition simple (no external
+`Monoid<E>` needed for `and`/`or`) and guarantees at least one error is always present. This
+design decision is documented in <a href={`${base}adr/adr-005-guard-error-type`}>ADR-005 — Guard&lt;T&gt; accumulates errors as a fixed NonEmptyList&lt;String&gt;</a>.
 
 Guards are the composable building block for [`Validated`](validated) pipelines.
 Instead of writing repeated `if`/`Validated.invalidNel(...)` branches, define each


### PR DESCRIPTION
  Add an "Error type" section to the Guard<T> class-level Javadoc explaining
  why the error type is fixed as NonEmptyList<String> and linking to ADR-005.
  Add the same rationale and link to the "What is Guard<T>?" section of the
  guard developer guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #365

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Guard library documentation with clarified error handling behavior and added reference to the architecture decision record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->