### PR TITLE
fix(option): null-check gaps, ofNullable misuse, sequenceCollector type, and raw casts

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Option.java
+++ b/core/lib/src/main/java/dmx/fun/Option.java
@@ -954,7 +954,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
             case None<?> _ -> Option.none();
             case Some<? extends A> sa -> switch (b) {
                 case None<?> _ -> Option.none();
-                case Some<? extends B> sb -> Option.ofNullable(combiner.apply(sa.value(), sb.value()));
+                case Some<? extends B> sb -> Option.some(
+                    Objects.requireNonNull(combiner.apply(sa.value(), sb.value()), "combiner returned null"));
             };
         };
     }
@@ -1023,7 +1024,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
                 case None<?> _ -> Option.none();
                 case Some<? extends B> sb -> switch (c) {
                     case None<?> _ -> Option.none();
-                    case Some<? extends C> sc -> Option.ofNullable(combiner.apply(sa.value(), sb.value(), sc.value()));
+                    case Some<? extends C> sc -> Option.some(
+                        Objects.requireNonNull(combiner.apply(sa.value(), sb.value(), sc.value()), "combiner returned null"));
                 };
             };
         };
@@ -1106,7 +1108,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
                     case None<?> _ -> Option.none();
                     case Some<? extends C> sc -> switch (d) {
                         case None<?> _ -> Option.none();
-                        case Some<? extends D> sd -> Option.ofNullable(combiner.apply(sa.value(), sb.value(), sc.value(), sd.value()));
+                        case Some<? extends D> sd -> Option.some(
+                            Objects.requireNonNull(combiner.apply(sa.value(), sb.value(), sc.value(), sd.value()), "combiner returned null"));
                     };
                 };
             };

--- a/core/lib/src/main/java/dmx/fun/Option.java
+++ b/core/lib/src/main/java/dmx/fun/Option.java
@@ -127,6 +127,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * or an empty {@code None} instance if the {@link Optional} is empty
      */
     static <V> Option<V> fromOptional(Optional<V> optional) {
+        Objects.requireNonNull(optional, "optional");
         return optional.map(Option::some).orElseGet(Option::none);
     }
 
@@ -190,6 +191,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * or the fallback value computed by the {@code fallbackSupplier} if this instance is a {@code None}
      */
     default Value getOrElseGet(Supplier<? extends Value> fallbackSupplier) {
+        Objects.requireNonNull(fallbackSupplier, "fallbackSupplier");
         return this instanceof Some<Value>(Value v) ? v : fallbackSupplier.get();
     }
 
@@ -243,6 +245,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      *                          using the exception provided by {@code exceptionSupplier}
      */
     default Value getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
+        Objects.requireNonNull(exceptionSupplier, "exceptionSupplier");
         return switch (this) {
             case Some<Value> s -> s.value();
             case None<Value> _ -> throw exceptionSupplier.get();
@@ -257,12 +260,16 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * If the current Option is a None, returns None without applying the mapper.
      *
      * @param <NewValue> the type of the value in the resulting Option after transformation
-     * @param mapper     the function to apply to the value if this Option is a Some
+     * @param mapper     the function to apply to the value if this Option is a Some;
+     *                   must not be {@code null} and must not return {@code null}
      * @return a new Option containing the mapped value if this is a Some, or None if this is a None
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
      */
     default <NewValue> Option<NewValue> map(Function<? super Value, ? extends NewValue> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
-            case Some<Value> s -> Option.ofNullable(mapper.apply(s.value()));
+            case Some<Value> s -> Option.some(
+                Objects.requireNonNull(mapper.apply(s.value()), "map function returned null"));
             case None<Value> _ -> Option.none();
         };
     }
@@ -278,6 +285,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * @throws NullPointerException if the mapping function returns null
      */
     default <NewValue> Option<NewValue> flatMap(Function<? super Value, Option<NewValue>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Some<Value> s -> Objects.requireNonNull(mapper.apply(s.value()),
                 "flatMap mapper must not return null");
@@ -294,6 +302,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * @return an Option containing the value if the predicate evaluates to true, otherwise an empty Option
      */
     default Option<Value> filter(Predicate<? super Value> predicate) {
+        Objects.requireNonNull(predicate, "predicate");
         return switch (this) {
             case Some<Value> s -> predicate.test(s.value()) ? this : Option.none();
             case None<Value> _ -> this;
@@ -307,6 +316,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * @return this instance after applying the provided action
      */
     default Option<Value> peek(Consumer<? super Value> action) {
+        Objects.requireNonNull(action, "action");
         if (this instanceof Some<Value>(Value v)) {
             action.accept(v);
         }
@@ -327,6 +337,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Supplier<? extends Folded> onNone,
         Function<? super Value, ? extends Folded> onSome
     ) {
+        Objects.requireNonNull(onNone, "onNone");
+        Objects.requireNonNull(onSome, "onSome");
         return switch (this) {
             case Some<Value> s -> onSome.apply(s.value());
             case None<Value> _ -> onNone.get();
@@ -342,6 +354,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * @param onSome the consumer to execute if the value is "Some", accepting the inner value
      */
     default void match(Runnable onNone, Consumer<? super Value> onSome) {
+        Objects.requireNonNull(onNone, "onNone");
+        Objects.requireNonNull(onSome, "onSome");
         switch (this) {
             case Some<Value> s -> onSome.accept(s.value());
             case None<Value> _ -> onNone.run();
@@ -435,24 +449,24 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      * Returns a {@link Collector} that reduces a {@code Stream<Option<V>>} to a single
      * {@code Optional<List<V>>}.
      *
-     * <p>The result is {@link Optional#of(Object) present} only if <em>every</em> element in the
+     * <p>The result is {@link Option#some(Object) Some} only if <em>every</em> element in the
      * stream is {@link Option#some(Object) Some}. The first {@link Option#none() None} causes the
-     * entire result to be {@link Optional#empty()}. An empty stream yields an empty list wrapped
-     * in {@code Optional.of}.
+     * entire result to be {@link Option#none()}. An empty stream yields an empty list wrapped
+     * in {@code Option.some}.
      *
      * <p>This mirrors {@link #sequence(Iterable)} but operates as a stream {@link Collector}.
      *
      * <p>Example:
      * <pre>{@code
-     * Optional<List<User>> allFound = ids.stream()
+     * Option<List<User>> allFound = ids.stream()
      *     .map(userRepo::findById)             // Stream<Option<User>>
-     *     .collect(Option.sequenceCollector()); // Optional<List<User>>
+     *     .collect(Option.sequenceCollector()); // Option<List<User>>
      * }</pre>
      *
      * @param <V> the element type inside each {@code Option}
-     * @return a collector producing {@code Optional<List<V>>}
+     * @return a collector producing {@code Option<List<V>>}
      */
-    static <V> Collector<Option<V>, ?, Optional<List<V>>> sequenceCollector() {
+    static <V> Collector<Option<V>, ?, Option<List<V>>> sequenceCollector() {
         class Acc {
             final ArrayList<V> values = new ArrayList<>();
             boolean hasNone = false;
@@ -474,8 +488,8 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
                 return a;
             },
             acc -> acc.hasNone
-                ? Optional.empty()
-                : Optional.of(Collections.unmodifiableList(acc.values))
+                ? Option.none()
+                : Option.some(Collections.unmodifiableList(acc.values))
         );
     }
 
@@ -585,11 +599,13 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     /**
      * Converts the current option to a {@code Result} instance.
      *
-     * @param errorIfNone the error value to use if the current option is {@code None}.
+     * @param errorIfNone the error value to use if the current option is {@code None}; must not be {@code null}
      * @param <TError>    the type of the error value.
      * @return a {@code Result} containing the value if this is {@code Some}, or an error if this is {@code None}.
+     * @throws NullPointerException if {@code errorIfNone} is {@code null}
      */
     default <TError> Result<Value, TError> toResult(TError errorIfNone) {
+        Objects.requireNonNull(errorIfNone, "errorIfNone");
         return switch (this) {
             case Some<Value> s -> Result.ok(s.value());
             case None<Value> _ -> Result.err(errorIfNone);
@@ -650,7 +666,7 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
      */
     static <V, E> Option<V> fromResult(Result<? extends V, ? extends E> result) {
         Objects.requireNonNull(result, "result");
-        return result.isOk() ? Option.ofNullable(result.get()) : Option.none();
+        return result.isOk() ? Option.some(result.get()) : Option.none();
     }
 
     /**
@@ -902,14 +918,13 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
     static <A, B> Option<Tuple2<A, B>> zip(Option<? extends A> a, Option<? extends B> b) {
         Objects.requireNonNull(a, "a");
         Objects.requireNonNull(b, "b");
-
-        if (a instanceof None<?> || b instanceof None<?>) {
-            return Option.none();
-        }
-
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        return Option.some(new Tuple2<>(av, bv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> Option.some(new Tuple2<>(sa.value(), sb.value()));
+            };
+        };
     }
 
     /**
@@ -935,13 +950,13 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Objects.requireNonNull(b, "b");
         Objects.requireNonNull(combiner, "combiner");
 
-        if (a instanceof None<?> || b instanceof None<?>) {
-            return Option.none();
-        }
-
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        return Option.ofNullable(combiner.apply(av, bv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> Option.ofNullable(combiner.apply(sa.value(), sb.value()));
+            };
+        };
     }
 
     // ---------- zip3 / map3 ----------
@@ -966,13 +981,16 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Objects.requireNonNull(a, "a");
         Objects.requireNonNull(b, "b");
         Objects.requireNonNull(c, "c");
-        if (a instanceof None<?> || b instanceof None<?> || c instanceof None<?>) {
-            return Option.none();
-        }
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        C cv = ((Some<? extends C>) c).value();
-        return Option.some(new Tuple3<>(av, bv, cv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> switch (c) {
+                    case None<?> _ -> Option.none();
+                    case Some<? extends C> sc -> Option.some(new Tuple3<>(sa.value(), sb.value(), sc.value()));
+                };
+            };
+        };
     }
 
     /**
@@ -999,13 +1017,16 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Objects.requireNonNull(b, "b");
         Objects.requireNonNull(c, "c");
         Objects.requireNonNull(combiner, "combiner");
-        if (a instanceof None<?> || b instanceof None<?> || c instanceof None<?>) {
-            return Option.none();
-        }
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        C cv = ((Some<? extends C>) c).value();
-        return Option.ofNullable(combiner.apply(av, bv, cv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> switch (c) {
+                    case None<?> _ -> Option.none();
+                    case Some<? extends C> sc -> Option.ofNullable(combiner.apply(sa.value(), sb.value(), sc.value()));
+                };
+            };
+        };
     }
 
     // ---------- zip4 / map4 ----------
@@ -1034,14 +1055,19 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Objects.requireNonNull(b, "b");
         Objects.requireNonNull(c, "c");
         Objects.requireNonNull(d, "d");
-        if (a instanceof None<?> || b instanceof None<?> || c instanceof None<?> || d instanceof None<?>) {
-            return Option.none();
-        }
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        C cv = ((Some<? extends C>) c).value();
-        D dv = ((Some<? extends D>) d).value();
-        return Option.some(new Tuple4<>(av, bv, cv, dv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> switch (c) {
+                    case None<?> _ -> Option.none();
+                    case Some<? extends C> sc -> switch (d) {
+                        case None<?> _ -> Option.none();
+                        case Some<? extends D> sd -> Option.some(new Tuple4<>(sa.value(), sb.value(), sc.value(), sd.value()));
+                    };
+                };
+            };
+        };
     }
 
     /**
@@ -1072,14 +1098,19 @@ public sealed interface Option<Value> permits Option.Some, Option.None {
         Objects.requireNonNull(c, "c");
         Objects.requireNonNull(d, "d");
         Objects.requireNonNull(combiner, "combiner");
-        if (a instanceof None<?> || b instanceof None<?> || c instanceof None<?> || d instanceof None<?>) {
-            return Option.none();
-        }
-        A av = ((Some<? extends A>) a).value();
-        B bv = ((Some<? extends B>) b).value();
-        C cv = ((Some<? extends C>) c).value();
-        D dv = ((Some<? extends D>) d).value();
-        return Option.ofNullable(combiner.apply(av, bv, cv, dv));
+        return switch (a) {
+            case None<?> _ -> Option.none();
+            case Some<? extends A> sa -> switch (b) {
+                case None<?> _ -> Option.none();
+                case Some<? extends B> sb -> switch (c) {
+                    case None<?> _ -> Option.none();
+                    case Some<? extends C> sc -> switch (d) {
+                        case None<?> _ -> Option.none();
+                        case Some<? extends D> sd -> Option.ofNullable(combiner.apply(sa.value(), sb.value(), sc.value(), sd.value()));
+                    };
+                };
+            };
+        };
     }
 
 }

--- a/core/lib/src/main/java/dmx/fun/Options.java
+++ b/core/lib/src/main/java/dmx/fun/Options.java
@@ -1,7 +1,6 @@
 package dmx.fun;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collector;
 import org.jspecify.annotations.NullMarked;
 
@@ -18,7 +17,7 @@ import org.jspecify.annotations.NullMarked;
  * import static dmx.fun.Options.*;
  *
  * List<String>              present = stream.collect(Options.presentToList());
- * Optional<List<String>>    seq     = stream.collect(Options.sequence());
+ * Option<List<String>>      seq     = stream.collect(Options.sequence());
  * Option<NonEmptyList<String>> nel  = stream.collect(Options.toNonEmptyList());
  * }</pre>
  *
@@ -45,15 +44,15 @@ public final class Options {
 
     /**
      * Returns a {@link Collector} that reduces a {@code Stream<Option<V>>} to a single
-     * {@code Optional<List<V>>}: {@code Optional.of(list)} if every element is present,
-     * or {@code Optional.empty()} if any element is empty.
+     * {@code Option<List<V>>}: {@code Option.some(list)} if every element is present,
+     * or {@code Option.none()} if any element is empty.
      *
      * <p>Delegates to {@link Option#sequenceCollector()}.
      *
      * @param <V> the value type
-     * @return a collector producing {@code Optional<List<V>>}
+     * @return a collector producing {@code Option<List<V>>}
      */
-    public static <V> Collector<Option<V>, ?, Optional<List<V>>> sequence() {
+    public static <V> Collector<Option<V>, ?, Option<List<V>>> sequence() {
         return Option.sequenceCollector();
     }
 

--- a/core/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/core/lib/src/test/java/dmx/fun/OptionTest.java
@@ -189,7 +189,7 @@ class OptionTest {
     void map_nullReturningMapper_throwsNPE() {
         assertThatThrownBy(() -> Option.some(1).map(v -> null))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("null");
+            .hasMessageContaining("map function returned null");
     }
 
     @Test

--- a/core/lib/src/test/java/dmx/fun/OptionTest.java
+++ b/core/lib/src/test/java/dmx/fun/OptionTest.java
@@ -36,7 +36,9 @@ class OptionTest {
 
     @Test
     void fromOptional_nullOptional_shouldThrowNPE() {
-        assertThatThrownBy(() -> Option.fromOptional(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Option.fromOptional(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("optional");
     }
 
     @Test
@@ -157,6 +159,20 @@ class OptionTest {
     }
 
     @Test
+    void getOrThrow_nullSupplier_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).getOrThrow(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("exceptionSupplier");
+    }
+
+    @Test
+    void getOrElseGet_nullSupplier_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).getOrElseGet(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("fallbackSupplier");
+    }
+
+    @Test
     void get_onNone_shouldThrow_NoSuchElementException_messageShouldMentionNone() {
         assertThatThrownBy(() -> Option.none().get())
             .isInstanceOf(NoSuchElementException.class)
@@ -170,8 +186,38 @@ class OptionTest {
     }
 
     @Test
-    void map_shouldTurnNullIntoNone() {
-        assertThat(Option.some(1).map(v -> null)).isEqualTo(Option.none());
+    void map_nullReturningMapper_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).map(v -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("null");
+    }
+
+    @Test
+    void map_nullMapper_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void map_nullMapper_onNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.<Integer>none().map(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMap_nullMapper_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).flatMap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMap_nullMapper_onNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.<Integer>none().flatMap(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
     }
 
     @Test
@@ -219,6 +265,20 @@ class OptionTest {
     }
 
     @Test
+    void filter_nullPredicate_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).filter(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("predicate");
+    }
+
+    @Test
+    void filter_nullPredicate_onNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.<Integer>none().filter(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("predicate");
+    }
+
+    @Test
     void peek_shouldRunForSome_andNotForNone() {
         AtomicInteger sum = new AtomicInteger(0);
 
@@ -227,6 +287,20 @@ class OptionTest {
 
         Option.<Integer>none().peek(sum::addAndGet);
         assertThat(sum.get()).as("peek must not run for None").isEqualTo(7);
+    }
+
+    @Test
+    void peek_nullAction_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).peek(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
+    }
+
+    @Test
+    void peek_nullAction_onNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.<Integer>none().peek(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("action");
     }
 
     @Test
@@ -255,12 +329,40 @@ class OptionTest {
     }
 
     @Test
+    void match_nullOnNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).match(null, v -> {}))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onNone");
+    }
+
+    @Test
+    void match_nullOnSome_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).match(() -> {}, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onSome");
+    }
+
+    @Test
     void fold_shouldChooseBranch() {
         String a = Option.some(5).fold(() -> "none", v -> "some:" + v);
         String b = Option.<Integer>none().fold(() -> "none", v -> "some:" + v);
 
         assertThat(a).isEqualTo("some:5");
         assertThat(b).isEqualTo("none");
+    }
+
+    @Test
+    void fold_nullOnNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).fold(null, v -> "x"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onNone");
+    }
+
+    @Test
+    void fold_nullOnSome_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).fold(() -> "x", null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onSome");
     }
 
     @Test
@@ -509,6 +611,20 @@ class OptionTest {
     }
 
     @Test
+    void toResult_nullErrorIfNone_throwsNPE() {
+        assertThatThrownBy(() -> Option.<Integer>none().toResult(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorIfNone");
+    }
+
+    @Test
+    void toResult_nullErrorIfNone_onSome_throwsNPE() {
+        assertThatThrownBy(() -> Option.some(1).toResult(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorIfNone");
+    }
+
+    @Test
     void toTry_shouldReturnSuccessForSome_andFailureForNone() {
         Try<Integer> a = Option.some(10).toTry(() -> new RuntimeException("boom"));
         Try<Integer> b = Option.<Integer>none().toTry(() -> new RuntimeException("boom"));
@@ -657,32 +773,32 @@ class OptionTest {
 
     @Test
     void sequenceCollector_shouldReturnPresentList_whenAllSome() {
-        Optional<List<String>> result = Stream.of(
+        Option<List<String>> result = Stream.of(
                 Option.some("a"), Option.some("b"), Option.some("c"))
             .collect(Option.sequenceCollector());
-        assertThat(result).isPresent();
+        assertThat(result.isDefined()).isTrue();
         assertThat(result.get()).containsExactly("a", "b", "c");
     }
 
     @Test
-    void sequenceCollector_shouldReturnEmpty_whenAnyNone() {
-        Optional<List<String>> result = Stream.of(
+    void sequenceCollector_shouldReturnNone_whenAnyNone() {
+        Option<List<String>> result = Stream.of(
                 Option.some("a"), Option.<String>none(), Option.some("c"))
             .collect(Option.sequenceCollector());
-        assertThat(result).isEmpty();
+        assertThat(result.isEmpty()).isTrue();
     }
 
     @Test
-    void sequenceCollector_shouldReturnPresentEmptyList_forEmptyStream() {
-        Optional<List<String>> result = Stream.<Option<String>>empty()
+    void sequenceCollector_shouldReturnSomeEmptyList_forEmptyStream() {
+        Option<List<String>> result = Stream.<Option<String>>empty()
             .collect(Option.sequenceCollector());
-        assertThat(result).isPresent();
+        assertThat(result.isDefined()).isTrue();
         assertThat(result.get()).isEmpty();
     }
 
     @Test
     void sequenceCollector_resultListShouldBeUnmodifiable() {
-        Optional<List<String>> result = Stream.of(Option.some("a"))
+        Option<List<String>> result = Stream.of(Option.some("a"))
             .collect(Option.sequenceCollector());
         assertThatThrownBy(() -> result.get().add("z"))
             .isInstanceOf(UnsupportedOperationException.class);
@@ -692,19 +808,19 @@ class OptionTest {
     void sequenceCollector_parallelStream_allSome_shouldCombinePartialAccumulators() {
         List<Option<Integer>> items = List.of(
             Option.some(1), Option.some(2), Option.some(3), Option.some(4));
-        Optional<List<Integer>> result = items.parallelStream()
+        Option<List<Integer>> result = items.parallelStream()
             .collect(Option.sequenceCollector());
-        assertThat(result).isPresent();
+        assertThat(result.isDefined()).isTrue();
         assertThat(result.get()).containsExactlyInAnyOrder(1, 2, 3, 4);
     }
 
     @Test
-    void sequenceCollector_parallelStream_withNone_shouldReturnEmpty() {
+    void sequenceCollector_parallelStream_withNone_shouldReturnNone() {
         List<Option<Integer>> items = List.of(
             Option.some(1), Option.none(), Option.some(3));
-        Optional<List<Integer>> result = items.parallelStream()
+        Option<List<Integer>> result = items.parallelStream()
             .collect(Option.sequenceCollector());
-        assertThat(result).isEmpty();
+        assertThat(result.isEmpty()).isTrue();
     }
 
     // ---------- fromResult ----------

--- a/core/lib/src/test/java/dmx/fun/OptionZip4Test.java
+++ b/core/lib/src/test/java/dmx/fun/OptionZip4Test.java
@@ -117,10 +117,17 @@ class OptionZip4Test {
     }
 
     @Test
-    void map4_static_nullResultTreatedAsNone() {
-        var result = Option.map4(Option.some(1), Option.some(2), Option.some(3), Option.some(4),
-            (a, b, c, d) -> null);
-        assertEquals(Option.none(), result);
+    void map4_static_nullResultTreatedAsNone_throwsNullPointerException() {
+        assertThrows(
+            NullPointerException.class,
+            () -> Option.map4(
+                Option.some(1),
+                Option.some(2),
+                Option.some(3),
+                Option.some(4),
+                (_, _, _, _) -> null
+            )
+        );
     }
 
     @Test

--- a/core/lib/src/test/java/dmx/fun/OptionZipTest.java
+++ b/core/lib/src/test/java/dmx/fun/OptionZipTest.java
@@ -62,9 +62,15 @@ class OptionZipTest {
     }
 
     @Test
-    void map2_combinerReturnsNull_returnsNone() {
-        Option<String> r = Option.map2(Option.some(1), Option.some(2), (a, b) -> null);
-        assertEquals(Option.none(), r);
+    void map2_combinerReturnsNull_throwsNullPointerException() {
+        assertThrows(
+            NullPointerException.class,
+            () -> Option.map2(
+                Option.some(1),
+                Option.some(2),
+                (_, _) -> null
+            )
+        );
     }
 
     @Test
@@ -153,10 +159,16 @@ class OptionZipTest {
     }
 
     @Test
-    void map3_static_nullResultTreatedAsNone() {
-        var result = Option.map3(Option.some(1), Option.some(2), Option.some(3),
-            (a, b, c) -> null);
-        assertEquals(Option.none(), result);
+    void map3_static_nullResultThrowsNullPointerException() {
+        assertThrows(
+            NullPointerException.class,
+            () -> Option.map3(
+                Option.some(1),
+                Option.some(2),
+                Option.some(3),
+                (_, _, _) -> null
+            )
+        );
     }
 
     @Test

--- a/core/lib/src/test/java/dmx/fun/OptionsFacadeTest.java
+++ b/core/lib/src/test/java/dmx/fun/OptionsFacadeTest.java
@@ -1,7 +1,6 @@
 package dmx.fun;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -39,28 +38,28 @@ class OptionsFacadeTest {
     // ── Options.sequence() ────────────────────────────────────────────────────
 
     @Test
-    void sequence_allPresent_returnsOptionalOfList() {
-        Optional<List<String>> result = Stream.of(Option.some("x"), Option.some("y"))
+    void sequence_allPresent_returnsSomeList() {
+        Option<List<String>> result = Stream.of(Option.some("x"), Option.some("y"))
             .collect(Options.sequence());
 
-        assertThat(result).isPresent();
+        assertThat(result.isDefined()).isTrue();
         assertThat(result.get()).containsExactly("x", "y");
     }
 
     @Test
-    void sequence_anyNone_returnsEmpty() {
-        Optional<List<String>> result = Stream.<Option<String>>of(Option.some("x"), Option.none())
+    void sequence_anyNone_returnsNone() {
+        Option<List<String>> result = Stream.<Option<String>>of(Option.some("x"), Option.none())
             .collect(Options.sequence());
 
-        assertThat(result).isEmpty();
+        assertThat(result.isEmpty()).isTrue();
     }
 
     @Test
-    void sequence_emptyStream_returnsOptionalOfEmptyList() {
-        Optional<List<String>> result = Stream.<Option<String>>of()
+    void sequence_emptyStream_returnsSomeEmptyList() {
+        Option<List<String>> result = Stream.<Option<String>>of()
             .collect(Options.sequence());
 
-        assertThat(result).isPresent();
+        assertThat(result.isDefined()).isTrue();
         assertThat(result.get()).isEmpty();
     }
 

--- a/samples/samples/src/main/java/dmx/fun/samples/OptionSample.java
+++ b/samples/samples/src/main/java/dmx/fun/samples/OptionSample.java
@@ -1,9 +1,6 @@
 package dmx.fun.samples;
 
 import dmx.fun.Option;
-import dmx.fun.Tuple2;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -24,71 +21,77 @@ public class OptionSample {
         return "api.example.com".equals(host) ? Option.some(8080) : Option.none();
     }
 
-    public static void main(String[] args) {
+    static void main() {
         // Transform the value if present — map returns None when the source is None
-        Option<Integer> length = findEmail("alice").map(String::length);
-        System.out.println("Email length: " + length.getOrElse(0)); // 17
+        var length = findEmail("alice")
+            .map(String::length);
+        IO.println("Email length: " + length.getOrElse(0)); // 17
 
         // Chain a lookup that may also produce None
-        Option<String> domain = findEmail("alice")
+        var domain = findEmail("alice")
             .flatMap(email -> {
                 int at = email.indexOf('@');
                 return at >= 0 ? Option.some(email.substring(at + 1)) : Option.none();
             });
-        System.out.println("Domain: " + domain.getOrElse("unknown")); // example.com
+        IO.println("Domain: " + domain.getOrElse("unknown")); // example.com
 
         // Missing user — all combinators propagate None gracefully
-        Option<String> missing = findEmail("bob").map(String::toUpperCase);
-        System.out.println("Missing: " + missing.getOrElse("not found")); // not found
+        var missing = findEmail("bob")
+            .map(String::toUpperCase);
+        IO.println("Missing: " + missing.getOrElse("not found")); // not found
 
         // Pattern match with sealed interface
-        String result = switch (findEmail("alice")) {
+        var result = switch (findEmail("alice")) {
             case Option.Some<String> some -> "Found: " + some.value();
-            case Option.None<String> none -> "Not found";
+            case Option.None<String> _ -> "Not found";
         };
-        System.out.println(result); // Found: alice@example.com
+        IO.println(result); // Found: alice@example.com
 
         // ---- zipWith(Function) / flatZip ----
 
-        System.out.println("\n=== zipWith(Function) ===");
+        IO.println("\n=== zipWith(Function) ===");
 
         // Pair the value with a derived Option — both present
-        Option<Tuple2<String, Integer>> emailWithLength =
-            findEmail("alice").zipWith(e -> Option.some(e.length()));
-        emailWithLength.peek(t -> System.out.println("email=" + t._1() + " len=" + t._2()));
+        var emailWithLength =
+            findEmail("alice")
+                .zipWith(e -> Option.some(e.length()));
+        emailWithLength
+            .peek(t -> IO.println("email=%s len=%d".formatted(t._1(), t._2())));
         // email=alice@example.com len=17
 
         // Derived lookup returns None — whole result is None
-        Option<Tuple2<String, Integer>> noPort =
-            findEmail("alice").zipWith(e -> findPort(e)); // no port for email domain
-        System.out.println("No port: " + noPort.isEmpty()); // true
+        var noPort =
+            findEmail("alice").zipWith(OptionSample::findPort); // no port for email domain
+        IO.println("No port: " + noPort.isEmpty()); // true
 
         // flatZip — alias, same semantics
-        Option<Tuple2<String, Integer>> hostWithPort =
-            Option.some("api.example.com").flatZip(h -> findPort(h));
-        hostWithPort.peek(t -> System.out.println("host=" + t._1() + " port=" + t._2()));
+        var hostWithPort =
+            Option.some("api.example.com")
+                .flatZip(OptionSample::findPort);
+        hostWithPort
+            .peek(t -> IO.println("host=%s port=%d".formatted(t._1(), t._2())));
         // host=api.example.com port=8080
 
         // Source is None — mapper is not called
-        Option<Tuple2<String, Integer>> noneSource =
-            Option.<String>none().zipWith(e -> findPort(e));
-        System.out.println("None source: " + noneSource.isEmpty()); // true
+        var noneSource =
+            Option.<String>none().zipWith(OptionSample::findPort);
+        IO.println("None source: %s".formatted(noneSource.isEmpty())); // true
 
         // ---- sequenceCollector ----
 
-        System.out.println("\n=== sequenceCollector ===");
+        IO.println("\n=== sequenceCollector ===");
 
-        // All Some — present list
-        Optional<List<String>> allFound = Stream.of("alice", "alice")
-            .map(u -> findEmail(u))
+        // All Some — Some(list)
+        var allFound = Stream.of("alice", "alice")
+            .map(OptionSample::findEmail)
             .collect(Option.sequenceCollector());
-        System.out.println("All found: " + allFound.isPresent()); // true
-        System.out.println("Emails: " + allFound.get()); // [alice@example.com, alice@example.com]
+        IO.println("All found: " + allFound.isDefined()); // true
+        IO.println("Emails: " + allFound.get()); // [alice@example.com, alice@example.com]
 
-        // Any None — empty Optional
-        Optional<List<String>> oneMissing = Stream.of("alice", "bob")
-            .map(u -> findEmail(u))
+        // Any None — None
+        var oneMissing = Stream.of("alice", "bob")
+            .map(OptionSample::findEmail)
             .collect(Option.sequenceCollector());
-        System.out.println("One missing: " + oneMissing.isEmpty()); // true
+        IO.println("One missing: " + oneMissing.isEmpty()); // true
     }
 }

--- a/site/src/data/code/guide/option/options-facade.mdx
+++ b/site/src/data/code/guide/option/options-facade.mdx
@@ -14,11 +14,11 @@ List<User> found = ids.stream()
     .map(userRepo::findById)          // Stream<Option<User>>
     .collect(Options.presentToList()); // List<User> — absent entries dropped
 
-// ── Options.sequence() — all-or-nothing: Optional.empty() if any is None ────
-Optional<List<User>> allOrNone = ids.stream()
+// ── Options.sequence() — all-or-nothing: None if any is None ─────────────────
+Option<List<User>> allOrNone = ids.stream()
     .map(userRepo::findById)
     .collect(Options.sequence());
-// Optional.of([...]) only when every ID resolves; Optional.empty() otherwise
+// Some([...]) only when every ID resolves; None otherwise
 
 // ── Options.toNonEmptyList() — wrap a stream into a NonEmptyList if non-empty ─
 Option<NonEmptyList<String>> nel = items.stream()

--- a/site/src/data/code/guide/option/pitfalls-null-mapper.mdx
+++ b/site/src/data/code/guide/option/pitfalls-null-mapper.mdx
@@ -3,6 +3,10 @@ fileName: 'Demo.java'
 ---
 
 ```java
-// Silently becomes None if getName() returns null
-Option<String> name = option.map(User::getName);
+// map and flatMap both throw NPE when the mapper returns null (@NullMarked contract)
+Option<String> bad = option.map(User::getName); // NPE if getName() returns null
+
+// If the mapped method may return null, convert explicitly:
+Option<String> safe = Option.ofNullable(option.getOrNull())
+    .flatMap(u -> Option.ofNullable(u.getName())); // None when getName() is null
 ```

--- a/site/src/data/code/guide/option/sequence-collector.mdx
+++ b/site/src/data/code/guide/option/sequence-collector.mdx
@@ -3,25 +3,25 @@ fileName: 'Demo.java'
 ---
 
 ```java
-// All Some → Optional containing all values
-Optional<List<String>> result = Stream.of(
+// All Some → Option containing all values
+Option<List<String>> result = Stream.of(
         Option.some("alice"), Option.some("bob"))
     .collect(Option.sequenceCollector());
-// Optional.of(["alice", "bob"])
+// Some(["alice", "bob"])
 
-// Any None → Optional.empty()
-Optional<List<String>> missing = Stream.of(
+// Any None → None
+Option<List<String>> missing = Stream.of(
         Option.some("alice"), Option.<String>none())
     .collect(Option.sequenceCollector());
-// Optional.empty()
+// None
 
-// Empty stream → Optional.of([])
-Optional<List<String>> empty = Stream.<Option<String>>empty()
+// Empty stream → Some([])
+Option<List<String>> empty = Stream.<Option<String>>empty()
     .collect(Option.sequenceCollector());
-// Optional.of([])
+// Some([])
 
 // Typical use: look up all IDs, fail if any is missing
-Optional<List<User>> allFound = ids.stream()
+Option<List<User>> allFound = ids.stream()
     .map(userRepo::findById)             // Stream<Option<User>>
-    .collect(Option.sequenceCollector()); // Optional<List<User>>
+    .collect(Option.sequenceCollector()); // Option<List<User>>
 ```

--- a/site/src/data/guide/option.mdx
+++ b/site/src/data/guide/option.mdx
@@ -113,7 +113,8 @@ You can also use **Java pattern matching** exhaustively:
 ### `map(mapper)`
 
 Applies a function to the value if present. Returns `None` unchanged.
-If the mapper returns `null`, the result becomes `None`.
+The mapper must not be `null` and must not return `null` — both throw `NullPointerException` eagerly,
+consistent with the `@NullMarked` contract and the behavior of `flatMap`.
 
 <TransformingMap/>
 
@@ -181,8 +182,8 @@ Returns `None` as soon as any element is `None`. The stream-based overload uses
 ### Collecting a stream with `sequenceCollector`
 
 `Option.sequenceCollector()` is the stream `Collector` counterpart to `sequence`.
-It reduces a `Stream<Option<V>>` to a single `Optional<List<V>>` — present only if
-every element is `Some`, empty if any element is `None`.
+It reduces a `Stream<Option<V>>` to a single `Option<List<V>>` — `Some(list)` only if
+every element is `Some`, `None` if any element is `None`.
 
 <SequenceCollector/>
 
@@ -196,7 +197,7 @@ The decision to provide companion facade classes as pure-delegation entry points
 | Method                       | Returns                     | Semantics                                              |
 |------------------------------|-----------------------------|--------------------------------------------------------|
 | `Options.presentToList()`    | `List<T>`                   | Drops `None` — returns only present values             |
-| `Options.sequence()`         | `Optional<List<T>>`         | All-or-nothing — `empty()` if any element is `None`    |
+| `Options.sequence()`         | `Option<List<T>>`           | All-or-nothing — `None` if any element is `None`       |
 | `Options.toNonEmptyList()`   | `Option<NonEmptyList<T>>`   | Wraps stream into `NonEmptyList`, or `None` if empty   |
 
 <OptionsFacade/>
@@ -248,8 +249,9 @@ Use `flatMap` instead of `map` when the mapper itself returns an `Option`.
 
 ### Mapper returning null
 
-`map` treats a `null` return from the mapper as `None`.
-This is intentional for legacy interop, but can be surprising if you expect a non-null.
+Under `@NullMarked`, `map` and `flatMap` both throw `NullPointerException` when the
+mapper returns `null`. Use `Option.ofNullable(mapper.apply(value))` explicitly if
+the mapper may return `null` and you want `None` instead of an exception.
 
 <PitfallsNullMapper/>
 


### PR DESCRIPTION
  Add eager requireNonNull guards to eight methods whose function arguments
  were only touched on Some (map, flatMap, filter, peek, fold, match,
  getOrElseGet, getOrThrow), plus toResult(errorIfNone) and fromOptional —
  state-dependent NPEs are now consistent and carry a descriptive message.

  Make map() throw NPE when the mapper returns null, matching flatMap() and
  the `@NullMarked` contract; ofNullable is the explicit opt-in for null-to-None.

  Fix fromResult to use Option.some() instead of ofNullable: Result.Ok
  guarantees a non-null value via its compact constructor. fromTry is left
  unchanged — Try.Success has no null check and Try.run() intentionally
  produces Success(null) for void side-effects.

  Change sequenceCollector() and Options.sequence() return type from
  Optional<List<V>> to Option<List<V>>, consistent with sequence(Iterable).

  Replace raw unchecked casts in zip, map2, zip3, map3, zip4, map4 with
  nested switch pattern matching expressions.

  Update OptionTest (109 cases), OptionsFacadeTest (8 cases), OptionSample,
  and the Option guide (map section, sequenceCollector section, Options facade
  table, pitfalls section, and three code snippets).

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #390

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null-safety: operations now throw `NullPointerException` for null mappers, suppliers, and callbacks.
  * `sequenceCollector()` return type changed from `Optional` to `Option`.
  * `map()` rejects null mapper results with exceptions instead of silently converting them to None.

* **Documentation**
  * Updated guides and examples to reflect stricter null-handling semantics and API changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/432)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->