### PR TITLE
docs(adr): reference ADR-009 (unmodifiableList in Try) in Try javadoc and guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -1048,6 +1048,14 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     /**
      * A typed container holding the two partitions produced by {@link #partitioningBy()}.
      *
+     * <p>The {@code successes} list uses {@link Collections#unmodifiableList} over a new
+     * {@link ArrayList} (not {@link java.util.List#copyOf}) so that {@code null} values
+     * produced by {@link #run(CheckedRunnable) Try.run(...)} are preserved. The same
+     * strategy applies in {@link #sequence(Iterable)}, {@link #traverse(Iterable, java.util.function.Function)},
+     * and {@link #toList()}. The rationale is documented in
+     * <a href="https://domix.github.io/dmx-fun/adr/adr-009-unmodifiable-list-try/">
+     * ADR-009 — unmodifiableList instead of List.copyOf in Try</a>.
+     *
      * @param <V>       the value type of the {@code Success} elements
      * @param successes an unmodifiable list of values from {@code Success} elements, in encounter order
      * @param failures  an unmodifiable list of causes from {@code Failure} elements, in encounter order

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -156,8 +156,10 @@ Call `toTryPartition()` to obtain the underlying `Try.Partition<V>` when needed.
 `null`. This has one important consequence: `toOption()` always returns `None`
 for a `Try<Void>`, even on success — use `isSuccess()` or `fold()` instead.
 
-`sequence` uses `Collections.unmodifiableList` internally (not `List.copyOf`),
+`sequence`, `traverse`, `toList()`, and `Try.Partition` all use
+`Collections.unmodifiableList` internally (not `List.copyOf`),
 so `null` elements in successful results are preserved.
+This implementation choice is documented in <a href={`${base}adr/adr-009-unmodifiable-list-try`}>ADR-009 — unmodifiableList instead of List.copyOf in Try</a>.
 
 This asymmetry with `Result.Ok` — which rejects `null` — is a deliberate design decision
 documented in <a href={`${base}adr/adr-004-null-in-try-vs-result`}>ADR-004 — Try allows Success(null); Result.Ok rejects null</a>.


### PR DESCRIPTION
  ADR-009 explains why Try.Partition, sequence, traverse, and toList use
  Collections.unmodifiableList over List.copyOf — to preserve null values
  produced by Try.run(). Added the ADR-009 link to the Partition record
  Javadoc in Try.java and to the "Null handling" section of the Try guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #368

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
