### PR TITLE
docs(adr): reference ADR-013 (Try.withTimeout virtual threads) in Try javadoc and guide

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -196,7 +196,11 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * e.g. {@code "Operation timed out after 500000000ns"}. Nanosecond precision is used so
      * that sub-millisecond timeouts are honoured without truncation.
      *
-     * <p><b>Requires Java 21+</b> (virtual threads).
+     * <p><b>Requires Java 21+</b> (virtual threads). The decision to use
+     * {@code Thread.ofVirtual()} over a platform-thread {@code ExecutorService} or a shared
+     * {@code CompletableFuture} pool is documented in
+     * <a href="https://domix.github.io/dmx-fun/adr/adr-013-try-with-timeout-virtual-threads/">
+     * ADR-013 — Try.withTimeout uses virtual threads (Thread.ofVirtual())</a>.
      *
      * <p>Example:
      * <pre>{@code

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -213,6 +213,8 @@ and enforces the time limit via `Future.get(timeout, unit)`.
 **Requires Java 21+** (virtual threads). Because `Try` is an immutable value type
 (already computed), timeout applies at creation time — use the static factory
 rather than trying to retroactively time-limit an existing `Try`.
+The choice to use `Thread.ofVirtual()` over a platform-thread `ExecutorService` or a shared
+`CompletableFuture` pool is documented in <a href={`${base}adr/adr-013-try-with-timeout-virtual-threads`}>ADR-013 — Try.withTimeout uses virtual threads (Thread.ofVirtual())</a>.
 
 <Timeout/>
 


### PR DESCRIPTION
  ADR-013 documents the decision to use Thread.ofVirtual() over a platform-thread
  ExecutorService or a shared CompletableFuture pool for Try.withTimeout. Added
  the ADR-013 link to the withTimeout method Javadoc in Try.java and to the
  "Time-bounded execution" section of the Try developer guide.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #370

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
