### PR TITLE
fix(Result): null-check gaps, toOptional contract, and minor cleanup

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Result.java
+++ b/core/lib/src/main/java/dmx/fun/Result.java
@@ -265,7 +265,7 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     default <NewValue> Result<NewValue, Error> flatMap(Function<Value, Result<NewValue, Error>> mapper) {
         Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
-            case Ok<Value, Error> ok -> mapper.apply(ok.value());
+            case Ok<Value, Error> ok -> Objects.requireNonNull(mapper.apply(ok.value()), "mapper returned null");
             case Err<Value, Error> err -> Result.err(err.error());
         };
     }
@@ -315,10 +315,11 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param errorIfFalse the error to return if the predicate evaluates to false
      * @return the current result if it is not an Ok instance or the predicate evaluates to true,
      * otherwise a new error result with the specified error value
-     * @throws NullPointerException if {@code predicate} is {@code null}
+     * @throws NullPointerException if {@code predicate} or {@code errorIfFalse} is {@code null}
      */
     default Result<Value, Error> filter(Predicate<Value> predicate, Error errorIfFalse) {
         Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(errorIfFalse, "errorIfFalse");
         if (this instanceof Ok<Value, Error>(Value value)) {
             return predicate.test(value) ? this : Result.err(errorIfFalse);
         }

--- a/core/lib/src/main/java/dmx/fun/Result.java
+++ b/core/lib/src/main/java/dmx/fun/Result.java
@@ -223,8 +223,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param mapper     the function to apply to the value of the successful result
      * @return a new {@code Result} instance, containing the mapped value if the original instance
      * was successful, or the same error if the original instance was an error
+     * @throws NullPointerException if {@code mapper} is {@code null}
      */
     default <NewValue> Result<NewValue, Error> map(Function<Value, NewValue> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Ok<Value, Error> ok -> Result.ok(mapper.apply(ok.value()));
             case Err<Value, Error> err -> Result.err(err.error());
@@ -239,8 +241,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param mapper     the function to apply to the error of the erroneous result
      * @return a new {@code Result} instance, containing the transformed error if the original instance
      * was an error, or the same value if the original instance was successful
+     * @throws NullPointerException if {@code mapper} is {@code null}
      */
     default <NewError> Result<Value, NewError> mapError(Function<Error, NewError> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Ok<Value, Error> ok -> Result.ok(ok.value());
             case Err<Value, Error> err -> Result.err(mapper.apply(err.error()));
@@ -256,8 +260,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param mapper     the function to apply to the value of the successful {@code Result} to produce a new {@code Result}
      * @return a new {@code Result} instance returned by applying the mapping function to the value if the original instance
      * was successful, or the same error if the original instance was an error
+     * @throws NullPointerException if {@code mapper} is {@code null}
      */
     default <NewValue> Result<NewValue, Error> flatMap(Function<Value, Result<NewValue, Error>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Ok<Value, Error> ok -> mapper.apply(ok.value());
             case Err<Value, Error> err -> Result.err(err.error());
@@ -271,8 +277,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      *
      * @param action a {@link Consumer} that accepts the value contained in a successful result
      * @return the original {@code Result} instance
+     * @throws NullPointerException if {@code action} is {@code null}
      */
     default Result<Value, Error> peek(Consumer<Value> action) {
+        Objects.requireNonNull(action, "action");
         if (this instanceof Ok<Value, Error>(Value value)) {
             action.accept(value);
         }
@@ -286,8 +294,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      *
      * @param action a {@link Consumer} that accepts the error contained in an erroneous result
      * @return the original {@code Result} instance
+     * @throws NullPointerException if {@code action} is {@code null}
      */
     default Result<Value, Error> peekError(Consumer<Error> action) {
+        Objects.requireNonNull(action, "action");
         if (this instanceof Err<Value, Error>(Error error)) {
             action.accept(error);
         }
@@ -305,8 +315,10 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param errorIfFalse the error to return if the predicate evaluates to false
      * @return the current result if it is not an Ok instance or the predicate evaluates to true,
      * otherwise a new error result with the specified error value
+     * @throws NullPointerException if {@code predicate} is {@code null}
      */
     default Result<Value, Error> filter(Predicate<Value> predicate, Error errorIfFalse) {
+        Objects.requireNonNull(predicate, "predicate");
         if (this instanceof Ok<Value, Error>(Value value)) {
             return predicate.test(value) ? this : Result.err(errorIfFalse);
         }
@@ -323,8 +335,11 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param errorIfFalse a function to generate an error if the predicate evaluates to false.
      * @return a filtered result, returning the same instance if the predicate evaluates to true or the result is Err;
      * otherwise, returns an Err with the provided error value.
+     * @throws NullPointerException if {@code predicate} or {@code errorIfFalse} is {@code null}
      */
     default Result<Value, Error> filter(Predicate<Value> predicate, Function<Value, Error> errorIfFalse) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(errorIfFalse, "errorIfFalse");
         if (this instanceof Ok<Value, Error>(Value value)) {
             return predicate.test(value) ? this : Result.err(errorIfFalse.apply(value));
         }
@@ -396,20 +411,6 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
             return this;
         }
         return (Result<Value, Error>) Objects.requireNonNull(alternative.get(), "alternative returned null");
-    }
-
-    /**
-     * Returns this {@code Result} if it is {@code Ok}; otherwise evaluates the given supplier
-     * and returns its result. The supplier is <em>not</em> called when this instance is {@code Ok}.
-     *
-     * @param fallback a lazy supplier of an alternative {@code Result} evaluated only on {@code Err};
-     *                 must not return {@code null}
-     * @return this instance if {@code Ok}, or the result of {@code fallback.get()} if {@code Err}
-     * @throws NullPointerException if {@code fallback} is null or if {@code fallback} returns {@code null}
-     */
-    default Result<Value, Error> or(Supplier<Result<Value, Error>> fallback) {
-        Objects.requireNonNull(fallback, "fallback");
-        return this instanceof Ok ? this : Objects.requireNonNull(fallback.get(), "fallback returned null");
     }
 
     /**
@@ -553,7 +554,8 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     /**
      * Converts this {@code Result} to a standard {@link Optional Optional&lt;V&gt;}.
      *
-     * <p>{@link Result.Ok Ok(v)} maps to {@code Optional.ofNullable(v)};
+     * <p>{@link Result.Ok Ok(v)} maps to {@code Optional.of(v)} — the value is guaranteed non-null
+     * by {@link Ok}'s compact constructor;
      * {@link Result.Err Err(e)} maps to {@link Optional#empty()}, silently discarding the
      * error value. This is a <em>partial</em> inverse of
      * {@link #fromOptional(Optional) fromOptional}: while {@code fromOptional} can produce
@@ -574,7 +576,7 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      */
     default Optional<Value> toOptional() {
         return switch (this) {
-            case Ok<Value, Error>  ok  -> Optional.ofNullable(ok.value());
+            case Ok<Value, Error>  ok  -> Optional.of(ok.value());
             case Err<Value, Error> _   -> Optional.empty();
         };
     }
@@ -588,9 +590,11 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * @param errorIfNone The error value to return if the {@link Option} is empty.
      * @return A {@link Result} that wraps the value from the {@link Option} if it is defined,
      * or an error containing {@code errorIfNone} if the {@link Option} is empty.
+     * @throws NullPointerException if {@code opt} or {@code errorIfNone} is {@code null}
      */
     static <V, E> Result<V, E> fromOption(Option<? extends V> opt, E errorIfNone) {
         Objects.requireNonNull(opt, "opt");
+        Objects.requireNonNull(errorIfNone, "errorIfNone");
         return switch (opt) {
             case Option.Some<? extends V> s -> Result.ok(s.value());
             case Option.None<? extends V> _ -> Result.err(errorIfNone);
@@ -995,15 +999,13 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
             Result<? extends V2, ? extends E> r2) {
         Objects.requireNonNull(r1, "r1");
         Objects.requireNonNull(r2, "r2");
-        if (r1 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r2 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        V1 v1 = ((Ok<? extends V1, ?>) r1).value();
-        V2 v2 = ((Ok<? extends V2, ?>) r2).value();
-        return Result.ok(new Tuple2<>(v1, v2));
+        return switch (r1) {
+            case Err<?, ? extends E> e -> Result.err(e.error());
+            case Ok<? extends V1, ?> ok1 -> switch (r2) {
+                case Err<?, ? extends E> e -> Result.err(e.error());
+                case Ok<? extends V2, ?> ok2 -> Result.ok(new Tuple2<>(ok1.value(), ok2.value()));
+            };
+        };
     }
 
     /**
@@ -1027,19 +1029,16 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
         Objects.requireNonNull(r1, "r1");
         Objects.requireNonNull(r2, "r2");
         Objects.requireNonNull(r3, "r3");
-        if (r1 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r2 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r3 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        V1 v1 = ((Ok<? extends V1, ?>) r1).value();
-        V2 v2 = ((Ok<? extends V2, ?>) r2).value();
-        V3 v3 = ((Ok<? extends V3, ?>) r3).value();
-        return Result.ok(new Tuple3<>(v1, v2, v3));
+        return switch (r1) {
+            case Err<?, ? extends E> e -> Result.err(e.error());
+            case Ok<? extends V1, ?> ok1 -> switch (r2) {
+                case Err<?, ? extends E> e -> Result.err(e.error());
+                case Ok<? extends V2, ?> ok2 -> switch (r3) {
+                    case Err<?, ? extends E> e -> Result.err(e.error());
+                    case Ok<? extends V3, ?> ok3 -> Result.ok(new Tuple3<>(ok1.value(), ok2.value(), ok3.value()));
+                };
+            };
+        };
     }
 
     /**
@@ -1067,19 +1066,17 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
         Objects.requireNonNull(r2, "r2");
         Objects.requireNonNull(r3, "r3");
         Objects.requireNonNull(combiner, "combiner");
-        if (r1 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r2 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r3 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        V1 v1 = ((Ok<? extends V1, ?>) r1).value();
-        V2 v2 = ((Ok<? extends V2, ?>) r2).value();
-        V3 v3 = ((Ok<? extends V3, ?>) r3).value();
-        return Result.ok(Objects.requireNonNull(combiner.apply(v1, v2, v3), "combiner returned null"));
+        return switch (r1) {
+            case Err<?, ? extends E> e -> Result.err(e.error());
+            case Ok<? extends V1, ?> ok1 -> switch (r2) {
+                case Err<?, ? extends E> e -> Result.err(e.error());
+                case Ok<? extends V2, ?> ok2 -> switch (r3) {
+                    case Err<?, ? extends E> e -> Result.err(e.error());
+                    case Ok<? extends V3, ?> ok3 -> Result.ok(Objects.requireNonNull(
+                        combiner.apply(ok1.value(), ok2.value(), ok3.value()), "combiner returned null"));
+                };
+            };
+        };
     }
 
     // ---------- zip4 ----------
@@ -1109,23 +1106,19 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
         Objects.requireNonNull(r2, "r2");
         Objects.requireNonNull(r3, "r3");
         Objects.requireNonNull(r4, "r4");
-        if (r1 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r2 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r3 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r4 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        V1 v1 = ((Ok<? extends V1, ?>) r1).value();
-        V2 v2 = ((Ok<? extends V2, ?>) r2).value();
-        V3 v3 = ((Ok<? extends V3, ?>) r3).value();
-        V4 v4 = ((Ok<? extends V4, ?>) r4).value();
-        return Result.ok(new Tuple4<>(v1, v2, v3, v4));
+        return switch (r1) {
+            case Err<?, ? extends E> e -> Result.err(e.error());
+            case Ok<? extends V1, ?> ok1 -> switch (r2) {
+                case Err<?, ? extends E> e -> Result.err(e.error());
+                case Ok<? extends V2, ?> ok2 -> switch (r3) {
+                    case Err<?, ? extends E> e -> Result.err(e.error());
+                    case Ok<? extends V3, ?> ok3 -> switch (r4) {
+                        case Err<?, ? extends E> e -> Result.err(e.error());
+                        case Ok<? extends V4, ?> ok4 -> Result.ok(new Tuple4<>(ok1.value(), ok2.value(), ok3.value(), ok4.value()));
+                    };
+                };
+            };
+        };
     }
 
     /**
@@ -1157,23 +1150,21 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
         Objects.requireNonNull(r3, "r3");
         Objects.requireNonNull(r4, "r4");
         Objects.requireNonNull(combiner, "combiner");
-        if (r1 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r2 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r3 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        if (r4 instanceof Err<?, ? extends E> e) {
-            return Result.err(e.error());
-        }
-        V1 v1 = ((Ok<? extends V1, ?>) r1).value();
-        V2 v2 = ((Ok<? extends V2, ?>) r2).value();
-        V3 v3 = ((Ok<? extends V3, ?>) r3).value();
-        V4 v4 = ((Ok<? extends V4, ?>) r4).value();
-        return Result.ok(Objects.requireNonNull(combiner.apply(v1, v2, v3, v4), "combiner returned null"));
+        return switch (r1) {
+            case Err<?, ? extends E> e -> Result.err(e.error());
+            case Ok<? extends V1, ?> ok1 -> switch (r2) {
+                case Err<?, ? extends E> e -> Result.err(e.error());
+                case Ok<? extends V2, ?> ok2 -> switch (r3) {
+                    case Err<?, ? extends E> e -> Result.err(e.error());
+                    case Ok<? extends V3, ?> ok3 -> switch (r4) {
+                        case Err<?, ? extends E> e -> Result.err(e.error());
+                        case Ok<? extends V4, ?> ok4 -> Result.ok(Objects.requireNonNull(
+                            combiner.apply(ok1.value(), ok2.value(), ok3.value(), ok4.value()),
+                            "combiner returned null"));
+                    };
+                };
+            };
+        };
     }
 
 }

--- a/core/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResultTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -135,6 +136,18 @@ class ResultTest {
         assertThat(ok.mapError(String::length).get()).isEqualTo("v");
     }
 
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Result.ok("v").map(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapError_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>err("e").mapError(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
     // ---------- flatMap ----------
 
     @Test
@@ -155,6 +168,12 @@ class ResultTest {
             });
         assertThat(result.isError()).isTrue();
         assertThat(secondCalled.get()).as("mapper must not be called for Err").isFalse();
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Result.ok("v").flatMap(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     // ---------- filter ----------
@@ -191,6 +210,24 @@ class ResultTest {
     void filter_shouldLeaveErrUntouched() {
         Result<String, String> err = Result.err("original");
         assertThat(err.filter(s -> false, "new error")).isSameAs(err);
+    }
+
+    @Test
+    void filter_withValue_shouldThrowNPE_whenPredicateIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v").filter(null, "e"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void filter_withFunction_shouldThrowNPE_whenPredicateIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v").filter(null, s -> "e"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void filter_withFunction_shouldThrowNPE_whenErrorIfFalseIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v").filter(s -> true, (Function<String, String>) null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     // ---------- fold / match ----------
@@ -250,6 +287,18 @@ class ResultTest {
         assertThat(touched.get()).isFalse();
     }
 
+    @Test
+    void peek_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Result.ok("v").peek(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void peekError_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>err("e").peekError(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
     // ---------- interop: toOption / toTry ----------
 
     @Test
@@ -278,6 +327,12 @@ class ResultTest {
     void fromOption_shouldWrapSome_andUseErrorForNone() {
         assertThat(Result.fromOption(Option.some("v"), "missing").get()).isEqualTo("v");
         assertThat(Result.fromOption(Option.none(), "missing").getError()).isEqualTo("missing");
+    }
+
+    @Test
+    void fromOption_shouldThrowNPE_whenErrorIfNoneIsNull() {
+        assertThatThrownBy(() -> Result.fromOption(Option.none(), null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -434,50 +489,6 @@ class ResultTest {
         assertThatThrownBy(() -> Result.<String, String>err("e").orElse(() -> null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("alternative returned null");
-    }
-
-    // ---------- or ----------
-
-    @Test
-    void or_shouldReturnSelf_whenOk() {
-        AtomicBoolean called = new AtomicBoolean(false);
-        Result<String, String> ok = Result.ok("primary");
-        Result<String, String> result = ok.or(() -> {
-            called.set(true);
-            return Result.ok("fallback");
-        });
-        assertThat(result).isSameAs(ok);
-        assertThat(called.get()).as("fallback supplier must not be called for Ok").isFalse();
-    }
-
-    @Test
-    void or_shouldReturnFallback_whenErr() {
-        Result<String, String> result = Result.<String, String>err("e")
-            .or(() -> Result.ok("fallback"));
-        assertThat(result.isOk()).isTrue();
-        assertThat(result.get()).isEqualTo("fallback");
-    }
-
-    @Test
-    void or_shouldChain_multipleAlternatives() {
-        Result<String, String> result = Result.<String, String>err("e1")
-            .or(() -> Result.err("e2"))
-            .or(() -> Result.ok("found"));
-        assertThat(result.isOk()).isTrue();
-        assertThat(result.get()).isEqualTo("found");
-    }
-
-    @Test
-    void or_shouldThrowNPE_ifFallbackIsNull() {
-        assertThatThrownBy(() -> Result.<String, String>err("e").or(null))
-            .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    void or_shouldThrowNPE_ifFallbackReturnsNull() {
-        assertThatThrownBy(() -> Result.<String, String>err("e").or(() -> null))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("fallback returned null");
     }
 
     // ---------- flatMapError ----------

--- a/core/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResultTest.java
@@ -176,6 +176,13 @@ class ResultTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperReturnsNull() {
+        assertThatThrownBy(() -> Result.ok("v").flatMap(_ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper returned null");
+    }
+
     // ---------- filter ----------
 
     @Test
@@ -215,6 +222,12 @@ class ResultTest {
     @Test
     void filter_withValue_shouldThrowNPE_whenPredicateIsNull() {
         assertThatThrownBy(() -> Result.<String, String>ok("v").filter(null, "e"))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void filter_withValue_shouldThrowNPE_whenErrorIfFalseIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v").filter(s -> false, (String) null))
             .isInstanceOf(NullPointerException.class);
     }
 


### PR DESCRIPTION
  - Add Objects.requireNonNull to map, mapError, flatMap, peek, peekError,
    filter(Predicate,Error), and filter(Predicate,Function); add @throws
    NullPointerException to all seven Javadocs
  - Add Objects.requireNonNull(errorIfNone) to fromOption; add @throws
    NullPointerException to its Javadoc
  - Fix toOptional() to use Optional.of instead of Optional.ofNullable —
    Ok.value is guaranteed non-null by the compact constructor
  - Remove or(Supplier) — redundant duplicate of the lazy orElse(Supplier)
    overload already present on the interface
  - Convert zip, zip3, zipWith3, zip4, zipWith4 from instanceof chains
    with raw casts to nested exhaustive switch expressions, eliminating
    all unchecked casts in the zip family
  - ResultTest: remove five or_* tests; add NPE tests for map, mapError,
    flatMap, peek, peekError, filter (×3), and fromOption (errorIfNone)

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #387

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened null-safety in functional combinators (map, flatMap, filter, peek) to throw exceptions for invalid inputs
  * Improved Optional conversion with stricter null validation

* **Chores**
  * Removed `or()` method for Result fallback handling
  * Refactored zip operations for improved implementation patterns

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/423)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->