### PR TITLE
docs(adr): reference ADR-014 (facade collectors) in Option, Result, and Try guides

### DIFF
--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -190,6 +190,7 @@ every element is `Some`, empty if any element is `None`.
 `Options` is a single discoverable entry point for all `Stream<Option<T>>` collectors —
 analogous to `java.util.stream.Collectors`. Import `dmx.fun.Options` instead of
 remembering which collector lives on which type.
+The decision to provide companion facade classes as pure-delegation entry points is documented in <a href={`${base}adr/adr-014-facade-collectors`}>ADR-014 — Facade collectors (Results, Options, Tries) as a single entry point</a>.
 
 | Method                       | Returns                     | Semantics                                              |
 |------------------------------|-----------------------------|--------------------------------------------------------|

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -157,6 +157,7 @@ The downstream variant `groupingBy(classifier, downstream)` applies a
 `Results` is a single discoverable entry point for all `Stream<Result<V,E>>` collectors —
 analogous to `java.util.stream.Collectors`. Import `dmx.fun.Results` instead of
 remembering which collector lives on which type.
+The decision to provide companion facade classes as pure-delegation entry points is documented in <a href={`${base}adr/adr-014-facade-collectors`}>ADR-014 — Facade collectors (Results, Options, Tries) as a single entry point</a>.
 
 | Method                                  | Returns                         | Semantics                                        |
 |-----------------------------------------|---------------------------------|--------------------------------------------------|

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -141,6 +141,7 @@ to achieve true short-circuit — a design decision documented in <a href={`${ba
 `Tries` is a single discoverable entry point for all `Stream<Try<V>>` collectors —
 analogous to `java.util.stream.Collectors`. Import `dmx.fun.Tries` instead of
 remembering which collector lives on which type.
+The decision to provide companion facade classes as pure-delegation entry points is documented in <a href={`${base}adr/adr-014-facade-collectors`}>ADR-014 — Facade collectors (Results, Options, Tries) as a single entry point</a>.
 
 | Method                    | Returns                   | Semantics                                          |
 |---------------------------|---------------------------|----------------------------------------------------|


### PR DESCRIPTION
  ADR-014 documents the decision to provide Results, Tries, and Options as
  companion facade classes — final, non-instantiable, pure-delegation entry
  points for stream collector factories. Added the ADR-014 link to the
  "Collector facade" intro paragraph in each of the three guide pages.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #371

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Collector facade documentation with clarifications across Options, Results, and Tries sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->