### PR TITLE
fix(Validated): null-checks on function args, bounded wildcards, uniform NPE messages

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Validated.java
+++ b/core/lib/src/main/java/dmx/fun/Validated.java
@@ -156,7 +156,8 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @param mapper the mapping function
      * @return a new {@code Validated} with the mapped value, or the original error
      */
-    default <B> Validated<E, B> map(Function<A, B> mapper) {
+    default <B> Validated<E, B> map(Function<? super A, ? extends B> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Valid<E, A> v -> Validated.valid(Objects.requireNonNull(mapper.apply(v.value()), "map mapper returned null"));
             case Invalid<E, A> inv -> Validated.invalid(inv.error());
@@ -170,7 +171,8 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @param mapper the error mapping function
      * @return a new {@code Validated} with the mapped error, or the original value
      */
-    default <F> Validated<F, A> mapError(Function<E, F> mapper) {
+    default <F> Validated<F, A> mapError(Function<? super E, ? extends F> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Valid<E, A> v -> Validated.valid(v.value());
             case Invalid<E, A> inv -> Validated.invalid(Objects.requireNonNull(mapper.apply(inv.error()), "mapError mapper returned null"));
@@ -185,7 +187,8 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @param mapper a function that maps the value to a new {@code Validated}
      * @return the result of {@code mapper} if valid, otherwise this invalid
      */
-    default <B> Validated<E, B> flatMap(Function<A, Validated<E, B>> mapper) {
+    default <B> Validated<E, B> flatMap(Function<? super A, Validated<E, B>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Valid<E, A> v -> Objects.requireNonNull(mapper.apply(v.value()), "flatMap mapper must not return null");
             case Invalid<E, A> inv -> Validated.invalid(inv.error());
@@ -239,7 +242,7 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
     default <B, C> Validated<E, C> combine(
         Validated<E, B> other,
         BinaryOperator<E> errMerge,
-        BiFunction<A, B, C> valueMerge
+        BiFunction<? super A, ? super B, ? extends C> valueMerge
     ) {
         Objects.requireNonNull(valueMerge, "valueMerge");
         return product(other, errMerge).map(t -> valueMerge.apply(t._1(), t._2()));
@@ -253,7 +256,7 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @param action a consumer of the value
      * @return this instance
      */
-    default Validated<E, A> peek(Consumer<A> action) {
+    default Validated<E, A> peek(Consumer<? super A> action) {
         Objects.requireNonNull(action, "action");
         if (this instanceof Valid<E, A>(A value)) {
             action.accept(value);
@@ -267,7 +270,7 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @param action a consumer of the error
      * @return this instance
      */
-    default Validated<E, A> peekError(Consumer<E> action) {
+    default Validated<E, A> peekError(Consumer<? super E> action) {
         Objects.requireNonNull(action, "action");
         if (this instanceof Invalid<E, A>(E error)) {
             action.accept(error);
@@ -600,7 +603,7 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
      * @throws NullPointerException if {@code error} is {@code null}
      */
     static <E, A> Validated<NonEmptyList<E>, A> invalidNel(E error) {
-        Objects.requireNonNull(error, "error must not be null");
+        Objects.requireNonNull(error, "error");
         return Validated.invalid(NonEmptyList.singleton(error));
     }
 
@@ -622,7 +625,7 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
     static <E, A> Validated<NonEmptyList<E>, List<A>> sequenceNel(
         Iterable<Validated<NonEmptyList<E>, A>> validated
     ) {
-        Objects.requireNonNull(validated, "validated must not be null");
+        Objects.requireNonNull(validated, "validated");
         return Validated.sequence(validated, NonEmptyList::concat);
     }
 
@@ -647,8 +650,8 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
         Iterable<A> values,
         Function<? super A, Validated<NonEmptyList<E>, B>> mapper
     ) {
-        Objects.requireNonNull(values, "values must not be null");
-        Objects.requireNonNull(mapper, "mapper must not be null");
+        Objects.requireNonNull(values, "values");
+        Objects.requireNonNull(mapper, "mapper");
         return Validated.traverse(values, mapper, NonEmptyList::concat);
     }
 
@@ -692,11 +695,11 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
         BinaryOperator<E> errMerge,
         TriFunction<? super A, ? super B, ? super C, ? extends R> valueMerge
     ) {
-        Objects.requireNonNull(va,         "va must not be null");
-        Objects.requireNonNull(vb,         "vb must not be null");
-        Objects.requireNonNull(vc,         "vc must not be null");
-        Objects.requireNonNull(errMerge,   "errMerge must not be null");
-        Objects.requireNonNull(valueMerge, "valueMerge must not be null");
+        Objects.requireNonNull(va,         "va");
+        Objects.requireNonNull(vb,         "vb");
+        Objects.requireNonNull(vc,         "vc");
+        Objects.requireNonNull(errMerge,   "errMerge");
+        Objects.requireNonNull(valueMerge, "valueMerge");
         return va.combine(vb, errMerge, Tuple2::new)
                  .combine(vc, errMerge, (t, c) -> valueMerge.apply(t._1(), t._2(), c));
     }
@@ -745,12 +748,12 @@ public sealed interface Validated<E, A> extends Bicontainer<A, E> permits Valida
         BinaryOperator<E> errMerge,
         QuadFunction<? super A, ? super B, ? super C, ? super D, ? extends R> valueMerge
     ) {
-        Objects.requireNonNull(va,         "va must not be null");
-        Objects.requireNonNull(vb,         "vb must not be null");
-        Objects.requireNonNull(vc,         "vc must not be null");
-        Objects.requireNonNull(vd,         "vd must not be null");
-        Objects.requireNonNull(errMerge,   "errMerge must not be null");
-        Objects.requireNonNull(valueMerge, "valueMerge must not be null");
+        Objects.requireNonNull(va,         "va");
+        Objects.requireNonNull(vb,         "vb");
+        Objects.requireNonNull(vc,         "vc");
+        Objects.requireNonNull(vd,         "vd");
+        Objects.requireNonNull(errMerge,   "errMerge");
+        Objects.requireNonNull(valueMerge, "valueMerge");
         return va.combine(vb, errMerge, Tuple2::new)
                  .combine(vc, errMerge, Tuple2::new)
                  .combine(vd, errMerge, (t, d) -> valueMerge.apply(t._1()._1(), t._1()._2(), t._2(), d));

--- a/core/lib/src/test/java/dmx/fun/ValidatedTest.java
+++ b/core/lib/src/test/java/dmx/fun/ValidatedTest.java
@@ -250,6 +250,70 @@ class ValidatedTest {
             .isFalse();
     }
 
+    // ---------- Null-check guards ----------
+
+    @Test
+    void map_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.valid(1).map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void map_onInvalid_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void mapError_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").mapError(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void mapError_onValid_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>valid(1).mapError(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.valid(1).flatMap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMap_onInvalid_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").flatMap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMap_shouldThrowNPE_whenMapperReturnsNull() {
+        assertThatThrownBy(() -> Validated.valid(1).flatMap(_ -> null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void peek_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Validated.valid(1).peek(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
+    @Test
+    void peekError_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").peekError(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
     @Test
     void match_onValid_shouldCallOnValidConsumer() {
         var val = new AtomicReference<Integer>();

--- a/core/lib/src/test/java/dmx/fun/ValidatedTest.java
+++ b/core/lib/src/test/java/dmx/fun/ValidatedTest.java
@@ -308,8 +308,22 @@ class ValidatedTest {
     }
 
     @Test
+    void peek_onInvalid_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").peek(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
+    @Test
     void peekError_shouldThrowNPE_whenActionIsNull() {
         assertThatThrownBy(() -> Validated.<String, Integer>invalid("err").peekError(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
+    @Test
+    void peekError_onValid_shouldThrowNPE_whenActionIsNull() {
+        assertThatThrownBy(() -> Validated.<String, Integer>valid(1).peekError(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("action");
     }

--- a/site/src/data/code/guide/validated/transforming.mdx
+++ b/site/src/data/code/guide/validated/transforming.mdx
@@ -5,14 +5,25 @@ fileName: 'Demo.java'
 ```java
 Validated<String, Integer> v = parse(input);
 
-// map — transforms the value; Invalid passes through
+// map — transforms the value; Invalid passes through unchanged
 Validated<String, String> hex = v.map(Integer::toHexString);
 
-// mapError — transforms the error; Valid passes through
-Validated<AppError, Integer> typed = v.mapError(msg -> new AppError(msg));
+// Bounded wildcards: a Function<Number, CharSequence> is accepted where
+// Function<Integer, String> was historically required
+Function<Number, CharSequence> broad = n -> n.toString();
+Validated<String, CharSequence> cs = v.map(broad); // compiles
+
+// mapError — transforms the error; Valid passes through unchanged
+Validated<AppError, Integer> typed = v.mapError(AppError::new);
 
 // flatMap — fail-fast sequential composition (does NOT accumulate)
 // Use only when the second validation depends on the first
 Validated<String, Address> address = validateCity(input)
     .flatMap(city -> validateZip(input, city)); // zip depends on city
+
+// Null safety: all three methods null-check the function argument eagerly.
+// NPE fires immediately, regardless of whether this is Valid or Invalid.
+v.map(null);      // NullPointerException("mapper") — always
+v.mapError(null); // NullPointerException("mapper") — always
+v.flatMap(null);  // NullPointerException("mapper") — always
 ```

--- a/site/src/data/guide/validated.mdx
+++ b/site/src/data/guide/validated.mdx
@@ -77,6 +77,15 @@ Prefer exhaustive switch patterns — the compiler enforces that both tracks are
 accumulate errors. Use it only when the second validation logically depends on
 the first. For independent validations, always use `combine`.
 
+**Null safety:** `map`, `mapError`, `flatMap`, `peek`, and `peekError` all
+null-check their function argument eagerly — `NullPointerException` is thrown
+immediately regardless of whether the instance is `Valid` or `Invalid`.
+
+**Broader function reuse:** all five methods accept bounded wildcard types
+(`Function<? super A, ? extends B>`, `Consumer<? super A>`, etc.), so a
+`Consumer<Object>` or `Function<Animal, String>` can be passed where a more
+specific type was previously required.
+
 ## Combining independent validations
 
 `combine(other, errMerge, valueMerge)` is the core of error accumulation.


### PR DESCRIPTION
  - Add Objects.requireNonNull(mapper, "mapper") to map, mapError, and flatMap;
    NPE now fires eagerly regardless of Valid/Invalid state, consistent with
    peek and peekError which already null-checked their action argument
  - Widen function parameter types to bounded wildcards: map uses
    Function<? super A, ? extends B>, mapError uses Function<? super E, ? extends F>,
    flatMap uses Function<? super A, Validated<E, B>>, peek and peekError use
    Consumer<? super A/E>, combine uses BiFunction<? super A, ? super B, ? extends C>;
    consistent with combine3/combine4 which already used wildcards
  - Standardize NPE message format to parameter-name-only throughout the file;
    invalidNel, sequenceNel, traverseNel, combine3, and combine4 previously
    appended " must not be null" while every other method used only the name
  - Skip ArrayList::new refactor in collector/traverseCollector: the constructor
    reference loses the type parameter, causing a compile error (ArrayList<Object>
    inferred instead of ArrayList<Validated<E,A>>)
  - Add 9 NPE tests covering null mapper/action on both Valid and Invalid paths,
    and null return from flatMap mapper
  - Update Validated guide: document eager null-check guarantee and bounded
    wildcard flexibility in the "Transforming values" section

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #393

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - `Validated` transformation methods now accept more general function types for improved code flexibility and composability.

* **Documentation**
  - Updated guides documenting null-safety guarantees and broader function type compatibility for transformation methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->