### PR TITLE
fix(Guard): nullable contract, checkToOptional semantics, and API symmetry gaps

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -572,6 +572,16 @@ public interface Guard<T> {
      * Optional<String> empty   = notBlank.checkToOptional("   ");   // Optional.empty()
      * }</pre>
      *
+     * <p><strong>Not suitable when {@code null} is a valid success value.</strong>
+     * This method calls {@link Optional#of(Object) Optional.of(value)} on the validated value,
+     * which throws {@link NullPointerException} if {@code value} is {@code null}.
+     * Under {@code @NullMarked}, {@code T} is non-null by default, so this is safe for ordinary
+     * guards. However, if {@code T} is a nullable type (e.g., {@code Guard<@Nullable String>})
+     * and the guard can return {@code Valid(null)}, calling this method will throw
+     * {@code NullPointerException}. In that case, use {@link #check(Object) check(value)} and
+     * work with the resulting {@link Validated} directly, applying
+     * {@link Optional#ofNullable(Object)} to the extracted value when needed.
+     *
      * @param value the value to validate
      * @return {@code Optional.of(value)} if the guard passes,
      *         {@code Optional.empty()} if the guard fails

--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -51,8 +51,8 @@ import org.jspecify.annotations.Nullable;
  *       accumulated (not fail-fast).</li>
  *   <li>{@link #or(Guard) or} — the first passing guard short-circuits; if all fail, all errors
  *       are accumulated.</li>
- *   <li>{@link #negate() negate} / {@link #negate(String) negate(message)} — inverts the
- *       predicate.</li>
+ *   <li>{@link #negate() negate} / {@link #negate(String) negate(message)} /
+ *       {@link #negate(Function) negate(messageFromValue)} — inverts the predicate.</li>
  * </ul>
  *
  * @param <T> the type of value being validated
@@ -68,7 +68,7 @@ public interface Guard<T> {
     /**
      * Applies this guard to {@code value}.
      *
-     * @param value the value to validate; must not be {@code null}
+     * @param value the value to validate
      * @return {@code Valid(value)} if the predicate passes, or
      *         {@code Invalid(errors)} if it fails
      */
@@ -272,6 +272,60 @@ public interface Guard<T> {
         return value -> this.check(value).isValid()
             ? Validated.invalidNel(errorMessage)
             : Validated.valid(value);
+    }
+
+    /**
+     * Returns a guard that is the logical negation of this guard, using a dynamic error message.
+     *
+     * <p>The {@code messageFromValue} function receives the value that passed the original guard,
+     * allowing a context-specific error message.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notReserved = Guard.of(s -> s.equals("admin") || s.equals("root"), "")
+     *     .negate(s -> "username '" + s + "' is reserved");
+     *
+     * notReserved.check("alice"); // Valid("alice")
+     * notReserved.check("admin"); // Invalid(["username 'admin' is reserved"])
+     * }</pre>
+     *
+     * @param messageFromValue function producing an error message from the passing value;
+     *                         must not be {@code null}
+     * @return the negated {@code Guard<T>}
+     * @throws NullPointerException if {@code messageFromValue} is {@code null}
+     */
+    default Guard<T> negate(Function<? super T, String> messageFromValue) {
+        Objects.requireNonNull(messageFromValue, "messageFromValue");
+        return value -> this.check(value).isValid()
+            ? Validated.invalidNel(messageFromValue.apply(value))
+            : Validated.valid(value);
+    }
+
+    /**
+     * Returns a guard that replaces any error messages produced by this guard with
+     * {@code message}.
+     *
+     * <p>Useful when you want to expose a single clean message at a public API boundary
+     * regardless of the internal validation details.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = notBlank.and(minLength3).withMessage("invalid username");
+     *
+     * username.check("");    // Invalid(["invalid username"])
+     * username.check("a");   // Invalid(["invalid username"])
+     * username.check("alice"); // Valid("alice")
+     * }</pre>
+     *
+     * @param message the replacement error message; must not be {@code null}
+     * @return a new {@code Guard<T>} that returns a single fixed error when this guard fails
+     * @throws NullPointerException if {@code message} is {@code null}
+     */
+    default Guard<T> withMessage(String message) {
+        Objects.requireNonNull(message, "message");
+        return value -> this.check(value).isValid()
+            ? Validated.valid(value)
+            : Validated.invalidNel(message);
     }
 
     // -------------------------------------------------------------------------
@@ -519,11 +573,11 @@ public interface Guard<T> {
      * }</pre>
      *
      * @param value the value to validate
-     * @return {@code Optional.of(value)} if the guard passes and {@code value} is non-null,
-     *         {@code Optional.empty()} if the guard fails or {@code value} is null
+     * @return {@code Optional.of(value)} if the guard passes,
+     *         {@code Optional.empty()} if the guard fails
      */
     default Optional<T> checkToOptional(T value) {
-        return this.check(value).isValid() ? Optional.ofNullable(value) : Optional.empty();
+        return this.check(value).isValid() ? Optional.of(value) : Optional.empty();
     }
 
     /**

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -653,12 +653,13 @@ class GuardTest {
     }
 
     @Test
-    void checkToOptional_usesOptionalOf_notOfNullable_whenGuardPasses() {
-        // Verify that the implementation calls Optional.of (not ofNullable) on the passing value.
-        // Optional.of would throw NPE if value were null — but that cannot happen under @NullMarked
-        // when the guard passes.
-        Optional<String> result = notBeBlank.checkToOptional("hello");
-        assertThat(result).isPresent().contains("hello");
+    void checkToOptional_throwsNPE_whenNullableGuardPassesNull() {
+        // Proves Optional.of (not ofNullable) is used: a guard that returns Valid(null)
+        // causes checkToOptional to call Optional.of(null), which must throw NPE.
+        Guard<@Nullable String> alwaysPassNullable = value -> Validated.valid(value);
+
+        assertThatThrownBy(() -> alwaysPassNullable.checkToOptional(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -256,9 +256,66 @@ class GuardTest {
     @Test
     void negate_withMessage_shouldThrowNPE_whenMessageIsNull() {
         var g = Guard.<String>of(_ -> true, "msg");
-        assertThatThrownBy(() -> g.negate(null))
+        assertThatThrownBy(() -> g.negate((String) null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("errorMessage");
+    }
+
+    @Test
+    void negate_withFunction_returnsDynamicError_whenOriginalPasses() {
+        var notReserved = Guard.<String>of(s -> s.equals("admin"), "is admin")
+            .negate(s -> "username '" + s + "' is reserved");
+
+        var result = notReserved.check("admin");
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("username 'admin' is reserved");
+    }
+
+    @Test
+    void negate_withFunction_returnsValid_whenOriginalFails() {
+        var notReserved = Guard.<String>of(s -> s.equals("admin"), "is admin")
+            .negate(s -> "username '" + s + "' is reserved");
+
+        assertThat(notReserved.check("alice").isValid()).isTrue();
+    }
+
+    @Test
+    void negate_withFunction_shouldThrowNPE_whenFunctionIsNull() {
+        var g = Guard.<String>of(_ -> true, "msg");
+        assertThatThrownBy(() -> g.negate((java.util.function.Function<String, String>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("messageFromValue");
+    }
+
+    // -------------------------------------------------------------------------
+    // withMessage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void withMessage_replacesAllErrors_withSingleMessage_whenGuardFails() {
+        var minLength = Guard.<String>of(s -> s.length() >= 3, "min 3 chars");
+        var guard = notBeBlank.and(minLength).withMessage("invalid username");
+
+        var result = guard.check("  "); // fails both notBeBlank and minLength
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getError().toList()).containsExactly("invalid username");
+    }
+
+    @Test
+    void withMessage_returnsValid_whenGuardPasses() {
+        var guard = notBeBlank.withMessage("invalid");
+
+        assertThat(guard.check("alice").isValid()).isTrue();
+        assertThat(guard.check("alice").get()).isEqualTo("alice");
+    }
+
+    @Test
+    void withMessage_shouldThrowNPE_whenMessageIsNull() {
+        assertThatThrownBy(() -> notBeBlank.withMessage(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("message");
     }
 
     // -------------------------------------------------------------------------
@@ -587,13 +644,21 @@ class GuardTest {
 
     @Test
     void checkToOptional_returnsEmpty_forNullInput_doesNotThrowNPE() {
-        // Guard.nonNull() is typed Guard<@Nullable T> and rejects null → Optional.empty()
-        // Regression: Optional.ofNullable is used so null never reaches Optional.of(null).
+        // Guard.nonNull() rejects null → Invalid → Optional.empty(); Optional.of is never reached.
         Guard<@Nullable String> nonNullGuard = Guard.nonNull();
 
         Optional<@Nullable String> result = nonNullGuard.checkToOptional(null);
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void checkToOptional_usesOptionalOf_notOfNullable_whenGuardPasses() {
+        // Verify that the implementation calls Optional.of (not ofNullable) on the passing value.
+        // Optional.of would throw NPE if value were null — but that cannot happen under @NullMarked
+        // when the guard passes.
+        Optional<String> result = notBeBlank.checkToOptional("hello");
+        assertThat(result).isPresent().contains("hello");
     }
 
     @Test

--- a/site/src/data/code/guide/guard/interop.mdx
+++ b/site/src/data/code/guide/guard/interop.mdx
@@ -65,4 +65,10 @@ Optional<String> empty   = username.checkToOptional("a!");    // Optional.empty(
 String upper = username.checkToOptional(input)
     .map(String::toUpperCase)
     .orElse("INVALID");
+
+// withMessage(message) — replace all errors with a single fixed message
+Guard<String> usernameSafe = notBlank.and(minLength3).withMessage("invalid username");
+usernameSafe.check("");    // Invalid(["invalid username"])
+usernameSafe.check("a");   // Invalid(["invalid username"])
+usernameSafe.check("alice"); // Valid("alice")
 ```

--- a/site/src/data/code/guide/guard/negate.mdx
+++ b/site/src/data/code/guide/guard/negate.mdx
@@ -13,4 +13,13 @@ noAdmin.check("admin"); // Invalid(["username must not be 'admin'"])
 // negate() with no argument uses a generic message
 Guard<String> notReserved = Guard.<String>of(s -> s.equals("root"), "is root").negate();
 notReserved.check("root"); // Invalid(["must not satisfy the condition"])
+
+// negate(messageFromValue) — dynamic message from the failing value
+Guard<String> notReservedDynamic = Guard.<String>of(
+        s -> s.equals("admin") || s.equals("root"), "reserved"
+    ).negate(s -> "username '" + s + "' is reserved");
+
+notReservedDynamic.check("alice"); // Valid("alice")
+notReservedDynamic.check("admin"); // Invalid(["username 'admin' is reserved"])
+notReservedDynamic.check("root");  // Invalid(["username 'root' is reserved"])
 ```

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -89,12 +89,32 @@ If all guards fail, errors from all of them are accumulated.
 Use `or` when a value is allowed to satisfy any one of several alternative formats
 (e.g., email or phone number, UUID or slug).
 
-## `negate()` / `negate(message)`
+## `negate()` / `negate(message)` / `negate(messageFromValue)`
 
-Inverts the predicate. Use `negate(message)` to supply a domain-specific error
-message; `negate()` falls back to the generic message `"must not satisfy the condition"`.
+Inverts the predicate. Three overloads are available:
+
+| Overload                         | Error message when original guard passes          |
+|----------------------------------|---------------------------------------------------|
+| `negate()`                       | Generic: `"must not satisfy the condition"`       |
+| `negate(String message)`         | Fixed string supplied by the caller               |
+| `negate(Function<T,String> fn)`  | Dynamic — the function receives the passing value |
 
 <Negate/>
+
+## `withMessage(message)`
+
+Replaces all error messages produced by this guard with a single fixed message.
+Useful at public API boundaries where you want to hide internal validation details
+and expose one clean, user-facing message regardless of which rule failed:
+
+```java
+Guard<String> username = notBlank.and(minLength3).and(alphanumeric)
+    .withMessage("invalid username");
+
+username.check("");    // Invalid(["invalid username"])
+username.check("a");   // Invalid(["invalid username"]) — not "min 3 chars"
+username.check("alice"); // Valid("alice")
+```
 
 ## Integrating with `Validated.combine`
 
@@ -115,6 +135,7 @@ Validated<NonEmptyList<String>, Form> form =
 
 | Method                             | Returns                           | Use case                                                                |
 |------------------------------------|-----------------------------------|-------------------------------------------------------------------------|
+| `withMessage(message)`             | `Guard<T>`                        | Replace all errors with one fixed message (hides internal rule details) |
 | `asPredicate()`                    | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
 | `contramap(fn)`                    | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
 | `checkToResult(value)`             | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic                       |


### PR DESCRIPTION
  - Remove "must not be null" from check(T) `@param` — null acceptance depends
    on T's bound; Guard.nonNull() intentionally receives `@Nullable` T
  - Fix checkToOptional to call Optional.of(value) instead of ofNullable;
    under `@NullMarked` a valid value is never null
  - Add negate(Function<? super T, String> messageFromValue) overload for
    dynamic negation messages derived from the failing value
  - Add withMessage(String) default method to replace all accumulated errors
    with a single fixed message at API boundaries
  - Update class-level Javadoc to reference the new negate(Function) overload
  - Add GuardTest cases for all new behaviour and the corrected contract
  - Expand Guard guide: overload table for negate, withMessage section,
    updated interop table, and new code snippets for both additions

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #388

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic message generation when negating validation rules
  * Added method to replace all validation errors with a single unified message

* **Bug Fixes**
  * Improved Optional handling for null values in validation checks (now throws instead of returning empty)

* **Documentation**
  * Updated validation guides with examples for new functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/427)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->