### PR TITLE
docs(adr): reference ADR-008 (jspecify null safety) in contributing and introduction guides

### DIFF
--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -59,6 +59,7 @@ The site is served under the `/dmx-fun/` base path to match GitHub Pages.
 All public methods must be annotated with `@NullMarked` (via the package-info or class-level annotation).
 Return `Option<T>` instead of a nullable type; accept `@Nullable` parameters only when the absence is
 meaningful to the implementation.
+The choice of jspecify as the null-safety annotation library is documented in <a href={`${base}adr/adr-008-jspecify-null-safety`}>ADR-008 — jspecify (@NullMarked, @Nullable) for null safety</a>.
 
 > **Exception:** `Try.Success` deliberately accepts `null` as a valid value when produced by
 > `Try.run()` (void side-effects — `Void` has no instances in Java). `Result.Ok` rejects `null`.

--- a/site/src/data/guide/introduction.mdx
+++ b/site/src/data/guide/introduction.mdx
@@ -19,8 +19,8 @@ precisely scoped types that eliminate the most common sources of runtime
 surprises: null references, swallowed exceptions, and silent partial failures.
 
 The library depends on **[JSpecify](https://jspecify.dev/)** for its null-safety
-annotations (`@NullMarked`). An optional `fun-jackson` module adds JSON
-serialization for all types.
+annotations (`@NullMarked`) — see <a href={`${base}adr/adr-008-jspecify-null-safety`}>ADR-008</a> for the rationale.
+An optional `fun-jackson` module adds JSON serialization for all types.
 
 ## Core philosophy
 


### PR DESCRIPTION
  Add a link to ADR-008 in the "No null in the public API" section of the
  contributing guide, and inline next to the existing JSpecify mention in
  the introduction guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #363

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide with clarified null-safety annotation standards
  * Enhanced introduction documentation with improved formatting for null-safety information and reference materials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->