### PR TITLE
docs(adr): ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class   interfaces

### DIFF
--- a/core/lib/src/main/java/dmx/fun/CheckedConsumer.java
+++ b/core/lib/src/main/java/dmx/fun/CheckedConsumer.java
@@ -8,6 +8,14 @@ import org.jspecify.annotations.NullMarked;
  * This is a variation of the standard {@code Consumer} interface, intended for use in scenarios where
  * the operation may involve checked exceptions.
  *
+ * <p>Used as the {@code release} parameter of {@link Resource#of(CheckedSupplier, CheckedConsumer)}
+ * to define the teardown action for a managed resource.
+ *
+ * <p>The rationale for providing checked variants of the standard functional interfaces
+ * (and the choice of {@code throws Exception} over {@code throws Throwable}) is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-019-checked-functional-interfaces/">
+ * ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces</a>.
+ *
  * @param <T> the type of the input to the operation
  */
 @NullMarked

--- a/core/lib/src/main/java/dmx/fun/CheckedFunction.java
+++ b/core/lib/src/main/java/dmx/fun/CheckedFunction.java
@@ -8,6 +8,14 @@ import org.jspecify.annotations.NullMarked;
  * This is a variation of the standard {@code Function} interface, intended for use in scenarios where
  * the operation may involve checked exceptions.
  *
+ * <p>Used by {@link Resource#use(CheckedFunction)} to execute a body function against an
+ * acquired resource within a managed {@link Try} scope.
+ *
+ * <p>The rationale for providing checked variants of the standard functional interfaces
+ * (and the choice of {@code throws Exception} over {@code throws Throwable}) is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-019-checked-functional-interfaces/">
+ * ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces</a>.
+ *
  * @param <T> the type of the input to the function
  * @param <R> the type of the result of the function
  */

--- a/core/lib/src/main/java/dmx/fun/CheckedRunnable.java
+++ b/core/lib/src/main/java/dmx/fun/CheckedRunnable.java
@@ -6,6 +6,14 @@ import org.jspecify.annotations.NullMarked;
  * A functional interface representing a runnable that may throw a checked exception.
  * This is a variation of the standard {@code Runnable} interface, intended for use in scenarios where
  * the operation may involve checked exceptions.
+ *
+ * <p>Primary entry point for {@link Try#run(CheckedRunnable)}: the runnable is executed and any
+ * thrown exception is captured as a {@code Failure}, returning {@code Success(null)} on completion.
+ *
+ * <p>The rationale for providing checked variants of the standard functional interfaces
+ * (and the choice of {@code throws Exception} over {@code throws Throwable}) is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-019-checked-functional-interfaces/">
+ * ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces</a>.
  */
 @NullMarked
 @FunctionalInterface

--- a/core/lib/src/main/java/dmx/fun/CheckedSupplier.java
+++ b/core/lib/src/main/java/dmx/fun/CheckedSupplier.java
@@ -7,6 +7,15 @@ import org.jspecify.annotations.NullMarked;
  * This is a variation of the standard {@code Supplier} interface, intended for use in scenarios where
  * the operation may involve checked exceptions.
  *
+ * <p>Primary entry point for {@link Try#of(CheckedSupplier)} and
+ * {@link Try#withTimeout(java.time.Duration, CheckedSupplier)}: the supplier is executed and any
+ * thrown exception is captured as a {@code Failure} without manual wrapping.
+ *
+ * <p>The rationale for providing checked variants of the standard functional interfaces
+ * (and the choice of {@code throws Exception} over {@code throws Throwable}) is documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-019-checked-functional-interfaces/">
+ * ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces</a>.
+ *
  * @param <T> the type of result supplied by this supplier
  */
 @NullMarked

--- a/docs/adr/ADR-019-checked-functional-interfaces.md
+++ b/docs/adr/ADR-019-checked-functional-interfaces.md
@@ -1,0 +1,89 @@
+---
+number: 19
+title: "CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+Java's standard functional interfaces — `Function`, `Supplier`, `Runnable`,
+`Consumer` — do not declare checked exceptions. Code that calls checked-exception
+APIs (JDBC, I/O, JNDI) cannot be used directly as lambdas or method references
+in `Try.of`, `map`, or `flatMap` without a manual `try/catch` wrapper at each
+call site, which obscures intent.
+
+## Decision
+
+Provide `CheckedFunction<T, R>`, `CheckedSupplier<T>`, `CheckedRunnable`, and
+`CheckedConsumer<T>` as `@FunctionalInterface` types whose single abstract method
+declares `throws Exception`:
+
+| Interface               | Checked equivalent of | Signature                           |
+|-------------------------|-----------------------|-------------------------------------|
+| `CheckedFunction<T, R>` | `Function<T, R>`      | `R apply(T t) throws Exception`     |
+| `CheckedSupplier<T>`    | `Supplier<T>`         | `T get() throws Exception`          |
+| `CheckedRunnable`       | `Runnable`            | `void run() throws Exception`       |
+| `CheckedConsumer<T>`    | `Consumer<T>`         | `void accept(T t) throws Exception` |
+
+The SAM is `throws Exception` rather than `throws Throwable`. This allows checked
+exceptions and `RuntimeException` to propagate through lambda boundaries without
+compilation errors, while `Error` (which signals JVM-level failures outside normal
+error handling) is not part of the declared surface. In practice, `Try.of` and
+`Try.run` catch `Throwable` internally, so an `Error` thrown inside the supplier
+or runnable is still captured as a `Failure` — but this is a `Try` implementation
+detail, not a contract of the `Checked*` interfaces themselves.
+
+`CheckedSupplier<T>` and `CheckedRunnable` are the primary entry points for `Try`:
+- `Try.of(CheckedSupplier)` executes the supplier and wraps any thrown exception
+  as a `Failure`.
+- `Try.run(CheckedRunnable)` executes the runnable and wraps any thrown exception
+  as a `Failure(Throwable)`, returning `Success(null)` on completion.
+- `Try.withTimeout(Duration, CheckedSupplier)` runs the supplier on a virtual
+  thread with a deadline (documented in ADR-013).
+
+`CheckedFunction<T, R>` and `CheckedConsumer<T>` are the primary API for
+`Resource<T>`:
+- `Resource.use(CheckedFunction)` opens the resource, passes it to the function
+  body, and closes it — all within a single `Try<R>`.
+- The `release` parameter of `Resource.of(CheckedSupplier, CheckedConsumer)`
+  accepts a `CheckedConsumer` for the teardown action.
+
+All four interfaces are `@NullMarked` (jspecify), consistent with the rest of
+the library's null safety policy.
+
+## Consequences
+
+**Positive:**
+
+- Throwing method references and lambdas can be passed directly to `Try.of`,
+  `Try.run`, `Resource.use`, and other functional APIs without manual
+  `try/catch` wrappers at every call site.
+- Consistent with the library's goal of capturing exceptions as values rather
+  than propagating them through imperative control flow.
+- Each interface is `@FunctionalInterface` — lambdas and method references work
+  directly without additional adapters.
+
+**Negative / tradeoffs:**
+
+- Four additional public interfaces increase the API surface.
+- `throws Exception` is broad — the signature alone does not reveal which specific
+  checked exceptions the implementation may throw. Callers relying only on the
+  interface type cannot statically determine the exception domain.
+- Introducing `CheckedConsumer` into `Resource.of` means a release action that
+  throws is captured as a `Failure`, which may be surprising if callers expect
+  teardown to be infallible.
+
+## Alternatives considered
+
+- **Sneaky-throws (Lombok `@SneakyThrows`):** hides checked exceptions from
+  callers at the bytecode level; breaks caller assumptions and requires an
+  external annotation processor dependency.
+- **Wrapper lambda at each call site:** boilerplate at every use of `Try.of` or
+  `map`; defeats the purpose of ergonomic API design.
+- **`UncheckedIOException` and siblings:** only covers specific exception families;
+  not a general solution.
+- **`throws Throwable` on the SAM:** wider than needed for the checked-exception
+  use case; `Error` subclasses signal unrecoverable JVM conditions and are not
+  part of the normal exception-as-value pattern. `throws Exception` is the
+  conventional boundary.

--- a/site/src/data/guide/checked-interfaces.mdx
+++ b/site/src/data/guide/checked-interfaces.mdx
@@ -11,6 +11,8 @@ import {Content as TryIntegration}    from '../code/guide/checked-interfaces/try
 import {Content as HigherArity}       from '../code/guide/checked-interfaces/higher-arity.mdx';
 import {Content as RealWorldExample}  from '../code/guide/checked-interfaces/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`CheckedInterfacesSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/CheckedInterfacesSample.java)
 
 ## The problem: checked exceptions in lambdas
@@ -34,7 +36,9 @@ so that throwing method references can be used directly.
 | `CheckedConsumer<T>`    | `Consumer<T>`         | `void accept(T t) throws Exception` |
 | `CheckedRunnable`       | `Runnable`            | `void run() throws Exception`       |
 
-All four are `@FunctionalInterface` and `@NullMarked`.
+All four are `@FunctionalInterface` and `@NullMarked`. The rationale for providing
+these interfaces — including the choice of `throws Exception` over `throws Throwable`
+— is documented in <a href={`${base}adr/adr-019-checked-functional-interfaces`}>ADR-019 — CheckedFunction, CheckedSupplier, CheckedRunnable, CheckedConsumer as first-class interfaces</a>.
 
 <CheckedIfaces/>
 


### PR DESCRIPTION
  - Add docs/adr/ADR-019-checked-functional-interfaces.md; corrects the issue draft:
    SAMs declare throws Exception (not throws Throwable), and CheckedFunction /
    CheckedConsumer are also the primary API for Resource, not only for Try
  - Document the throws Throwable alternative and why throws Exception is the right
    boundary for the checked-exception use case
  - Add class-level Javadoc with primary use site and ADR-019 link to
    CheckedFunction, CheckedSupplier, CheckedRunnable, and CheckedConsumer
  - Reference ADR-019 in checked-interfaces.mdx after the interface table;
    add missing base export to the guide page

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #414

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
