### PR TITLE
docs(adr): reference ADR-011 (Guard as @FunctionalInterface) in Guard javadoc and guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -10,10 +10,16 @@ import org.jspecify.annotations.Nullable;
 /**
  * A named, composable predicate that produces a {@link Validated} result when applied to a value.
  *
- * <p>{@code Guard<T>} is a functional interface whose single abstract method is
+ * <p>{@code Guard<T>} is a {@code @FunctionalInterface} whose single abstract method is
  * {@link #check(Object) check(T)}, which returns
  * {@code Validated<NonEmptyList<String>, T>}: {@code Valid(value)} when the predicate passes,
  * or {@code Invalid(errors)} when it fails.
+ * All composition operators ({@link #and}, {@link #or}, {@link #negate()}, {@link #andThen},
+ * {@link #contramap}) are {@code default} methods, so guards can be defined as lambdas and
+ * composed without inheritance. The choice to use {@code @FunctionalInterface} with
+ * {@code default} methods rather than an abstract class is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-011-guard-functional-interface/">
+ * ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods</a>.
  *
  * <p>Guards are designed to be defined once and reused across validation pipelines, eliminating
  * the repetitive {@code if}/{@link Validated#invalidNel(Object)} pattern:

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -23,6 +23,9 @@ a predicate over `T` with an associated error message.
 Applying a guard via `check(value)` returns a
 `Validated<NonEmptyList<String>, T>` — `Valid(value)` when the rule passes,
 or `Invalid(errors)` when it fails.
+All composition operators (`and`, `or`, `negate`, `andThen`, `contramap`) are `default` methods
+on the interface, so guards can be defined as lambdas and composed without inheritance.
+This design decision is documented in <a href={`${base}adr/adr-011-guard-functional-interface`}>ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods</a>.
 
 The error type is fixed as `NonEmptyList<String>` — this keeps composition simple (no external
 `Monoid<E>` needed for `and`/`or`) and guarantees at least one error is always present. This


### PR DESCRIPTION
  ADR-011 documents the decision to model Guard<T> as a @FunctionalInterface
  with default methods for composition rather than an abstract class. Added
  the ADR-011 link to the class-level Javadoc of Guard.java and to the
  "What is Guard<T>?" section of the Guard developer guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #367

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
