### PR TITLE
docs(adr): ADR-015 — Option<T> as a custom type instead of java.util.Optional

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Option.java
+++ b/core/lib/src/main/java/dmx/fun/Option.java
@@ -23,10 +23,19 @@ import org.jspecify.annotations.Nullable;
 /**
  * A sealed interface representing an optional value with two possible states:
  * either a value is present ("Some") or absent ("None").
- * <p>
- * This interface provides a flexible alternative to {@link Optional},
- * integrating functional-style operations for working with optional values in a more
- * expressive and composable manner.
+ *
+ * <p>Unlike {@link Optional}, which is a {@code final} class, {@code Option} is a
+ * {@code sealed interface} with two record variants — {@link Some} and {@link None} —
+ * enabling exhaustive pattern matching: the compiler enforces that both states are handled
+ * in a switch expression without a wildcard arm.
+ *
+ * <p>{@code Option<T>} participates in the library's type graph with first-class
+ * conversion methods: {@link #toResult(Object)}, {@link #toTry(Supplier)},
+ * {@link #toEither(Object)}. The reverse conversions are symmetric:
+ * {@link #fromOptional(Optional)}, {@link #fromResult(Result)}, {@link #fromTry(Try)}.
+ * The design rationale is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-015-option-vs-optional/">
+ * ADR-015 — Option&lt;T&gt; as a custom type instead of java.util.Optional</a>.
  *
  * <p>This interface is {@link NullMarked}: all types are non-null by default.
  *

--- a/docs/adr/ADR-015-option-vs-optional.md
+++ b/docs/adr/ADR-015-option-vs-optional.md
@@ -1,0 +1,33 @@
+---
+number: 15
+title: "Option<T> as a custom type instead of java.util.Optional"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+Java provides `java.util.Optional<T>` as a standard absent-value container. dmx-fun must decide whether to use it directly or provide a custom `Option<T>` type.
+
+## Decision
+
+Provide a custom `Option<T>` sealed interface with `Some<T>` and `None<T>` record variants, rather than wrapping or extending `java.util.Optional`.
+
+## Consequences
+
+**Positive:**
+
+- **Exhaustive pattern matching.** `Optional` is a `final` class; `Option` is a `sealed interface`. The compiler enforces that both `Some` and `None` branches are handled in a switch expression — no wildcard arm needed, unlike `Optional.isPresent()` checks.
+- **Type-graph integration.** `Option<T>` participates in the library's type graph with first-class conversion methods: `toResult()`, `toTry()`, `toEither()`. The reverse conversions are symmetric: `Option.fromOptional()`, `Option.fromResult()`, `Option.fromTry()`.
+- **Consistent pipeline API.** `map`, `flatMap`, `filter`, `zip`, `fold`, and `sequence` all return `Option<T>`, keeping pipelines within the library's type system.
+- **Singleton absence value.** `Option.none()` returns a pre-allocated, cast-safe singleton (`None.INSTANCE`), avoiding repeated allocations of the absent case.
+
+**Negative / tradeoffs:**
+
+- Users must convert at JDK API boundaries: `Option.fromOptional(opt)` / `option.toOptional()`.
+- Two absent-value types in the same codebase can be confusing without clear conventions; the rule is: use `Option<T>` within library and domain code, convert to `Optional` only at JDK or framework API boundaries.
+
+## Alternatives considered
+
+- **Use `java.util.Optional` directly:** no custom type needed, but `Optional` is a `final` class — not a sealed interface — so exhaustive compile-time matching is impossible. It also has no integration with `Result`, `Try`, or `Either`, and its `get()` method throws `NoSuchElementException` without statically enforcing a prior `isPresent()` check.
+- **Wrap `Optional` in `Option<T>`:** adds indirection without benefit; the inner `Optional` is redundant once the sealed interface is in place.

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -46,6 +46,7 @@ Unlike a raw `null`, an `Option` is explicit in the type system:
 callers are forced to handle both the present and absent cases.
 Unlike `java.util.Optional`, `Option` is a _sealed interface_
 and can be used in switch expressions with exhaustive pattern matching.
+The decision to provide a custom `Option<T>` type instead of reusing `java.util.Optional` is documented in <a href={`${base}adr/adr-015-option-vs-optional`}>ADR-015 — Option&lt;T&gt; as a custom type instead of java.util.Optional</a>.
 
 ## Creating instances
 


### PR DESCRIPTION
  - Add docs/adr/ADR-015-option-vs-optional.md: documents the decision to
    provide a custom sealed-interface Option<T> with Some/None record
    variants instead of java.util.Optional; corrects the issue draft by
    removing the inaccurate claim that Optional.empty() allocates per call
    (it is also a singleton in modern JDK) and by omitting toValidated()
    which does not exist in Option
  - Expand Option class-level Javadoc to explain the sealed-interface
    advantage over Optional, list conversion methods, and link to ADR-015
  - Reference ADR-015 in the option.mdx guide "What is Option<T>?" section

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #410

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
