### PR TITLE
fix(lazy): deduplicate rethrow logic, align NPE messages, and polish Javadoc

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Lazy.java
+++ b/core/lib/src/main/java/dmx/fun/Lazy.java
@@ -117,11 +117,13 @@ public final class Lazy<T> {
      * Evaluates this {@code Lazy} and wraps the result in an {@link Option}.
      *
      * <p>Unlike {@link #toTry()}, this method does <em>not</em> capture exceptions —
-     * if the supplier throws, the exception propagates to the caller.
+     * any unchecked throwable ({@link RuntimeException} or {@link Error}) thrown by the
+     * supplier propagates to the caller, with the same semantics as {@link #get()}.
      * Use {@code toTry().toOption()} if you need exception-safe conversion.
      *
      * @return {@code Option.some(value)}
-     * @throws RuntimeException if the supplier throws (same semantics as {@link #get()})
+     * @throws RuntimeException if the supplier throws a {@code RuntimeException}
+     * @throws Error            if the supplier throws an {@code Error}
      */
     public Option<T> toOption() {
         return Option.some(get());
@@ -214,11 +216,13 @@ public final class Lazy<T> {
      * {@link java.util.Optional Optional}.
      *
      * <p>Unlike {@link #toTry()}, this method does <em>not</em> capture exceptions —
-     * if the supplier throws, the exception propagates to the caller.
+     * any unchecked throwable ({@link RuntimeException} or {@link Error}) thrown by the
+     * supplier propagates to the caller, with the same semantics as {@link #get()}.
      * Use {@code toTry().toOptional()} if you need exception-safe conversion.
      *
      * @return {@code Optional.of(value)}; never {@code Optional.empty()}
-     * @throws RuntimeException if the supplier throws (same semantics as {@link #get()})
+     * @throws RuntimeException if the supplier throws a {@code RuntimeException}
+     * @throws Error            if the supplier throws an {@code Error}
      */
     public Optional<T> toOptional() {
         return Optional.of(get());

--- a/core/lib/src/main/java/dmx/fun/Lazy.java
+++ b/core/lib/src/main/java/dmx/fun/Lazy.java
@@ -69,14 +69,7 @@ public final class Lazy<T> {
         if (s.isSuccess()) {
             return s.get();
         }
-        var cause = s.getCause();
-        if (cause instanceof RuntimeException re) {
-            throw re;
-        }
-        if (cause instanceof Error e) {
-            throw e;
-        }
-        throw new RuntimeException(cause);
+        throw rethrowOrWrap(s.getCause());
     }
 
     /**
@@ -100,7 +93,7 @@ public final class Lazy<T> {
      * @throws NullPointerException if {@code f} is {@code null}
      */
     public <R> Lazy<R> map(Function<? super T, ? extends R> f) {
-        Objects.requireNonNull(f, "f must not be null");
+        Objects.requireNonNull(f, "mapper must not be null");
         return Lazy.of(() -> Objects.requireNonNull(f.apply(get()), "map function returned null"));
     }
 
@@ -116,14 +109,19 @@ public final class Lazy<T> {
      * @throws NullPointerException if {@code f} is {@code null} or returns {@code null}
      */
     public <R> Lazy<R> flatMap(Function<? super T, Lazy<? extends R>> f) {
-        Objects.requireNonNull(f, "f must not be null");
+        Objects.requireNonNull(f, "mapper must not be null");
         return Lazy.of(() -> Objects.requireNonNull(f.apply(get()), "flatMap function returned null").get());
     }
 
     /**
      * Evaluates this {@code Lazy} and wraps the result in an {@link Option}.
      *
+     * <p>Unlike {@link #toTry()}, this method does <em>not</em> capture exceptions —
+     * if the supplier throws, the exception propagates to the caller.
+     * Use {@code toTry().toOption()} if you need exception-safe conversion.
+     *
      * @return {@code Option.some(value)}
+     * @throws RuntimeException if the supplier throws (same semantics as {@link #get()})
      */
     public Option<T> toOption() {
         return Option.some(get());
@@ -160,17 +158,7 @@ public final class Lazy<T> {
     public static <T> Lazy<T> fromFuture(CompletableFuture<? extends T> future) {
         Objects.requireNonNull(future, "future must not be null");
         return Lazy.of(
-            () -> Try.<T>fromFuture(future)
-                .getOrThrow(cause -> {
-                        if (cause instanceof RuntimeException re) {
-                            return re;
-                        }
-                        if (cause instanceof Error e) {
-                            throw e;
-                        }
-                        return new RuntimeException(cause);
-                    }
-                )
+            () -> Try.<T>fromFuture(future).getOrThrow(Lazy::rethrowOrWrap)
         );
     }
 
@@ -285,6 +273,17 @@ public final class Lazy<T> {
     }
 
     // ── internals ─────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the cause as a {@link RuntimeException} if it already is one, or wraps it.
+     * Rethrows {@link Error} directly — {@code Error} subclasses signal unrecoverable JVM
+     * conditions and must not be wrapped.
+     */
+    private static RuntimeException rethrowOrWrap(Throwable cause) {
+        if (cause instanceof RuntimeException re) return re;
+        if (cause instanceof Error e) throw e;
+        return new RuntimeException(cause);
+    }
 
     private Try<T> evaluate() {
         // Using a local variable throughout

--- a/core/lib/src/test/java/dmx/fun/LazyTest.java
+++ b/core/lib/src/test/java/dmx/fun/LazyTest.java
@@ -124,7 +124,9 @@ class LazyTest {
 
     @Test
     void map_nullFunction_throwsNullPointerException() {
-        assertThatThrownBy(() -> Lazy.of(() -> "x").map(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Lazy.of(() -> "x").map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
     }
 
     @Test
@@ -154,7 +156,9 @@ class LazyTest {
 
     @Test
     void flatMap_nullFunction_throwsNullPointerException() {
-        assertThatThrownBy(() -> Lazy.of(() -> "x").flatMap(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Lazy.of(() -> "x").flatMap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
     }
 
     @Test
@@ -170,6 +174,12 @@ class LazyTest {
         var opt = Lazy.of(() -> "value").toOption();
         assertThat(opt.isDefined()).isTrue();
         assertThat(opt.get()).isEqualTo("value");
+    }
+
+    @Test
+    void toOption_throwingSupplier_propagatesException() {
+        var lazy = Lazy.<String>of(() -> { throw new IllegalStateException("boom"); });
+        assertThatThrownBy(lazy::toOption).isInstanceOf(IllegalStateException.class);
     }
 
     // ---------- toTry ----------

--- a/site/src/data/code/guide/lazy/interop-conversions.mdx
+++ b/site/src/data/code/guide/lazy/interop-conversions.mdx
@@ -25,7 +25,9 @@ Either<AppError, Config> e2 = config.toEither(ex -> new AppError("Config load fa
 // ── Unsafe conversions (propagate exceptions) ────────────────────────────────
 
 // toOption() — forces evaluation; wraps value in Some (throws if supplier throws)
+//   Use toTry().toOption() for a safe, exception-capturing alternative
 Option<Config> opt = config.toOption();
+Option<Config> safeOption = config.toTry().toOption(); // None on failure
 
 // toOptional() — forces evaluation; wraps value in Optional.of (throws if supplier throws)
 //   Use toTry().toOptional() for a safe, exception-capturing alternative

--- a/site/src/data/guide/lazy.mdx
+++ b/site/src/data/guide/lazy.mdx
@@ -69,7 +69,7 @@ until the terminal `get()` is invoked on the result.
 | `toResult(errorMapper)`   | Yes                | `Result<T, E>`             | Maps exception to a domain error.                                 |
 | `toEither()`              | Yes                | `Either<Throwable, T>`     | Exception becomes `Left`; safe (no throw).                        |
 | `toEither(errorMapper)`   | Yes                | `Either<E, T>`             | Maps exception to a typed left value; safe (no throw).            |
-| `toOption()`              | Yes                | `Option<T>`                | Throws if supplier throws.                                        |
+| `toOption()`              | Yes                | `Option<T>`                | Throws if supplier throws. Use `toTry().toOption()` for safe conversion. |
 | `toOptional()`            | Yes                | `Optional<T>`              | JDK interop; throws if supplier throws. Use `toTry().toOptional()` for safe conversion. |
 | `toFuture()`              | No (async if not cached) | `CompletableFuture<T>` | Returns already-completed future if cached; async via `supplyAsync` otherwise. |
 | `Lazy.fromFuture(future)` | No                 | `Lazy<T>`                  | Defers the blocking join to `get()` time.                         |


### PR DESCRIPTION
  Extract private rethrowOrWrap(Throwable) helper to eliminate the duplicate
  RuntimeException/Error branching that existed in both get() and fromFuture().
  Rename NPE messages "f must not be null" → "mapper must not be null" in map()
  and flatMap() to match the `@param` name and library convention. Document that
  toOption() propagates supplier exceptions to the caller (same semantics as
  get()); recommend toTry().toOption() for exception-safe conversion.

  Update the Lazy guide: add the safe-alternative hint to the toOption() row
  in the interop table and add a toTry().toOption() example in the code snippet,
  parallel to the existing toTry().toOptional() pattern.

  Strengthen LazyTest: assert NPE message contains "mapper" for map/flatMap
  null-function checks; add toOption_throwingSupplier_propagatesException.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #389

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error messages for invalid parameters in operations.

* **Documentation**
  * Clarified exception handling behavior during value conversions.
  * Added safer conversion pattern recommendations with practical examples.
  * Improved guidance for lazy value transformation workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/431)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->