### PR TITLE
docs(adr): correct ADR-007 and reference it in Either javadoc and guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Either.java
+++ b/core/lib/src/main/java/dmx/fun/Either.java
@@ -21,6 +21,11 @@ import org.jspecify.annotations.NullMarked;
  * the <em>right</em> side. Use {@link #swap()} to flip the sides when you need
  * to operate on the left.
  *
+ * <p>This semantic neutrality — and the decision to keep right-biased operations
+ * without error/success connotation — is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-007-either-neutral/">
+ * ADR-007 — Either as a neutral type with no directional bias</a>.
+ *
  * <p>This interface is {@code @NullMarked}: all values — left and right — are
  * non-null by default.
  *

--- a/docs/adr/ADR-007-either-neutral.md
+++ b/docs/adr/ADR-007-either-neutral.md
@@ -7,23 +7,26 @@ date: 2026-05-05
 
 ## Context
 
-In Haskell and Scala, `Either` is right-biased: `map`/`flatMap` operate on the right side. dmx-fun includes `Either<L, R>` but must decide whether to adopt that bias or remain neutral.
+In Haskell and Scala, `Either` is right-biased: `map`/`flatMap` operate on the right side. dmx-fun includes `Either<L, R>` but must decide whether to adopt that bias and what semantic contract to assign to each side.
 
 ## Decision
 
-`Either<L, R>` in dmx-fun is **neutral** — it does not expose `map`/`flatMap`. It serves as an interoperability and transport type, not as a functional monad.
+`Either<L, R>` in dmx-fun is **semantically neutral**: neither side carries error or success connotation — both `Left` and `Right` are equally legitimate outcomes. Operations (`map`, `mapLeft`, `flatMap`) follow the right-bias convention from Haskell/Scala for familiarity, but `Either` is not intended as a primary error-handling monad.
+
+When one side represents an error, use `Result<V, E>` instead — it is semantically opinionated and offers richer recovery operations (`recover`, `recoverWith`, `flatMapError`).
 
 ## Consequences
 
 **Positive:**
 - Avoids semantic ambiguity: if `L` represents an error, use `Result`; if `R` is success, use `Result` or `Try`.
-- Forces the user to convert to a type with explicit semantics (`toResult()`, `toTry()`) in order to operate functionally.
+- Right-biased operations (`map`, `flatMap`) are familiar to FP practitioners without implying error semantics.
 - `Either` remains useful as a return type in APIs that need two symmetric cases with no error/success connotation.
 
 **Negative / tradeoffs:**
-- Users coming from Scala/Haskell expect `map`/`flatMap` on `Either`.
-- Some conversions require an extra step.
+- Users coming from Scala/Haskell may be surprised that `Either` is not the primary monad for error handling.
+- Some conversions require an extra step (`toResult()`, `toTry()`).
 
 ## Alternatives considered
 
-- **Right-biased with `map`/`flatMap`:** introduces redundancy with `Result` and adds confusion about when to use each type.
+- **Right-biased with full error-handling semantics:** introduces redundancy with `Result` and adds confusion about when to use each type.
+- **Fully neutral (no `map`/`flatMap`):** would prevent integration into functional pipelines — discarded because it makes `Either` too limited as a transport type.

--- a/site/src/data/guide/either.mdx
+++ b/site/src/data/guide/either.mdx
@@ -13,6 +13,8 @@ import {Content as SideEffects}        from '../code/guide/either/side-effects.m
 import {Content as InteropConversions} from '../code/guide/either/interop-conversions.mdx';
 import {Content as RealWorldExample}   from '../code/guide/either/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`EitherSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/EitherSample.java)
 
 ## What is Either&lt;L, R&gt;?
@@ -30,6 +32,8 @@ neither should be labelled an error.
 
 By convention, `map`, `flatMap`, and related operations act on the **right** side.
 Use `swap()` to flip the sides when you need to operate on the left.
+
+This design — semantically neutral but right-biased for operations — is documented in <a href={`${base}adr/adr-007-either-neutral`}>ADR-007 — Either as a neutral type with no directional bias</a>.
 
 **When to use `Either` vs other types:**
 


### PR DESCRIPTION
  ADR-007 incorrectly stated that Either does not expose map/flatMap.
  The actual implementation is right-biased (map, mapLeft, flatMap act on
  the right side per the Haskell/Scala convention) while remaining
  semantically neutral (no error/success connotation on either side).
  Corrected the Decision and Alternatives sections, then linked ADR-007
  from the Either<L,R> class-level Javadoc and the either developer guide.

  close #362

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #362

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Either documentation with enhanced clarification on semantic neutrality and right-biased operation conventions for better API understanding
  * Published new Architecture Decision Record (ADR-007) detailing Either usage semantics, guidance for choosing between Either and Result types, and available recovery operation options
  * Corrected documentation links to ensure proper reference navigation to architecture decision records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->