### PR TITLE
docs(blog): add post on Vavr, Arrow, Cats, and fp-ts

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -69,7 +69,7 @@
 51. How functional can an object-oriented language really be?
 52. Functional libraries worth knowing
 53. ~~JDK-first functional programming: how far can you go without dependencies?~~
-54. Vavr, Arrow, Cats, fp-ts: what problems do they solve?
+54. ~~Vavr, Arrow, Cats, fp-ts: what problems do they solve?~~
 55. ~~Do you need a functional library or just better habits?~~
 
 ### Critical and opinionated topics
@@ -85,6 +85,78 @@
 64. The cognitive cost of functional abstraction
 65. How to teach functional programming without scaring people away
 
+### Core concepts, deeper
+
+66. Closures and variable capture explained for Java developers
+67. Expressions over statements: why functional code avoids `void`
+68. Recursion vs iteration: tail calls, stack safety, and the JVM
+69. The substitution model: evaluating code in your head
+70. Total vs partial functions: making every input return a value
+
+### Working with the core types
+
+71. Traverse and sequence: turning a `List<Result>` into a `Result<List>`
+72. Mapping the error channel: when and how to transform failures
+73. Combining independent computations with zip and applicative style
+74. From Optional to Option: migrating null-handling in an existing codebase
+75. Designing a good error type: sealed hierarchies callers can act on
+76. Option vs nullable vs Optional: choosing an absence strategy in Java
+
+### Functional patterns in practice
+
+77. Replacing if/else and switch sprawl with maps of functions
+78. Memoization: caching pure functions safely
+79. Retry, timeout, and backoff as composable functions
+80. The Reader pattern: passing dependencies without a framework
+81. Building a small rules engine with composable predicates
+82. Parsing and decoding input the functional way
+83. Modeling finite state machines with sealed types and transitions
+
+### Concurrency, effects, and performance
+
+84. Modeling side effects as values: a gentle intro to effect types
+85. Virtual threads and functional code: what changes and what does not
+86. Functional concurrency: structuring parallel work without shared state
+87. Laziness and streaming: processing large data without loading it all
+88. The performance cost of immutability, and when it actually matters
+
+### Java platform and language evolution
+
+89. What records and sealed types changed for functional Java
+90. Stream gatherers: custom intermediate operations in modern Java
+91. Pattern matching in Java: from instanceof to record deconstruction
+92. Project Valhalla and value classes: the functional payoff
+93. Optional done right: the dos and don'ts the JDK does not enforce
+
+### Testing and quality
+
+94. Property-based testing for pure functions
+95. How to review functional code without slowing the team down
+96. Testing the imperative shell without mocking everything
+97. Golden/approval tests for functional pipelines
+
+### Architecture and systems
+
+98. Functional event sourcing: folding events into state
+99. Typed error taxonomies for HTTP APIs
+100. Where to put validation: at the boundary, not in the core
+101. Functional approaches to idempotency in distributed systems
+102. CQRS through a functional lens
+
+### Teaching, teams, and career
+
+103. A practical learning path for functional programming in Java
+104. Onboarding a developer to a functional codebase
+105. Selling functional programming to skeptical stakeholders
+106. Functional thinking as a career skill, not a language feature
+
+### More reflective and opinionated topics
+
+107. The monad tutorial fallacy: why the analogies keep failing
+108. Why "just use exceptions" persists, and when it is actually right
+109. The hidden cost of cleverness in functional code
+110. What survived the functional programming hype
+
 ### More random ideas to blog
 
 * ~~**What functional programming means for a backend engineer**~~
@@ -93,3 +165,8 @@
 * **Option, Result, and Try explained pragmatically**
 * **Functional programming in Java without losing pragmatism**
 * **Functional core, imperative shell applied to a real service**
+* **The day a NullPointerException taught me to use Option**
+* **Rewriting a tangled service method into a pure pipeline**
+* **A glossary of functional terms, in plain language**
+* **Reading functional code: a guided tour of a real pull request**
+* **Functional programming without the monad word**

--- a/site/src/data/blog/vavr-arrow-cats-fp-ts-what-problems-they-solve.md
+++ b/site/src/data/blog/vavr-arrow-cats-fp-ts-what-problems-they-solve.md
@@ -1,0 +1,211 @@
+---
+title: "Vavr, Arrow, Cats, fp-ts: What Problems Do They Solve?"
+description: "Four libraries, four languages, one recurring motivation. Vavr, Arrow, Cats, and fp-ts exist because mainstream languages gave developers functional building blocks but left out the types that make them safe. This post maps what each library actually provides — and what gap in the host language each one fills."
+pubDate: 2026-06-16
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Article"
+tags: ["Functional Programming", "Java", "Kotlin", "Scala", "TypeScript", "Vavr", "Arrow", "Cats", "fp-ts", "Libraries"]
+image: "https://images.pexels.com/photos/256541/pexels-photo-256541.jpeg"
+imageCredit:
+    author: "Pixabay"
+    authorUrl: "https://www.pexels.com/@pixabay/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/photo/library-256541/"
+---
+
+If you have spent any time reading about functional programming in the JVM or JavaScript ecosystems, you have run into the same four names: **Vavr** for Java, **Arrow** for Kotlin, **Cats** for Scala, **fp-ts** for TypeScript.
+
+They get mentioned together so often that it is easy to assume they are interchangeable — four flavors of the same thing. They are not. They differ in scope, in ambition, and in how much of their host language's grain they cut against.
+
+But they do share a common origin story. Each one exists because a mainstream, multi-paradigm language gave developers lambdas and a streams API, and then stopped — leaving out the types that make functional programming actually safe. These libraries fill that gap. This post maps what each one provides, and what specific hole in the host language it was built to fill.
+
+---
+
+## The Common Gap
+
+Start with what every one of these languages already has.
+
+Java, Kotlin, Scala, and TypeScript all support first-class functions. They all have lambdas. They all have a `map`/`filter`/`reduce` story for collections. By the mid-2010s, "functional programming" in the sense of "passing functions around" was solved everywhere.
+
+What none of them shipped with — or shipped incompletely — was the second half of the functional toolkit: the **data types that model outcomes**.
+
+- A type for *absence* that is better than `null`
+- A type for *failure* that is better than a thrown exception
+- A type for *accumulating* multiple errors instead of stopping at the first
+- A type for *deferred* or *asynchronous* computation that composes
+- The combinators — `map`, `flatMap`, `fold`, `traverse` — that make those types work together
+
+This is the gap. Every library on this list is, at its core, an implementation of these types plus the operations that connect them. Where they diverge is *how far past that baseline they go*.
+
+---
+
+## Vavr (Java): Backfilling What Java Left Out
+
+Java is the most conservative language of the four, and Vavr is the most conservative library — by necessity. It exists to give Java the data types the JDK never added.
+
+The JDK has `Optional<T>`. It does not have:
+
+- A `Try<T>` for capturing exceptions as values
+- An `Either<L, R>` for representing two outcomes
+- A `Validated` for accumulating errors
+- Persistent, truly immutable collections (`List`, `Map`, `Set`, `Seq`)
+- Tuples
+- Pattern matching (before Java caught up with sealed types and switch patterns)
+
+Vavr provides all of these:
+
+```java
+// Vavr's Try captures the exception as a value
+Try<Config> config = Try.of(() -> loadConfig(path));
+
+Try<ServerSettings> settings = config.map(Config::serverSettings);
+
+// Vavr's Either for a typed two-outcome result
+Either<ValidationError, Order> result = validate(request)
+    .map(this::buildOrder);
+
+// Vavr's persistent collections — immutable, structural sharing
+io.vavr.collection.List<Integer> nums = io.vavr.collection.List.of(1, 2, 3);
+io.vavr.collection.List<Integer> more = nums.append(4);  // nums unchanged
+```
+
+Vavr's scope is deliberately bounded. It does not introduce type classes, higher-kinded types, or an effect system. It cannot — Java's type system will not express them cleanly. Vavr's job is to fill the most painful, most concrete gaps: typed errors, immutable collections, `Try`. It is a *data types* library, not a *category theory* library.
+
+This is worth dwelling on, because it explains a tension Java developers feel. As Java the language has added `record`, sealed interfaces, and pattern-matching `switch`, some of Vavr's original motivation has eroded. You can now model `Either` and `Result` yourself with a sealed interface and two records — which is exactly the approach a JDK-first library like dmx-fun takes. Vavr's persistent collections and its large combinator catalog remain its strongest justification.
+
+---
+
+## Arrow (Kotlin): Idiomatic FP for a Pragmatic Language
+
+Kotlin sits one step further toward functional expressiveness than Java. It has nullable types built in (`String?`), so the "absence" problem is largely solved at the language level — you rarely need an `Option` type in Kotlin because `T?` already does the job with compiler support.
+
+Arrow, therefore, does not spend much effort on `Option`. It focuses on what Kotlin still lacks:
+
+- `Either<L, R>` and a rich error-handling story
+- `Validated` / accumulating errors (via `EitherNel` and friends)
+- Typed error handling with `Raise` — a Kotlin-idiomatic effect that uses the language's own control flow
+- Coroutine-aware functional composition
+- Optics (lenses, prisms) for immutable data updates
+
+What makes Arrow notable is how hard it leans on Kotlin's language features instead of fighting them. The `Raise` DSL is the clearest example:
+
+```kotlin
+// Arrow's Raise: typed errors using Kotlin's own syntax, no flatMap chains
+fun Raise<OrderError>.placeOrder(request: Request): Order {
+    val customer = findCustomer(request.customerId)  // may raise OrderError
+    val items    = validateItems(request.items)      // may raise OrderError
+    return Order(customer, items)
+}
+
+// Run it, get an Either back
+val result: Either<OrderError, Order> = either { placeOrder(request) }
+```
+
+Notice there is no explicit `flatMap`. Arrow uses Kotlin's context receivers and suspension machinery so that error-prone code reads like ordinary sequential code, while still being typed and short-circuiting. This is Arrow's philosophy: functional *semantics*, imperative-looking *syntax*, riding on Kotlin's grain rather than against it.
+
+---
+
+## Cats (Scala): The Full Type Class Hierarchy
+
+With Cats, the ambition changes category entirely.
+
+Vavr and Arrow are, broadly, "here are some useful data types." Cats is "here is the abstract algebra that all of those data types share, expressed as type classes, so you can write code that is generic over *any* type that satisfies the laws."
+
+Scala has higher-kinded types — the ability to abstract over `F[_]`, a type constructor, not just a concrete type. This is the language feature Java and (until recently) Kotlin lack, and it is what makes Cats possible.
+
+Cats provides the now-canonical hierarchy:
+
+- `Functor` — anything you can `map` over
+- `Applicative` — anything you can combine independent values in
+- `Monad` — anything you can `flatMap` (sequence dependent steps) in
+- `Semigroup` / `Monoid` — anything you can combine associatively
+- `Traverse` — turn a structure of effects into an effect of a structure
+
+```scala
+import cats.syntax.all._
+
+// This function works for ANY F that has an Applicative instance:
+// Option, Either, List, IO, Future, Validated...
+def combine[F[_]: Applicative](fa: F[Int], fb: F[Int]): F[Int] =
+  (fa, fb).mapN(_ + _)
+
+combine(Option(1), Option(2))          // Some(3)
+combine(List(1, 2), List(10, 20))      // List(11, 21, 12, 22)
+```
+
+That single `combine` function is genuinely generic over the *shape of the effect*. You cannot write this in Java or vanilla Kotlin — there is no way to say "for any container `F` that supports combining." This is the power Cats unlocks, and it is also its cost: the abstraction is real, and so is the learning curve. Cats (and its sibling Cats Effect for managing side effects) is the most powerful and the most demanding library on this list.
+
+---
+
+## fp-ts (TypeScript): Bringing Typed FP to JavaScript
+
+fp-ts brought the Cats/Scalaz style of programming to TypeScript. It provides `Option`, `Either`, `Task` (async), `TaskEither`, `Reader`, and the same type class vocabulary — `Functor`, `Monad`, `Traversable` — simulated on top of TypeScript's structural type system.
+
+TypeScript does not have higher-kinded types natively, so fp-ts famously emulated them with a clever "URI" encoding. The result was powerful but notoriously verbose, especially around the pipe-based composition style:
+
+```typescript
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+
+const result = pipe(
+  validateInput(raw),                       // Either<Error, Input>
+  E.flatMap(parseOrder),                    // Either<Error, Order>
+  E.map(order => order.total),              // Either<Error, number>
+  E.getOrElse(() => 0)
+)
+```
+
+fp-ts is worth understanding for a reason beyond TypeScript itself: it is the clearest illustration of what happens when you push a full type-class-based FP style into a language whose type system was not designed for it. It works, it is type-safe, and it is undeniably heavier than the language's native idioms. That tension is exactly why its successor, **Effect**, has been gaining ground — it keeps the typed-error and typed-effect benefits while presenting a more approachable, less category-theory-forward API. The lesson echoes Arrow's: the libraries that thrive are the ones that bend toward the host language's grain.
+
+---
+
+## Side by Side
+
+| | **Vavr** | **Arrow** | **Cats** | **fp-ts** |
+|---|---|---|---|---|
+| Language | Java | Kotlin | Scala | TypeScript |
+| Higher-kinded types? | No (language limit) | Emulated/limited | Yes (native) | Emulated (URI trick) |
+| Core offering | Data types + immutable collections | Typed errors + optics, on Kotlin's grain | Full type class hierarchy | Type classes ported to TS |
+| `Option` emphasis | Yes (JDK gap) | Low (Kotlin has `T?`) | Yes | Yes |
+| Effect system | No | Partial (coroutines) | Yes (Cats Effect) | Yes (Task; Effect successor) |
+| Learning curve | Low | Moderate | High | High |
+| Fills which gap | Missing JDK data types | Composable typed errors | Generic abstraction over effects | Typed FP for JS |
+
+---
+
+## What This Tells You About the Java Decision
+
+Reading across all four, a pattern emerges that is directly useful when deciding what to do in Java.
+
+The libraries split into two philosophies:
+
+1. **Data-types-first** (Vavr, mostly Arrow): "Here are `Option`, `Either`, `Try`, `Validated` and the combinators to use them. We will not ask you to learn category theory." These libraries are easy to adopt incrementally and easy to leave.
+
+2. **Type-classes-first** (Cats, fp-ts): "Here is an abstract algebra. Once you learn it, you can write code generic over any effect." These deliver more power and demand more investment, and they tend to take over a codebase's style rather than sit at its edges.
+
+Java, with its lack of higher-kinded types, simply cannot host the second philosophy comfortably — and that is fine. The realistic, valuable target for Java is the *first* one: typed absence, typed failure, typed accumulation, and the combinators that compose them. That is exactly the niche Vavr occupies and the niche a smaller, JDK-first library like dmx-fun aims at with `Option`, `Result`, `Try`, `Either`, and `Validated` built directly on sealed interfaces and records.
+
+The arrival of records, sealed types, and pattern-matching `switch` means a Java team can now get a large fraction of the data-types-first benefit either from a focused library or, for the simplest cases, from a handful of their own sealed types. The type-classes-first power of Cats remains genuinely out of reach — and for most business software, genuinely unnecessary.
+
+---
+
+## So: What Problems Do They Solve?
+
+All four solve the same root problem — **mainstream languages shipped the function-passing half of functional programming and skipped the typed-outcome half** — but they aim at different points on the power/cost curve:
+
+- **Vavr** restores the data types Java's standard library never added.
+- **Arrow** gives Kotlin composable typed errors that read like ordinary code.
+- **Cats** gives Scala a complete, lawful abstraction over effects via higher-kinded types.
+- **fp-ts** ported that abstraction into TypeScript, proving both its power and its friction in a language not built for it.
+
+Knowing which gap each fills is what lets you choose deliberately — and, in Java specifically, recognize how much of that gap you can now close with the language alone plus a focused set of types.
+
+---
+
+## Further reading
+
+- [Do You Need a Functional Library or Just Better Habits?](/dmx-fun/blog/library-vs-habits) — when a library earns its place and when discipline is enough
+- [JDK-First Functional Programming: How Far Can You Go Without Dependencies?](/dmx-fun/blog/jdk-first-functional-programming) — how much of the data-types-first toolkit the modern JDK gives you for free
+- [Designing More Expressive APIs with Functional Types](/dmx-fun/blog/expressive-apis-with-functional-types) — putting Option, Result, and Validated to work in real signatures
+- [Monads Without the Smoke and Mirrors](/dmx-fun/blog/monads-without-smoke-and-mirrors) — the abstraction that Cats and fp-ts build their hierarchy around, explained plainly


### PR DESCRIPTION
  Maps what each functional library provides and which gap in its host
  language it fills, splitting them into data-types-first (Vavr, Arrow)
  and type-classes-first (Cats, fp-ts) philosophies, and draws the
  implication for JDK-first Java.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published comprehensive blog post comparing functional programming libraries and their approaches to solving typed-outcome patterns across multiple languages

* **Documentation**
  * Updated editorial roadmap with additional planned content topics and blog ideas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->