### PR TITLE
docs(adr): ADR-018 — NonEmptyList<T>, NonEmptySet<T>, NonEmptyMap<K,V> as structural guarantee types

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -27,6 +27,11 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>This class is {@code @NullMarked}: all elements and parameters are non-null by default.
  *
+ * <p>The rationale for introducing dedicated non-empty collection types instead of using
+ * standard JDK types with runtime checks is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-018-non-empty-collections/">
+ * ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
+ *
  * @param <T> the type of elements in this list
  */
 @NullMarked

--- a/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyMap.java
@@ -30,6 +30,11 @@ import org.jspecify.annotations.NullMarked;
  * <p>This class is {@code @NullMarked}: all keys, values, and parameters are non-null
  * by default.
  *
+ * <p>The rationale for introducing dedicated non-empty collection types instead of using
+ * standard JDK types with runtime checks is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-018-non-empty-collections/">
+ * ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
+ *
  * @param <K> the type of keys
  * @param <V> the type of values
  */

--- a/core/lib/src/main/java/dmx/fun/NonEmptySet.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptySet.java
@@ -29,6 +29,11 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>This class is {@code @NullMarked}: all elements and parameters are non-null by default.
  *
+ * <p>The rationale for introducing dedicated non-empty collection types instead of using
+ * standard JDK types with runtime checks is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-018-non-empty-collections/">
+ * ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
+ *
  * @param <T> the type of elements in this set
  */
 @NullMarked

--- a/docs/adr/ADR-018-non-empty-collections.md
+++ b/docs/adr/ADR-018-non-empty-collections.md
@@ -1,0 +1,91 @@
+---
+number: 18
+title: "NonEmptyList<T>, NonEmptySet<T>, NonEmptyMap<K,V> as structural guarantee types"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+Many domain operations require collections with at least one element: validation
+errors, grouped results, non-empty inputs to functions. The standard JDK types
+`List<T>`, `Set<T>`, and `Map<K,V>` allow empty instances and carry no non-emptiness
+invariant in the type system, so the check is scattered across every caller.
+
+## Decision
+
+Provide `NonEmptyList<T>`, `NonEmptySet<T>`, and `NonEmptyMap<K,V>` as dedicated
+types that encode the non-emptiness constraint in the static type. Each type
+stores a guaranteed `head` element plus an optionally-empty `tail`
+(an unmodifiable sub-collection), making it structurally impossible to construct an
+instance without at least one element. There is no emptiness check at a single
+entry point; the constraint is a consequence of the representation.
+
+Smart constructors that accept potentially empty sources (`fromList`, `fromSet`,
+`fromMap`) return `Option<NonEmptyX>` rather than throwing, shifting the emptiness
+handling to the type system — callers must handle the `None` case explicitly.
+
+The three types choose their JDK interface based on what can be honoured without
+violating the invariant or the interface contract:
+
+- **`NonEmptyList<T>`** implements `java.util.SequencedCollection<T>` (Java 21+),
+  not `List<T>`. This provides `getFirst()`, `getLast()`, and `reversed()` as total
+  functions (they never throw `NoSuchElementException`), while all mutating methods
+  throw `UnsupportedOperationException`. Implementing `List<T>` would expose
+  `remove(int)` and `clear()`, which cannot be implemented without breaking the
+  non-emptiness invariant.
+- **`NonEmptySet<T>`** implements `Iterable<T>` only. Backed by `LinkedHashSet`,
+  insertion order is preserved. `toSet()` provides an unmodifiable `java.util.Set`
+  for standard API interop. Implementing `Set<T>` would expose `remove` and `clear`.
+- **`NonEmptyMap<K,V>`** is a standalone `final` class. Backed by `LinkedHashMap`,
+  insertion order is preserved. `toMap()` provides an unmodifiable `java.util.Map`.
+  Implementing `Map<K,V>` would expose `put`, `remove`, and `clear`.
+
+`Validated` and `Guard` use `NonEmptyList<String>` for error accumulation:
+a `Validated.Invalid` always carries at least one error, and `Guard` always returns
+at least one message when a check fails. This eliminates defensive `isEmpty()` checks
+in callers.
+
+`Result.groupingBy` returns `Map<K, NonEmptyList<V>>` rather than
+`Map<K, List<V>>` — every group produced by grouping always contains at least one
+element by construction. This decision is documented in
+[ADR-017](https://domix.github.io/dmx-fun/adr/adr-017-groupingby-nonemptylist/).
+
+## Consequences
+
+**Positive:**
+
+- The invariant is enforced once at construction, not scattered across callers.
+- Method signatures that require non-empty collections express it in the type
+  (`NonEmptyList<E>` vs `List<E>`); callers never need to guard against empty
+  instances.
+- `NonEmptyList.head()`, `getFirst()`, and `getLast()` are total functions — they
+  never throw.
+- Validation pipelines using `Validated<NonEmptyList<E>, A>` are guaranteed to carry
+  at least one error in the `Invalid` case, removing the need for defensive
+  `isEmpty()` checks on error lists.
+- Consistent with the library's philosophy of making illegal states
+  unrepresentable.
+
+**Negative / tradeoffs:**
+
+- Three additional public types; callers must convert to JDK collections at API
+  boundaries via `toList()`, `toSet()`, or `toMap()`.
+- `NonEmptyList<T>` does not implement `List<T>`, so it cannot be passed to APIs
+  that expect `List<T>` without conversion. It does implement `SequencedCollection<T>`
+  (and transitively `Collection<T>` and `Iterable<T>`), which satisfies many use sites.
+- `fromList` / `fromSet` / `fromMap` return `Option<NonEmptyX>`, requiring callers to
+  handle the `None` case when bridging from standard JDK types.
+
+## Alternatives considered
+
+- **Runtime assertion in callers:** enforces the invariant only where remembered;
+  fails late and is not visible at API boundaries.
+- **Implementing `List<T>` / `Set<T>` / `Map<K,V>` directly:** would expose mutating
+  methods (`add`, `remove`, `clear`) that can only respond with
+  `UnsupportedOperationException`, violating the interface contract and giving callers
+  a false sense of compatibility.
+- **Vavr's `NonEmptyList`:** external dependency; heavier than needed for this
+  focused use case.
+- **Guava `ImmutableList` with a size check:** doesn't encode non-emptiness in the
+  type; still requires a runtime check at every call site.

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -18,6 +18,8 @@ import {Content as ToNonEmptyListCollector} from '../code/guide/non-empty-list/t
 import {Content as SequencedCollection}    from '../code/guide/non-empty-list/sequenced-collection.mdx';
 import {Content as RealWorldExample}       from '../code/guide/non-empty-list/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`NonEmptyListSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyListSample.java)
 
 ## What is NonEmptyList&lt;T&gt;?
@@ -37,6 +39,9 @@ present.
 `Validated.Invalid` always carries at least one error, so
 `Validated<NonEmptyList<E>, A>` is the idiomatic type for accumulating validation
 errors without losing any of them.
+
+The design rationale — why a structural head+tail representation was chosen over
+runtime checks or existing JDK types — is documented in <a href={`${base}adr/adr-018-non-empty-collections`}>ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
 
 Use it when:
 

--- a/site/src/data/guide/non-empty-map.mdx
+++ b/site/src/data/guide/non-empty-map.mdx
@@ -15,6 +15,8 @@ import {Content as InteropOption}      from '../code/guide/non-empty-map/interop
 import {Content as InteropSequences}   from '../code/guide/non-empty-map/interop-sequences.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-map/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`NonEmptyMapSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptyMapSample.java)
 
 ## What is NonEmptyMap&lt;K, V&gt;?
@@ -32,6 +34,9 @@ throw `NullPointerException` at construction time.
 
 **Insertion order preserved**: backed by `LinkedHashMap`, so iteration follows
 insertion order with the head entry always first.
+
+The design rationale — why a structural head+tail representation was chosen over
+runtime checks or existing JDK types — is documented in <a href={`${base}adr/adr-018-non-empty-collections`}>ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
 
 Use it when:
 

--- a/site/src/data/guide/non-empty-set.mdx
+++ b/site/src/data/guide/non-empty-set.mdx
@@ -15,6 +15,8 @@ import {Content as InteropOption}      from '../code/guide/non-empty-set/interop
 import {Content as InteropSequences}   from '../code/guide/non-empty-set/interop-sequences.mdx';
 import {Content as RealWorldExample}   from '../code/guide/non-empty-set/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`NonEmptySetSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/NonEmptySetSample.java)
 
 ## What is NonEmptySet&lt;T&gt;?
@@ -35,6 +37,9 @@ insertion order with the head element always first.
 
 **Implements `Iterable<T>`**: use directly in for-each loops, or adapt to streams
 via `StreamSupport.stream(nes.spliterator(), false)`.
+
+The design rationale — why a structural head+tail representation was chosen over
+runtime checks or existing JDK types — is documented in <a href={`${base}adr/adr-018-non-empty-collections`}>ADR-018 — NonEmptyList&lt;T&gt;, NonEmptySet&lt;T&gt;, NonEmptyMap&lt;K,V&gt; as structural guarantee types</a>.
 
 Use it when:
 


### PR DESCRIPTION
  - Add docs/adr/ADR-018-non-empty-collections.md documenting the decision to
    enforce non-emptiness structurally via a head+tail representation rather than
    runtime checks; corrects the issue draft (no IllegalArgumentException, no
    wrapping of a full collection; fromList/fromSet/fromMap return Option<NonEmptyX>)
  - Document the JDK interface choices: NonEmptyList implements SequencedCollection<T>
    (Java 21+), NonEmptySet implements Iterable<T>, NonEmptyMap is a standalone class
  - Add ADR-018 link to the class-level Javadoc of NonEmptyList, NonEmptySet, and
    NonEmptyMap
  - Reference ADR-018 in the developer guide pages non-empty-list.mdx,
    non-empty-set.mdx, and non-empty-map.mdx; add missing base export to each page

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #413

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
