### PR TITLE
fix(resource): enforce null contracts and polish NPE messages

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Resource.java
+++ b/core/lib/src/main/java/dmx/fun/Resource.java
@@ -219,7 +219,7 @@ public final class Resource<T> {
             Function<? super Throwable, ? extends E> onError) {
         Objects.requireNonNull(body, "body");
         Objects.requireNonNull(onError, "onError");
-        Try<Result<R, E>> tryResult = use(t -> {
+        var tryResult = use(t -> {
             @SuppressWarnings("unchecked")
             Result<R, E> r = (Result<R, E>) Objects.requireNonNull(
                 body.apply(t), "useAsResult body must not return null");
@@ -228,7 +228,12 @@ public final class Resource<T> {
         if (tryResult.isSuccess()) {
             return tryResult.get();
         }
-        return Result.err(onError.apply(tryResult.getCause()));
+        return Result.err(
+            Objects.requireNonNull(
+                onError.apply(tryResult.getCause()),
+                "onError returned null"
+            )
+        );
     }
 
     /**
@@ -277,7 +282,12 @@ public final class Resource<T> {
         if (tryResult.isSuccess()) {
             return tryResult.get();
         }
-        return Either.left(onError.apply(tryResult.getCause()));
+        return Either.left(
+            Objects.requireNonNull(
+                onError.apply(tryResult.getCause()),
+                "onError returned null"
+            )
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -298,7 +308,7 @@ public final class Resource<T> {
      * @throws NullPointerException if {@code fn} is {@code null}
      */
     public <R> Resource<R> map(Function<? super T, ? extends R> fn) {
-        Objects.requireNonNull(fn, "fn");
+        Objects.requireNonNull(fn, "mapper");
         Effect<T> self = this.effect;
         return new Resource<>(new Effect<>() {
             @Override
@@ -333,7 +343,7 @@ public final class Resource<T> {
      * @throws NullPointerException if {@code fn} is {@code null} or returns {@code null}
      */
     public <R> Resource<R> flatMap(Function<? super T, ? extends Resource<R>> fn) {
-        Objects.requireNonNull(fn, "fn");
+        Objects.requireNonNull(fn, "resourceMapper");
         Effect<T> self = this.effect;
         return new Resource<>(new Effect<>() {
             @Override
@@ -382,7 +392,7 @@ public final class Resource<T> {
      * @throws NullPointerException if {@code fn} is {@code null}
      */
     public <R> Resource<R> mapTry(Function<? super T, ? extends Try<? extends R>> fn) {
-        Objects.requireNonNull(fn, "fn");
+        Objects.requireNonNull(fn, "mapper");
         Effect<T> self = this.effect;
         return new Resource<>(new Effect<>() {
             @Override
@@ -415,7 +425,7 @@ public final class Resource<T> {
         Throwable bodyEx = null;
         R result = null;
         try {
-            result = body.apply(resource);
+            result = Objects.requireNonNull(body.apply(resource), "body returned null");
         } catch (Throwable t) {
             bodyEx = t;
         }

--- a/core/lib/src/test/java/dmx/fun/ResourceTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResourceTest.java
@@ -60,6 +60,19 @@ class ResourceTest {
     }
 
     @Test
+    void use_nullBodyResult_shouldReturnFailureWithNPE() {
+        var released = new AtomicBoolean(false);
+        var r = Resource.of(() -> "hello", _ -> released.set(true));
+
+        var result = r.use(_ -> null);
+
+        assertThat(released.get()).isTrue();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("body returned null");
+    }
+
+    @Test
     void use_shouldAlwaysCallRelease_whenBodySucceeds() {
         var released = new AtomicBoolean(false);
         var r = Resource.of(() -> "hello", _ -> released.set(true));
@@ -200,7 +213,8 @@ class ResourceTest {
         });
 
         assertThatThrownBy(() -> r.map(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
     }
 
     // -------------------------------------------------------------------------
@@ -296,7 +310,8 @@ class ResourceTest {
         var r = Resource.of(() -> "hello", _ -> {
         });
         assertThatThrownBy(() -> r.flatMap(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("resourceMapper");
     }
 
     @Test
@@ -521,6 +536,14 @@ class ResourceTest {
             .hasMessageContaining("onError");
     }
 
+    @Test
+    void useAsResult_nullOnErrorReturn_shouldThrowNPEWithDescriptiveMessage() {
+        var r = Resource.<String>of(() -> { throw new RuntimeException("fail"); }, _ -> {});
+        assertThatThrownBy(() -> r.useAsResult(_ -> Result.ok("x"), _ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onError returned null");
+    }
+
     // -------------------------------------------------------------------------
     // useAsEither — Either-integrated use
     // -------------------------------------------------------------------------
@@ -645,6 +668,14 @@ class ResourceTest {
             .hasMessageContaining("onError");
     }
 
+    @Test
+    void useAsEither_nullOnErrorReturn_shouldThrowNPEWithDescriptiveMessage() {
+        var r = Resource.<String>of(() -> { throw new RuntimeException("fail"); }, _ -> {});
+        assertThatThrownBy(() -> r.useAsEither(_ -> Either.right("x"), _ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("onError returned null");
+    }
+
     // -------------------------------------------------------------------------
     // mapTry — transform resource value with Try-returning function
     // -------------------------------------------------------------------------
@@ -689,7 +720,8 @@ class ResourceTest {
         });
 
         assertThatThrownBy(() -> r.mapTry(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
     }
 
     @Test

--- a/site/src/data/guide/resource.mdx
+++ b/site/src/data/guide/resource.mdx
@@ -49,6 +49,9 @@ Each call to `use()` is independent: it acquires the resource, runs the body, an
 resource. The same `Resource<T>` can be used multiple times — each call goes through the full
 acquire/run/release cycle.
 
+The body function must not return `null` — if it does, `use()` returns `Try.failure(NullPointerException)`
+and the resource is still released normally.
+
 ## Exception-merging contract
 
 `Resource<T>` follows the same exception-suppression semantics as `try-with-resources`:
@@ -119,6 +122,7 @@ If the `Try` is a failure, `use` returns that failure immediately and `release` 
 The `Result`-counterpart of `use()`. The body returns a `Result<R, E>` directly.
 Any `Throwable` from acquire, release, or an unexpected body exception is mapped to `E` via
 `onError`, eliminating the `Try<Result<R, E>>` nesting.
+`onError` must not return `null` — a null return throws `NullPointerException` immediately.
 
 <UseAsResult/>
 
@@ -128,6 +132,7 @@ The `Either`-counterpart of `use()`, symmetric with `useAsResult`. Use it when t
 layer models results as neutral two-track `Either<E, R>` values. The body returns an
 `Either<E, R>` directly; any `Throwable` from acquire, release, or an unexpected body
 exception is mapped to `E` via `onError`.
+`onError` must not return `null` — a null return throws `NullPointerException` immediately.
 
 <UseAsEither/>
 


### PR DESCRIPTION
  - Wrap body result in requireNonNull inside runBody so a null-returning
    body produces Try.failure(NullPointerException("body returned null"))
    with the resource still released, instead of silently propagating null
  - Wrap onError return in requireNonNull in useAsResult and useAsEither so
    a null-returning error mapper throws NullPointerException("onError returned null")
    instead of passing null into Result.err / Either.left
  - Rename requireNonNull labels: "fn" → "mapper" in map/mapTry,
    "fn" → "resourceMapper" in flatMap, for consistency with the rest of the library

  test(resource): add and tighten NPE coverage for issue #391
  - New: use_nullBodyResult_shouldReturnFailureWithNPE
  - New: useAsResult_nullOnErrorReturn_shouldThrowNPEWithDescriptiveMessage
  - New: useAsEither_nullOnErrorReturn_shouldThrowNPEWithDescriptiveMessage
  - Tightened: map/flatMap/mapTry null-mapper tests assert the specific
    NPE message ("mapper", "resourceMapper")

  docs(resource): document null contracts introduced in issue #391
  - use(): note that body must not return null
  - useAsResult / useAsEither: note that onError must not return null

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #391

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced validation of resource operations with stricter null-safety checks and improved error messages
  * Body functions and mapping operations now enforced to return non-null values; violations surface as descriptive exceptions

* **Documentation**
  * Updated Resource API guide clarifying non-null contract requirements for body and error handler functions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/433)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->