### PR TITLE
docs(adr): ADR-020 — Accumulator<E, A> (Writer monad) — rationale for inclusion

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Accumulator.java
+++ b/core/lib/src/main/java/dmx/fun/Accumulator.java
@@ -62,6 +62,12 @@ import org.jspecify.annotations.Nullable;
  * (the accumulation side-channel is the only meaningful payload). Call
  * {@link #hasValue()} before calling {@link #value()} if the source is not known.
  *
+ * <p>The rationale for including this type in the library — and the design choices around
+ * the Writer monad pattern, the merge-function API, and the alternatives considered — is
+ * documented in
+ * <a href="https://domix.github.io/dmx-fun/adr/adr-020-accumulator-writer-monad/">
+ * ADR-020 — Accumulator&lt;E, A&gt; (Writer monad) — rationale for inclusion</a>.
+ *
  * @param <E>         the accumulation type (log entries, metrics, etc.)
  * @param <A>         the value type
  * @param value       the computed value; {@code null} only for accumulators created by

--- a/docs/adr/ADR-020-accumulator-writer-monad.md
+++ b/docs/adr/ADR-020-accumulator-writer-monad.md
@@ -1,0 +1,92 @@
+---
+number: 20
+title: "Accumulator<E, A> (Writer monad) — rationale for inclusion"
+status: Accepted
+date: 2026-05-09
+---
+
+## Context
+
+Some computations need to produce a value alongside a side-channel accumulation
+(audit log, metrics events, warning messages) without resorting to mutable state
+or global logging. The standard Java approach uses mutable lists or thread-local
+logging, both of which are invisible at API boundaries and lost on virtual threads
+or async boundaries.
+
+## Decision
+
+Include `Accumulator<E, A>` as an immutable record pairing a computed value `A`
+with a side-channel accumulation `E`. This is the Writer monad pattern from
+functional programming.
+
+The type parameter order is `<E, A>` where `E` is the accumulation type and `A`
+is the value type. The record components are `(@Nullable A value, E accumulated)`.
+
+**Accumulation is always explicit and composable through the API surface:**
+
+- `Accumulator.of(value, accumulated)` — create with a value and an initial entry.
+- `Accumulator.pure(value, empty)` — create with a value and an identity
+  accumulation. The identity must be supplied by the caller because Java does not
+  have type classes; common choices are `List.of()`, `0`, or `""`.
+- `Accumulator.tell(accumulated)` — record a side-channel entry without producing
+  a meaningful value; the `value()` component is `null` (`Void`).
+- `flatMap(f, merge)` — chain a next step: applies `f` to the current value to
+  get the next `Accumulator`, then merges both accumulations with `merge`
+  (`BinaryOperator<E>`). This is the primary composition combinator.
+- `combine(other, merge, f)` — combine two independently computed accumulators:
+  merges their accumulations and applies `f` to both values.
+- `sequence(list, merge, empty)` — fold a `List<Accumulator<E, A>>` into a single
+  `Accumulator<E, List<A>>` by merging all accumulations left-to-right.
+- `map(f)` — transform the value without touching the accumulation.
+- `mapAccumulated(f)` — transform the accumulation without touching the value.
+
+The key invariant: **accumulation always continues**. Unlike `Result` or `Try`,
+there is no failure path — every step contributes to both the value and the
+accumulation. This makes `Accumulator` the natural choice for tracing what
+happened, not just whether it succeeded.
+
+`Accumulator` integrates with `NonEmptyList<E>` via `NonEmptyList::concat` as the
+`merge` function, guaranteeing that at least one log entry is always present.
+For `Option`, `Try`, `Result`, and `Either`, the static `liftOption`,
+`liftTry`, `liftResult`, and `liftEither` helpers record a log entry regardless
+of which branch was taken while preserving the wrapped value as the accumulator's
+value.
+
+## Consequences
+
+**Positive:**
+
+- Side-channel data (logs, warnings, events) remains a pure value alongside the
+  result — no global mutable state, no thread-local context, and no loss on
+  virtual-thread or async boundaries.
+- Composable: `flatMap` chains steps and merges accumulations; `combine` merges
+  parallel computations; both are explicit and testable.
+- The side-channel is visible in the function return type — callers can see that
+  a function produces log entries without reading its implementation.
+- Interoperates with the rest of the library: `toOption()`, `toResult()`,
+  `toEither()`, and `toTuple2()` bridge to other types at pipeline boundaries.
+
+**Negative / tradeoffs:**
+
+- Less familiar than traditional logging — teams must adopt the pattern
+  deliberately, and the merge function must be threaded through every `flatMap`
+  call.
+- Does not handle failures: a step that can fail should return
+  `Accumulator<E, Result<A, Err>>` (or use `liftResult`) rather than trying to
+  express both concerns inside `Accumulator` alone.
+- `tell()` produces a `null` value, which requires callers to use `hasValue()`
+  or `flatMap` rather than `map` — a sharp edge when the origin of an accumulator
+  is not statically known.
+
+## Alternatives considered
+
+- **Mutable list passed as parameter:** works but breaks referential transparency
+  and complicates testing and concurrent use.
+- **MDC / thread-local logging:** invisible in the type system; lost on virtual
+  threads or async boundaries.
+- **`Result<A, List<Warning>>`:** conflates non-fatal warnings with fatal errors;
+  `Accumulator` separates the two tracks — the value is always present, and
+  warnings are always accumulated, regardless of success or failure.
+- **Returning a custom pair type per use case:** each domain would need its own
+  ad-hoc wrapper; `Accumulator<E, A>` is the general solution that works for any
+  `E` and any merge strategy.

--- a/site/src/data/guide/accumulator.mdx
+++ b/site/src/data/guide/accumulator.mdx
@@ -11,6 +11,8 @@ import {Content as MapAccumulated}    from '../code/guide/accumulator/map-accumu
 import {Content as Interop}           from '../code/guide/accumulator/interop.mdx';
 import {Content as RealWorldExample}  from '../code/guide/accumulator/real-world-example.mdx';
 
+export const base = import.meta.env.BASE_URL;
+
 > **Runnable example:** [`AccumulatorSample.java`](https://github.com/domix/dmx-fun/blob/main/samples/src/main/java/dmx/fun/samples/AccumulatorSample.java)
 
 ## What is Accumulator&lt;E, A&gt;?
@@ -30,6 +32,7 @@ the accumulation. This makes `Accumulator` unsuitable for error handling (use
 something, but you also want a trace of what happened along the way.
 
 This type is sometimes called the **Writer monad** in functional programming literature.
+The rationale for including it in the library is documented in <a href={`${base}adr/adr-020-accumulator-writer-monad`}>ADR-020 — Accumulator&lt;E, A&gt; (Writer monad) — rationale for inclusion</a>.
 
 ## Factories
 


### PR DESCRIPTION
  - Add docs/adr/ADR-020-accumulator-writer-monad.md; corrects the issue draft:
    the API has no add(e) method — accumulation is extended via tell(), flatMap(f,
    merge), combine(), and sequence(); documents the merge-function design, the
    tell()/null-value sharp edge, and why Result<A,List<Warning>> is the wrong
    alternative for non-fatal side-channel data
  - Add ADR-020 link to Accumulator class-level Javadoc
  - Reference ADR-020 in accumulator.mdx after the Writer monad sentence;
    add missing base export to the guide page

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #415

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
