### PR TITLE
docs(adr): reference ADR-012 (Lazy double-checked locking) in Lazy javadoc and guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Lazy.java
+++ b/core/lib/src/main/java/dmx/fun/Lazy.java
@@ -13,8 +13,15 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>The supplier passed to {@link #of(Supplier)} is not invoked until the first call to
  * {@link #get()}. Subsequent calls return the cached result without invoking the supplier again.
- * Memoization is thread-safe: the supplier is guaranteed to be called at most once even under
- * concurrent access.
+ * Memoization is thread-safe via a {@code volatile} {@link Try}{@code <T>} state field and
+ * double-checked locking: the first read is lock-free; if the state is {@code null}, a
+ * {@code synchronized} block is entered and the state is checked again before evaluating
+ * the supplier. Both successful values and supplier exceptions are stored in the state as a
+ * {@link Try}, so any exception thrown during evaluation is memoized and rethrown on every
+ * subsequent {@link #get()} call without re-invoking the supplier. The thread-safety design
+ * is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-012-lazy-double-checked-locking/">
+ * ADR-012 — Lazy&lt;T&gt; with volatile Try&lt;T&gt; and double-checked locking</a>.
  *
  * <p>This type is {@code @NullMarked}: the supplier must return a non-null value.
  * Use {@code Lazy<Option<T>>} to model a lazily evaluated optional result.

--- a/site/src/data/guide/lazy.mdx
+++ b/site/src/data/guide/lazy.mdx
@@ -13,6 +13,8 @@ import {Content as PitfallsSideEffects} from '../code/guide/lazy/pitfalls-side-e
 import {Content as PitfallsGetOrElse}  from '../code/guide/lazy/pitfalls-get-or-else.mdx';
 import {Content as RealWorldExample}   from '../code/guide/lazy/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`LazySample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/LazySample.java)
 
 ## What is Lazy&lt;T&gt;?
@@ -33,6 +35,7 @@ Use it when:
 **at most once** even under concurrent access. Both the successful value and any
 thrown exception are memoized — subsequent `get()` calls rethrow the same exception
 without re-invoking the supplier.
+The thread-safety design is documented in <a href={`${base}adr/adr-012-lazy-double-checked-locking`}>ADR-012 — Lazy&lt;T&gt; with volatile Try&lt;T&gt; and double-checked locking</a>.
 
 **Null policy**: the supplier must return a non-null value (`@NullMarked`).
 Use `Lazy<Option<T>>` to model a lazily evaluated result that may be absent.


### PR DESCRIPTION
  ADR-012 documents the decision to use a volatile Try<T> state field with
  double-checked locking in Lazy<T> to guarantee at-most-once supplier
  evaluation under concurrent access while keeping post-evaluation reads
  lock-free. Expanded the class-level Javadoc of Lazy.java to describe the
  mechanism in full and link to ADR-012. Added export const base and the
  ADR-012 link to the "Thread-safety" paragraph of the Lazy developer guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #369

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
