### PR TITLE
docs(adr): ADR-016 — Try.toList() collector consumes entire stream while sequence is fail-fast

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -1101,7 +1101,10 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * <p><strong>Note:</strong> this Collector is <em>not</em> fail-fast. All stream elements
      * are always consumed. The accumulator records the first {@code Failure} cause and skips
      * subsequent values; the finisher returns that failure, or {@code Success(List)} if all
-     * elements succeeded.
+     * elements succeeded. Use {@link #sequence(Stream)} for true short-circuit behaviour.
+     * The intentional difference between this collector and {@code sequence} is documented in
+     * <a href="https://domix.github.io/dmx-fun/adr/adr-016-tolist-vs-sequence-consumption/">
+     * ADR-016 — Try.toList() collector consumes the entire stream while sequence is fail-fast</a>.
      *
      * <p>Example:
      * <pre>{@code
@@ -1194,6 +1197,13 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      * If any element is a {@code Failure}, that failure is returned immediately (fail-fast) and
      * the stream is closed. If all elements are {@code Success}, returns {@code Success} containing
      * an unmodifiable list of values in encounter order.
+     *
+     * <p>This operation is fail-fast: it uses a {@link java.util.stream.Gatherer} (finalized in
+     * Java 24, JEP 485) that returns {@code false} from the integrator on the first {@code Failure},
+     * causing the pipeline to stop consuming elements immediately. This contrasts with
+     * {@link #toList()}, which always consumes the entire stream. The difference is documented in
+     * <a href="https://domix.github.io/dmx-fun/adr/adr-016-tolist-vs-sequence-consumption/">
+     * ADR-016 — Try.toList() collector consumes the entire stream while sequence is fail-fast</a>.
      *
      * @param <V>   the value type
      * @param tries the stream of Try values; must not be {@code null} and must not contain {@code null} elements

--- a/docs/adr/ADR-016-tolist-vs-sequence-consumption.md
+++ b/docs/adr/ADR-016-tolist-vs-sequence-consumption.md
@@ -1,0 +1,46 @@
+---
+number: 16
+title: "Try.toList() collector consumes the entire stream while sequence is fail-fast"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+`Try` provides two ways to aggregate a stream of `Try<V>` into a single `Try<List<V>>`:
+`Try.toList()` (a `Collector`) and `Try.sequence(Stream)` (using a `Gatherer`, see ADR-010).
+Both return the first `Failure` encountered, but their stream-consumption semantics differ.
+
+## Decision
+
+`Try.toList()` (and `Try.partitioningBy()`) always consume every element of the stream.
+They cannot short-circuit because the `Collector` contract — `Collector.of(supplier, accumulator, combiner, finisher)` — calls the accumulator for every element; there is no mechanism to signal early termination.
+
+`Try.sequence` uses a `Gatherer` (finalized in Java 24, JEP 485) and stops processing at
+the first `Failure` by returning `false` from the integrator. Both behaviors are intentional
+and explicitly documented.
+
+## Consequences
+
+**Positive:**
+
+- `toList()` and `partitioningBy()` support parallel streams: their combiner merges partial
+  results from multiple threads, which `Gatherer.ofSequential` cannot do.
+- `sequence` gives true fail-fast behavior with minimal resource usage when streams are large
+  or when individual `Try` computations are expensive.
+- The behavioral difference is explicit in the API rather than hidden in an implementation
+  detail: `toList()` Javadoc states "this Collector is *not* fail-fast".
+
+**Negative / tradeoffs:**
+
+- Two APIs with the same apparent purpose but different consumption semantics can surprise
+  callers who assume all "first-failure" APIs short-circuit.
+- Callers must consciously choose between them based on whether early termination matters.
+
+## Alternatives considered
+
+- **Make `toList()` fail-fast:** not possible within the `Collector` contract; the accumulator
+  is called for every element regardless. Switching to a `Gatherer` would lose parallel-stream
+  compatibility and `Stream.collect` integration.
+- **Remove `toList()` and provide only `sequence`:** loses parallel-stream support and the
+  standard `Stream.collect(...)` call site that many Java developers prefer.

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -134,6 +134,9 @@ to achieve true short-circuit — a design decision documented in <a href={`${ba
 
 `Try.Partition<V>` is a record with two unmodifiable lists.
 
+**Important:** `toList()` always consumes the entire stream — the `Collector` contract has no early-termination mechanism. Use `sequence` when you need true fail-fast behaviour on large or expensive streams.
+The intentional difference between `toList()` and `sequence` is documented in <a href={`${base}adr/adr-016-tolist-vs-sequence-consumption`}>ADR-016 — Try.toList() collector consumes the entire stream while sequence is fail-fast</a>.
+
 <TryCollectors/>
 
 ## Collector facade: Tries


### PR DESCRIPTION
  - Add docs/adr/ADR-016-tolist-vs-sequence-consumption.md: documents the
    intentional difference between Try.toList() (Collector — always consumes
    all elements, supports parallel streams) and Try.sequence (Gatherer —
    true fail-fast via integrator returning false); references ADR-010 for
    the Gatherer design and Java 24 / JEP 485
  - toList() Javadoc: add cross-reference to sequence and ADR-016 link
  - sequence(Stream) Javadoc: add explanation of the Gatherer short-circuit
    mechanism (Java 24, JEP 485) and ADR-016 link
  - try.mdx: add Important note in "Stream collectors" section clarifying
    that toList() always traverses the full stream, with ADR-016 link

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #411

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
