### PR TITLE
docs(adr): ADR-017 — Result.groupingBy returns Map<K, NonEmptyList<V>> instead of Map<K, List<V>>

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Result.java
+++ b/core/lib/src/main/java/dmx/fun/Result.java
@@ -880,7 +880,15 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     /**
      * Returns a {@link Collector} that groups stream elements by a key derived from each element.
      * Each group is collected into a {@link NonEmptyList}, making the non-emptiness of every
-     * group explicit in the type.
+     * group explicit in the type. A group that appears in the returned map always contains at least
+     * one element by construction — {@link NonEmptyList} encodes this invariant at the type level,
+     * eliminating the need for defensive {@code isEmpty()} checks.
+     *
+     * <p>The returned map preserves encounter order (backed by {@link java.util.LinkedHashMap}) and
+     * is unmodifiable. The rationale for using {@code NonEmptyList} instead of {@code List} is
+     * documented in
+     * <a href="https://domix.github.io/dmx-fun/adr/adr-017-groupingby-nonemptylist/">
+     * ADR-017 — Result.groupingBy returns Map&lt;K, NonEmptyList&lt;V&gt;&gt; instead of Map&lt;K, List&lt;V&gt;&gt;</a>.
      *
      * <p>Example:
      * <pre>{@code

--- a/docs/adr/ADR-017-groupingby-nonemptylist.md
+++ b/docs/adr/ADR-017-groupingby-nonemptylist.md
@@ -1,0 +1,49 @@
+---
+number: 17
+title: "Result.groupingBy returns Map<K, NonEmptyList<V>> instead of Map<K, List<V>>"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+`Result.groupingBy(classifier)` is a `Collector<V, ?, Map<K, NonEmptyList<V>>>` that groups
+any stream of values by a key derived from each element. The standard library equivalent —
+`Collectors.groupingBy` — returns `Map<K, List<V>>`. The value type for each group must be
+chosen between `List<V>` (matching the JDK convention) and a type that encodes the invariant
+that every group is non-empty.
+
+## Decision
+
+Each group in the returned map is typed as `NonEmptyList<V>` instead of `List<V>`.
+A group produced by `groupingBy` always contains at least one element by construction:
+if a key appears in the map, at least one stream element was classified under it.
+`NonEmptyList<V>` makes this invariant explicit and enforced at the type level.
+
+The downstream variant — `groupingBy(classifier, downstream)` — accepts a
+`Function<NonEmptyList<V>, R>` that transforms each group after grouping.
+The returned maps are **insertion-order** (backed by `LinkedHashMap`) and **unmodifiable**
+(wrapped with `Collections.unmodifiableMap`).
+
+## Consequences
+
+**Positive:**
+
+- The type system enforces a real invariant: callers never need to guard against empty groups.
+  Every `NonEmptyList<V>` in the map is guaranteed to have at least one element.
+- Consistent with the library's philosophy of making illegal states unrepresentable.
+- Callers can call `NonEmptyList.head()`, `NonEmptyList.tail()`, and other non-empty-aware
+  operations without defensive checks.
+
+**Negative / tradeoffs:**
+
+- Users who need a plain `List<V>` must call `nonEmptyList.toList()`.
+- `NonEmptyList<V>` is a library type; code passing the map to JDK APIs expecting `List<V>`
+  must convert, though `NonEmptyList` implements `SequencedCollection<T>`.
+
+## Alternatives considered
+
+- **`List<V>`:** matches `Collectors.groupingBy` signature but hides the non-empty invariant;
+  callers must defensively check `isEmpty()` even though it can never be true after grouping.
+- **`Collection<V>`:** even less precise; discards ordering guarantees provided by the
+  encounter-order-preserving `LinkedHashMap` accumulator.

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -144,6 +144,7 @@ two lists, consuming the entire stream.
 `NonEmptyList<V>` rather than `List<V>`, making the non-emptiness of every group
 explicit in the type. The returned `Map<K, NonEmptyList<V>>` is **insertion-order**
 (encounter order of the stream) and **unmodifiable**.
+The decision to use `NonEmptyList<V>` instead of `List<V>` is documented in <a href={`${base}adr/adr-017-groupingby-nonemptylist`}>ADR-017 — Result.groupingBy returns Map&lt;K, NonEmptyList&lt;V&gt;&gt; instead of Map&lt;K, List&lt;V&gt;&gt;</a>.
 
 The downstream variant `groupingBy(classifier, downstream)` applies a
 `Function<NonEmptyList<V>, R>` to each group after grouping, producing a


### PR DESCRIPTION
  - Add docs/adr/ADR-017-groupingby-nonemptylist.md: documents the decision
    to use NonEmptyList<V> as the group value type; corrects the issue draft
    by clarifying that the collector is Collector<V,?,Map<K,NonEmptyList<V>>>
    (operates on V directly, not Stream<Result<V,E>>), and notes that
    NonEmptyList implements SequencedCollection, not List, for the tradeoff
  - groupingBy(classifier) Javadoc: expand with the type-level invariant
    rationale, LinkedHashMap/unmodifiableMap implementation notes, and
    ADR-017 link
  - result.mdx: add ADR-017 link at the end of the groupingBy section

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #412

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
