### PR TITLE
fix(either): null-check map/mapLeft return values and add left-track API symmetry

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Either.java
+++ b/core/lib/src/main/java/dmx/fun/Either.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
@@ -145,6 +146,68 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
         };
     }
 
+    /**
+     * Returns the right value if present, or {@code fallback} if this is a {@link Left}.
+     *
+     * @param fallback the non-null value returned when this is {@code Left}
+     * @return the right value, or {@code fallback}
+     * @throws NullPointerException if {@code fallback} is {@code null}
+     */
+    default R getRightOrElse(R fallback) {
+        Objects.requireNonNull(fallback, "fallback");
+        return switch (this) {
+            case Right<L, R> right -> right.value();
+            case Left<L, R> _      -> fallback;
+        };
+    }
+
+    /**
+     * Returns the right value if present, or the value supplied by {@code supplier} if this
+     * is a {@link Left}. The supplier is called lazily — only when this is {@code Left}.
+     *
+     * @param supplier provides the fallback value; must not be {@code null} and must not return {@code null}
+     * @return the right value, or the result of {@code supplier}
+     * @throws NullPointerException if {@code supplier} is {@code null} or returns {@code null}
+     */
+    default R getRightOrElseGet(Supplier<? extends R> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
+        return switch (this) {
+            case Right<L, R> right -> right.value();
+            case Left<L, R> _      -> Objects.requireNonNull(supplier.get(), "supplier returned null");
+        };
+    }
+
+    /**
+     * Returns the left value if present, or {@code fallback} if this is a {@link Right}.
+     *
+     * @param fallback the non-null value returned when this is {@code Right}
+     * @return the left value, or {@code fallback}
+     * @throws NullPointerException if {@code fallback} is {@code null}
+     */
+    default L getLeftOrElse(L fallback) {
+        Objects.requireNonNull(fallback, "fallback");
+        return switch (this) {
+            case Left<L, R> left -> left.value();
+            case Right<L, R> _   -> fallback;
+        };
+    }
+
+    /**
+     * Returns the left value if present, or the value supplied by {@code supplier} if this
+     * is a {@link Right}. The supplier is called lazily — only when this is {@code Right}.
+     *
+     * @param supplier provides the fallback value; must not be {@code null} and must not return {@code null}
+     * @return the left value, or the result of {@code supplier}
+     * @throws NullPointerException if {@code supplier} is {@code null} or returns {@code null}
+     */
+    default L getLeftOrElseGet(Supplier<? extends L> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
+        return switch (this) {
+            case Left<L, R> left -> left.value();
+            case Right<L, R> _   -> Objects.requireNonNull(supplier.get(), "supplier returned null");
+        };
+    }
+
     // -------------------------------------------------------------------------
     // Transformation
     // -------------------------------------------------------------------------
@@ -173,14 +236,16 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
      * Maps the right value using {@code mapper}, leaving a {@link Left} unchanged.
      *
      * @param <R2>   the new right type
-     * @param mapper function applied to the right value
+     * @param mapper function applied to the right value; must not be {@code null} and must not return {@code null}
      * @return a new {@code Either} with the mapped right value, or the original {@code Left}
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
      */
     default <R2> Either<L, R2> map(Function<? super R, ? extends R2> mapper) {
         Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
             case Left<L, R> left   -> Either.left(left.value());
-            case Right<L, R> right -> Either.right(mapper.apply(right.value()));
+            case Right<L, R> right -> Either.right(
+                Objects.requireNonNull(mapper.apply(right.value()), "mapper returned null"));
         };
     }
 
@@ -188,13 +253,20 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
      * Maps the left value using {@code mapper}, leaving a {@link Right} unchanged.
      *
      * @param <L2>   the new left type
-     * @param mapper function applied to the left value
+     * @param mapper function applied to the left value; must not be {@code null} and must not return {@code null}
      * @return a new {@code Either} with the mapped left value, or the original {@code Right}
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
      */
     default <L2> Either<L2, R> mapLeft(Function<? super L, ? extends L2> mapper) {
         Objects.requireNonNull(mapper, "mapper");
         return switch (this) {
-            case Left<L, R> left   -> Either.left(mapper.apply(left.value()));
+            case Left<L, R> left   ->
+                Either.left(
+                    Objects.requireNonNull(
+                        mapper.apply(left.value()),
+                        "mapper returned null"
+                    )
+                );
             case Right<L, R> right -> Either.right(right.value());
         };
     }
@@ -215,6 +287,30 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
             case Right<L, R> right -> {
                 @SuppressWarnings("unchecked")
                 Either<L, R2> result = (Either<L, R2>) mapper.apply(right.value());
+                yield Objects.requireNonNull(result, "mapper returned null");
+            }
+        };
+    }
+
+    /**
+     * Applies {@code mapper} to the left value and returns the resulting {@code Either},
+     * leaving a {@link Right} unchanged. This is the monadic bind for the left track,
+     * symmetric with {@link #flatMap(Function)}.
+     *
+     * @param <L2>   the new left type
+     * @param mapper function that returns an {@code Either} for the left value;
+     *               must not be {@code null} and must not return {@code null}
+     * @return the result of {@code mapper} applied to the left value, or the original {@code Right}
+     * @throws NullPointerException if {@code mapper} is {@code null} or returns {@code null}
+     */
+    default <L2> Either<L2, R> flatMapLeft(
+            Function<? super L, ? extends Either<? extends L2, ? extends R>> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+        return switch (this) {
+            case Right<L, R> right -> Either.right(right.value());
+            case Left<L, R> left -> {
+                @SuppressWarnings("unchecked")
+                Either<L2, R> result = (Either<L2, R>) mapper.apply(left.value());
                 yield Objects.requireNonNull(result, "mapper returned null");
             }
         };
@@ -354,6 +450,30 @@ public sealed interface Either<L, R> permits Either.Left, Either.Right {
         return switch (this) {
             case Right<L, R> right -> Stream.of(right.value());
             case Left<L, R> _      -> Stream.empty();
+        };
+    }
+
+    /**
+     * Returns this {@code Either} as a single-element or empty {@link Stream} of the left value.
+     *
+     * <p>{@link Left Left(l)} produces {@code Stream.of(l)};
+     * {@link Right} produces {@code Stream.empty()}.
+     * Symmetric with {@link #stream()}, which operates on the right track.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Stream<Either<String, Integer>> eithers = ...;
+     * List<String> lefts = eithers
+     *     .flatMap(Either::streamLeft)
+     *     .toList();
+     * }</pre>
+     *
+     * @return a one-element stream of the left value, or an empty stream
+     */
+    default Stream<L> streamLeft() {
+        return switch (this) {
+            case Left<L, R> left -> Stream.of(left.value());
+            case Right<L, R> _   -> Stream.empty();
         };
     }
 

--- a/core/lib/src/test/java/dmx/fun/EitherTest.java
+++ b/core/lib/src/test/java/dmx/fun/EitherTest.java
@@ -73,6 +73,120 @@ class EitherTest {
     }
 
     // -------------------------------------------------------------------------
+    // getRightOrElse / getRightOrElseGet / getLeftOrElse / getLeftOrElseGet
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getRightOrElse_returnsRight_whenRight() {
+        var value = Either
+            .right(42)
+            .getRightOrElse(0);
+        assertThat(value)
+            .isEqualTo(42);
+    }
+
+    @Test
+    void getRightOrElse_returnsFallback_whenLeft() {
+        var value = Either
+            .left("err")
+            .getRightOrElse(0);
+        assertThat(value)
+            .isEqualTo(0);
+    }
+
+    @Test
+    void getRightOrElse_throwsNPE_whenFallbackIsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>left("err").getRightOrElse(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("fallback");
+    }
+
+    @Test
+    void getRightOrElseGet_returnsRight_whenRight() {
+        assertThat(Either.<String, Integer>right(42).getRightOrElseGet(() -> 0)).isEqualTo(42);
+    }
+
+    @Test
+    void getRightOrElseGet_callsSupplier_whenLeft() {
+        assertThat(Either.<String, Integer>left("err").getRightOrElseGet(() -> 99)).isEqualTo(99);
+    }
+
+    @Test
+    void getRightOrElseGet_doesNotCallSupplier_whenRight() {
+        var called = new ArrayList<String>();
+        Either.<String, Integer>right(1).getRightOrElseGet(() -> {
+            called.add("called");
+            return 0;
+        });
+        assertThat(called).isEmpty();
+    }
+
+    @Test
+    void getRightOrElseGet_throwsNPE_whenSupplierIsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>left("err").getRightOrElseGet(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("supplier");
+    }
+
+    @Test
+    void getRightOrElseGet_throwsNPE_whenSupplierReturnsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>left("err").getRightOrElseGet(() -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("supplier returned null");
+    }
+
+    @Test
+    void getLeftOrElse_returnsLeft_whenLeft() {
+        assertThat(Either.<String, Integer>left("err").getLeftOrElse("default")).isEqualTo("err");
+    }
+
+    @Test
+    void getLeftOrElse_returnsFallback_whenRight() {
+        assertThat(Either.<String, Integer>right(1).getLeftOrElse("default")).isEqualTo("default");
+    }
+
+    @Test
+    void getLeftOrElse_throwsNPE_whenFallbackIsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>right(1).getLeftOrElse(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("fallback");
+    }
+
+    @Test
+    void getLeftOrElseGet_returnsLeft_whenLeft() {
+        assertThat(Either.<String, Integer>left("err").getLeftOrElseGet(() -> "default")).isEqualTo("err");
+    }
+
+    @Test
+    void getLeftOrElseGet_callsSupplier_whenRight() {
+        assertThat(Either.<String, Integer>right(1).getLeftOrElseGet(() -> "fallback")).isEqualTo("fallback");
+    }
+
+    @Test
+    void getLeftOrElseGet_doesNotCallSupplier_whenLeft() {
+        var called = new ArrayList<String>();
+        Either.<String, Integer>left("x").getLeftOrElseGet(() -> {
+            called.add("called");
+            return "y";
+        });
+        assertThat(called).isEmpty();
+    }
+
+    @Test
+    void getLeftOrElseGet_throwsNPE_whenSupplierIsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>right(1).getLeftOrElseGet(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("supplier");
+    }
+
+    @Test
+    void getLeftOrElseGet_throwsNPE_whenSupplierReturnsNull() {
+        assertThatThrownBy(() -> Either.<String, Integer>right(1).getLeftOrElseGet(() -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("supplier returned null");
+    }
+
+    // -------------------------------------------------------------------------
     // fold
     // -------------------------------------------------------------------------
 
@@ -128,7 +242,16 @@ class EitherTest {
     void map_shouldThrowNPE_whenMapperIsNull() {
         var e = Either.right(1);
         assertThatThrownBy(() -> e.map(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void map_shouldThrowNPE_whenMapperReturnsNull() {
+        var e = Either.right(1);
+        assertThatThrownBy(() -> e.map(_ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper returned null");
     }
 
     // -------------------------------------------------------------------------
@@ -155,7 +278,16 @@ class EitherTest {
     void mapLeft_shouldThrowNPE_whenMapperIsNull() {
         var e = Either.left("x");
         assertThatThrownBy(() -> e.mapLeft(null))
-            .isInstanceOf(NullPointerException.class);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void mapLeft_shouldThrowNPE_whenMapperReturnsNull() {
+        var e = Either.left("x");
+        assertThatThrownBy(() -> e.mapLeft(_ -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper returned null");
     }
 
     // -------------------------------------------------------------------------
@@ -202,6 +334,55 @@ class EitherTest {
     void flatMap_shouldThrowNPE_whenMapperReturnsNull() {
         var e = Either.right(1);
         assertThatThrownBy(() -> e.flatMap(v -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper returned null");
+    }
+
+    // -------------------------------------------------------------------------
+    // flatMapLeft
+    // -------------------------------------------------------------------------
+
+    @Test
+    void flatMapLeft_shouldChain_whenLeft() {
+        var result = Either.<String, Integer>left("error")
+            .flatMapLeft(s -> s.isEmpty() ? Either.right(0) : Either.left(s.toUpperCase()));
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isEqualTo("ERROR");
+    }
+
+    @Test
+    void flatMapLeft_shouldShortCircuit_whenRight() {
+        var called = new ArrayList<String>();
+        var result = Either.<String, Integer>right(42)
+            .flatMapLeft(s -> {
+                called.add("called");
+                return Either.left(s);
+            });
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight()).isEqualTo(42);
+        assertThat(called).isEmpty();
+    }
+
+    @Test
+    void flatMapLeft_shouldReturnRight_whenMapperReturnsRight() {
+        var result = Either.<String, Integer>left("skip")
+            .flatMapLeft(_ -> Either.right(99));
+        assertThat(result.isRight()).isTrue();
+        assertThat(result.getRight()).isEqualTo(99);
+    }
+
+    @Test
+    void flatMapLeft_shouldThrowNPE_whenMapperIsNull() {
+        var e = Either.left("x");
+        assertThatThrownBy(() -> e.flatMapLeft(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+
+    @Test
+    void flatMapLeft_shouldThrowNPE_whenMapperReturnsNull() {
+        var e = Either.left("x");
+        assertThatThrownBy(() -> e.flatMapLeft(_ -> null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("mapper returned null");
     }
@@ -410,6 +591,32 @@ class EitherTest {
             .flatMap(Either::stream)
             .toList();
         assertThat(rights).containsExactly(1, 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // streamLeft
+    // -------------------------------------------------------------------------
+
+    @Test
+    void streamLeft_shouldReturnSingleElementStream_whenLeft() {
+        List<String> collected = Either.<String, Integer>left("err").streamLeft().toList();
+        assertThat(collected).containsExactly("err");
+    }
+
+    @Test
+    void streamLeft_shouldReturnEmptyStream_whenRight() {
+        List<String> collected = Either.<String, Integer>right(7).streamLeft().toList();
+        assertThat(collected).isEmpty();
+    }
+
+    @Test
+    void streamLeft_shouldIntegrateIntoStreamPipeline() {
+        List<Either<String, Integer>> eithers = List.of(
+            Either.left("a"), Either.right(1), Either.left("b"));
+        List<String> lefts = eithers.stream()
+            .flatMap(Either::streamLeft)
+            .toList();
+        assertThat(lefts).containsExactly("a", "b");
     }
 
     // -------------------------------------------------------------------------

--- a/site/src/data/code/guide/either/extracting-values.mdx
+++ b/site/src/data/code/guide/either/extracting-values.mdx
@@ -14,4 +14,12 @@ String rendered = e.fold(
 // Unsafe accessors — throw NoSuchElementException on the wrong side
 String leftVal  = e.getLeft();  // throws if Right
 int    rightVal = e.getRight(); // throws if Left
+
+// Safe accessors with a fallback value (eagerly evaluated)
+int rightOrZero   = e.getRightOrElse(0);
+String leftOrDef  = e.getLeftOrElse("default");
+
+// Safe accessors with a lazy supplier (supplier called only if wrong side)
+int rightLazy   = e.getRightOrElseGet(() -> expensiveDefault());
+String leftLazy = e.getLeftOrElseGet(() -> computeDefault());
 ```

--- a/site/src/data/code/guide/either/interop-conversions.mdx
+++ b/site/src/data/code/guide/either/interop-conversions.mdx
@@ -28,6 +28,12 @@ List<Integer> rights = Stream.of(Either.right(1), Either.left("err"), Either.rig
     .flatMap(Either::stream)
     .toList(); // [1, 3]
 
+// → Stream of left  (Left(l) → Stream.of(l), Right → Stream.empty())
+//   Symmetric with stream(); collects only the left values
+List<String> lefts = Stream.of(Either.right(1), Either.left("err"), Either.left("bad"))
+    .flatMap(Either::streamLeft)
+    .toList(); // ["err", "bad"]
+
 // ── Other types → Either ────────────────────────────────────────────────────
 
 // Try → Either  (Success → Right, Failure → Left with the exception)

--- a/site/src/data/code/guide/either/transforming.mdx
+++ b/site/src/data/code/guide/either/transforming.mdx
@@ -19,6 +19,13 @@ Either<String, String> result =
             ? Either.right(Integer.toBinaryString(n))
             : Either.left("non-positive"));
 
+// flatMapLeft — chains left-biased operations (symmetric with flatMap)
+Either<String, Integer> recovered =
+    Either.<String, Integer>left("retry")
+        .flatMapLeft(s -> s.equals("retry")
+            ? Either.right(0)
+            : Either.left("permanent failure"));
+
 // swap — flips Left ↔ Right
 Either<Integer, String> swapped = Either.<String, Integer>left("hello").swap();
 // → Right("hello")

--- a/site/src/data/guide/either.mdx
+++ b/site/src/data/guide/either.mdx
@@ -60,23 +60,28 @@ Prefer exhaustive switch patterns — the compiler enforces that both sides are 
 
 ## Extracting values
 
-| Method                      | On wrong side                   | Notes                                               |
-|-----------------------------|---------------------------------|-----------------------------------------------------|
-| `getLeft()`                 | Throws `NoSuchElementException` | Only safe after an `isLeft()` check.                |
-| `getRight()`                | Throws `NoSuchElementException` | Only safe after an `isRight()` check.               |
-| `fold(onLeft, onRight)`     | N/A — handles both sides        | The safest extractor; forces both branches.         |
+| Method                              | On wrong side                   | Notes                                                                     |
+|-------------------------------------|---------------------------------|---------------------------------------------------------------------------|
+| `getLeft()`                         | Throws `NoSuchElementException` | Only safe after an `isLeft()` check.                                      |
+| `getRight()`                        | Throws `NoSuchElementException` | Only safe after an `isRight()` check.                                     |
+| `getLeftOrElse(fallback)`           | Returns `fallback`              | Fallback is always evaluated — use `getLeftOrElseGet` for expensive defaults. |
+| `getRightOrElse(fallback)`          | Returns `fallback`              | Fallback is always evaluated — use `getRightOrElseGet` for expensive defaults. |
+| `getLeftOrElseGet(supplier)`        | Calls supplier                  | Lazily computed fallback for the left track.                              |
+| `getRightOrElseGet(supplier)`       | Calls supplier                  | Lazily computed fallback for the right track.                             |
+| `fold(onLeft, onRight)`             | N/A — handles both sides        | The safest extractor; forces both branches.                               |
 
 <ExtractingValues/>
 
 ## Transforming values
 
-| Method             | Operates on | Left passes through | Notes                                                |
-|--------------------|-------------|---------------------|------------------------------------------------------|
-| `map(mapper)`      | Right       | Yes                 | Standard right-biased functor map.                   |
-| `mapLeft(mapper)`  | Left        | Yes (Right)         | Transforms the left value; Right passes through.     |
-| `flatMap(mapper)`  | Right       | Yes                 | Monadic bind for the right track.                    |
-| `swap()`           | Both        | N/A                 | Flips Left ↔ Right; useful before operating on Left. |
-| `fold(fn, fn)`     | Both        | N/A                 | Terminal — collapses both sides into one value.      |
+| Method                | Operates on | Passes through | Notes                                                |
+|-----------------------|-------------|----------------|------------------------------------------------------|
+| `map(mapper)`         | Right       | Left           | Standard right-biased functor map. Mapper must not return `null`. |
+| `mapLeft(mapper)`     | Left        | Right          | Transforms the left value. Mapper must not return `null`.         |
+| `flatMap(mapper)`     | Right       | Left           | Monadic bind for the right track.                    |
+| `flatMapLeft(mapper)` | Left        | Right          | Monadic bind for the left track; symmetric with `flatMap`. |
+| `swap()`              | Both        | N/A            | Flips Left ↔ Right; useful before operating on Left. |
+| `fold(fn, fn)`        | Both        | N/A            | Terminal — collapses both sides into one value.      |
 
 <Transforming/>
 
@@ -99,7 +104,8 @@ it executes exactly one consumer and returns `void`.
 | `Either` → `Validated`       | `e.toValidated()`                          | Right → Valid; Left → Invalid.                          |
 | `Either` → `Optional`        | `e.toOptional()`                           | Right(r) → Optional.of(r); Left → Optional.empty().     |
 | `Either` → `Try`             | `e.toTry(leftMapper)`                      | Right → Success; Left mapped to `Throwable` → Failure.  |
-| `Either` → `Stream`          | `e.stream()`                               | Right(r) → Stream.of(r); Left → Stream.empty().         |
+| `Either` → `Stream` (right)  | `e.stream()`                               | Right(r) → Stream.of(r); Left → Stream.empty().         |
+| `Either` → `Stream` (left)   | `e.streamLeft()`                           | Left(l) → Stream.of(l); Right → Stream.empty().         |
 | `Try` → `Either`             | `tryVal.toEither()`                        | Success → Right; Failure → Left.                        |
 | `Result` → `Either`          | `result.toEither()`                        | Ok → Right; Err → Left.                                 |
 | `Validated` → `Either`       | `validated.toEither()`                     | Valid → Right; Invalid → Left.                          |


### PR DESCRIPTION
  Finding 1 — map and mapLeft now wrap the mapper result in requireNonNull("mapper
  returned null"), consistent with flatMap. Previously a null-returning mapper fell
  through to the Right/Left constructor, producing a less descriptive NPE.

  Finding 2 — flatMapLeft added as the left-track counterpart to flatMap. Eliminates
  the swap().flatMap(...).swap() workaround.

  Finding 3 — getRightOrElse, getRightOrElseGet, getLeftOrElse, getLeftOrElseGet
  added as fallback extractors, symmetric with Option.getOrElse / getOrElseGet.

  Finding 4 — streamLeft() added as the left-track counterpart to stream(), for
  integrating left values into Stream pipelines.

  test(either): add coverage for all four findings
  - map_shouldThrowNPE_whenMapperReturnsNull
  - mapLeft_shouldThrowNPE_whenMapperReturnsNull
  - tightened map/mapLeft null-mapper tests to assert message "mapper"
  - flatMapLeft: chain, short-circuit, returns-right, null mapper, null return
  - getRightOrElse/getRightOrElseGet/getLeftOrElse/getLeftOrElseGet: happy path,
    fallback, lazy evaluation, NPE on null supplier/supplier-return

  docs(either): update guide for all new and changed methods
  - Extracting values table: added four getOrElse/getOrElseGet rows
  - Transforming table: added flatMapLeft row; noted null-return NPE for map/mapLeft
  - Interop table: split stream() row; added streamLeft() row
  - Updated extracting-values, transforming, and interop-conversions code snippets

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [X] I have tested my changes locally
- [X] I have added unit tests where applicable
- [X] I have updated documentation where necessary
- [X] My code follows the project's coding conventions
- [X] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #392

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe value extraction methods with eager and lazy fallback options on both sides of the `Either` type.
  * Introduced left-side monadic bind (`flatMapLeft`) for left-track transformations.
  * Added `streamLeft()` for streaming left values.
  * Enhanced null safety with stricter mapper result validation.

* **Documentation**
  * Updated guides and examples demonstrating new `Either` API capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/domix/dmx-fun/pull/434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->