### PR TITLE
docs(adr): reference ADR-010 (Gatherer for sequence/traverse) in Option, Result, and Try guides

### DIFF
--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -30,6 +30,8 @@ import {Content as PitfallsNested}         from '../code/guide/option/pitfalls-n
 import {Content as PitfallsNullMapper}     from '../code/guide/option/pitfalls-null-mapper.mdx';
 import {Content as RealWorldExample}       from '../code/guide/option/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`OptionSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/OptionSample.java)
 
 ## What is Option&lt;T&gt;?
@@ -170,7 +172,8 @@ _from_ the first value.
 ### Collecting a list with `sequence`
 
 Converts a `List<Option<T>>` into an `Option<List<T>>`.
-Returns `None` as soon as any element is `None`.
+Returns `None` as soon as any element is `None`. The stream-based overload uses
+`Stream.gather(Gatherer.ofSequential(...))` for true short-circuit (see <a href={`${base}adr/adr-010-gatherer-sequence-traverse`}>ADR-010</a>).
 
 <ComposingSequence/>
 

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -23,6 +23,8 @@ import {Content as GroupingBy}           from '../code/guide/result/grouping-by.
 import {Content as ResultsFacade}        from '../code/guide/result/results-facade.mdx';
 import {Content as RealWorldExample}     from '../code/guide/result/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`ResultSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/ResultSample.java)
 
 ## What is Result&lt;V, E&gt;?
@@ -126,7 +128,8 @@ For a simple static fallback without inspecting the error, use `orElse`.
 
 Both operations apply **fail-fast semantics**: they stop at the first
 `Err` and return it immediately, without consuming the rest of the stream.
-This is implemented internally with a Stream Gatherer.
+This is implemented with `Stream.gather(Gatherer.ofSequential(...))` (finalized in Java 24)
+to achieve true short-circuit — a design decision documented in <a href={`${base}adr/adr-010-gatherer-sequence-traverse`}>ADR-010 — Gatherer for sequence/traverse with true short-circuit</a>.
 
 <SequenceTraverse/>
 

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -116,7 +116,9 @@ exception. Typed overloads match only a specific exception subtype.
 ## sequence and traverse
 
 Both operations apply **fail-fast semantics**: they stop at the first `Failure`
-and return it immediately.
+and return it immediately, without consuming the rest of the stream.
+This is implemented with `Stream.gather(Gatherer.ofSequential(...))` (finalized in Java 24)
+to achieve true short-circuit — a design decision documented in <a href={`${base}adr/adr-010-gatherer-sequence-traverse`}>ADR-010 — Gatherer for sequence/traverse with true short-circuit</a>.
 
 <SequenceTraverse/>
 


### PR DESCRIPTION
  ADR-010 explains why sequence/traverse use Stream.gather(Gatherer.ofSequential(...))
  for true short-circuit instead of reduce, forEach, or Collector. Added the ADR-010
  link to the "sequence and traverse" section of the Result and Try guides, and to the
  "sequence" section of the Option guide. Added export const base to option.mdx and
  result.mdx which lacked it.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #366

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
