### PR TITLE
docs(adr): reference ADR-006 in Validated javadoc and validated guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Validated.java
+++ b/core/lib/src/main/java/dmx/fun/Validated.java
@@ -24,6 +24,11 @@ import org.jspecify.annotations.Nullable;
  * This makes it ideal for form/DTO validation where all errors should be reported at once.
  * Sequential fail-fast composition is still available through {@link #flatMap}.
  *
+ * <p>The deliberate co-existence of both types — {@code Validated} for accumulation and
+ * {@link Result} for fail-fast — is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-006-validated-vs-result/">
+ * ADR-006 — Validated (error accumulation) vs Result (fail-fast)</a>.
+ *
  * <p>This interface is {@link NullMarked}: all types are non-null by default.
  *
  * @param <E> the type of the error contained in an invalid result

--- a/site/src/data/guide/validated.mdx
+++ b/site/src/data/guide/validated.mdx
@@ -18,6 +18,8 @@ import {Content as Combining34}          from '../code/guide/validated/combining
 import {Content as PitfallsFlatMap}     from '../code/guide/validated/pitfalls-flatmap.mdx';
 import {Content as RealWorldExample}    from '../code/guide/validated/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`ValidatedSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ValidatedSample.java)
 
 ## What is Validated&lt;E, A&gt;?
@@ -159,6 +161,8 @@ See the [Combining Types](combining-types) page for the full conversion matrix.
 | Wrap throwing legacy code                                | `Try`       |
 | Independent field validations (form, config)             | `Validated` |
 | Pipeline where each step feeds the next                  | `Result`    |
+
+The deliberate co-existence of both types is documented in <a href={`${base}adr/adr-006-validated-vs-result`}>ADR-006 — Validated (error accumulation) vs Result (fail-fast)</a>.
 
 ## Common pitfalls
 


### PR DESCRIPTION
  Add ADR-006 link to the Validated<E,A> class-level Javadoc after the
  "Unlike Result (fail-fast)" paragraph, and to the "Validated vs Result —
  when to use each" section of the validated developer guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #364

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
