### PR TITLE
docs(blog): add post on a practical FP learning path for Java

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -145,7 +145,7 @@
 
 ### Teaching, teams, and career
 
-103. A practical learning path for functional programming in Java
+103. ~~A practical learning path for functional programming in Java~~
 104. Onboarding a developer to a functional codebase
 105. Selling functional programming to skeptical stakeholders
 106. Functional thinking as a career skill, not a language feature

--- a/site/src/data/blog/practical-learning-path-functional-programming-java.md
+++ b/site/src/data/blog/practical-learning-path-functional-programming-java.md
@@ -1,0 +1,265 @@
+---
+title: "A Practical Learning Path for Functional Programming in Java"
+description: "Most developers learn functional programming in the wrong order — starting with monads and category theory instead of the habits that actually change their code. This is a staged path that starts with pure functions and immutability, then adds types, then composition, building each skill on the one before it."
+pubDate: 2026-06-22
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Guide"
+tags: ["Functional Programming", "Java", "Learning Path", "Career", "Fundamentals", "Best Practices"]
+image: "https://images.pexels.com/photos/249220/pexels-photo-249220.jpeg"
+imageCredit:
+    author: "Maria Tyutina"
+    authorUrl: "https://www.pexels.com/@mtyutina/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/foto/taza-de-cafe-y-un-libro-249220/"
+---
+
+Most developers learn functional programming in the wrong order.
+
+They read a monad tutorial first. They bounce off the burrito analogies, conclude that functional programming is academic, and go back to writing the code they already knew. The concepts were not the problem — the *order* was. Monads are near the end of the path, not the beginning.
+
+This post lays out a learning path that starts where the practical payoff is largest and the prerequisites are smallest, then builds upward. Each stage uses only Java — no new language, no heavy library — and each one produces code you can ship the same week you learn it.
+
+The path has five stages. You should feel comfortable at each one before moving to the next. Resist the urge to skip ahead; the later stages only make sense once the earlier habits are automatic.
+
+---
+
+## Stage 0: The Mindset Shift (Before Any Code)
+
+Functional programming is not a framework you import. It is a set of constraints you accept voluntarily because they make code easier to reason about. Before writing anything, internalize the one idea that everything else follows from:
+
+**Prefer computing values over performing actions.**
+
+An imperative program is a list of instructions that change state. A functional program is an expression that computes a result. The shift is from "do this, then do that, then mutate this" to "this value is defined as that transformation of those inputs."
+
+You do not need new tools for this. You need to notice, every time you write a method, whether it is *computing something* or *changing something* — and to prefer the former wherever you have a choice.
+
+That is the whole mindset. Everything below is mechanics in service of it.
+
+---
+
+## Stage 1: Pure Functions and Immutability
+
+**Goal:** Write code whose behavior depends only on its inputs.
+
+This is the foundation, and it requires no functional types at all — just discipline with the Java you already know.
+
+### What to practice
+
+**Write pure functions.** A pure function returns the same output for the same input and changes nothing outside itself. Start by extracting the *calculation* out of methods that currently mix calculation with I/O:
+
+```java
+// Before: calculation tangled with side effects
+public BigDecimal chargeCustomer(Customer c, Cart cart) {
+    BigDecimal total = BigDecimal.ZERO;
+    for (Item i : cart.items()) total = total.add(i.price());
+    if (c.isPremium()) total = total.multiply(new BigDecimal("0.9"));
+    auditLog.record(c.id(), total);   // side effect
+    return total;
+}
+
+// After: the pure calculation stands alone, testable in isolation
+static BigDecimal orderTotal(Cart cart, boolean premium) {
+    BigDecimal subtotal = cart.items().stream()
+        .map(Item::price)
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+    return premium ? subtotal.multiply(new BigDecimal("0.9")) : subtotal;
+}
+```
+
+**Use `record` for data.** Records are immutable by default. Make them your reflex for any value that carries data — DTOs, value objects, events, commands.
+
+**Stop mutating collections.** Replace `list.add(...)` loops with stream pipelines that produce new collections. Return `List.copyOf(...)` instead of exposing internal mutable lists.
+
+### How you know you are ready for Stage 2
+
+You can look at any method and say whether it is pure, and when it is not, you know exactly which line makes it impure. Testing your calculations no longer requires mocks.
+
+**Read:** [Pure Functions and Side Effects](/dmx-fun/blog/pure-functions-and-side-effects) and [Immutability: The Foundation of Functional Programming](/dmx-fun/blog/immutability-foundation-functional-programming).
+
+---
+
+## Stage 2: Functions as Values
+
+**Goal:** Treat behavior as data you can pass, store, and return.
+
+Java has had lambdas since version 8. Most developers use them only inside `stream()` calls. This stage is about using them everywhere a "unit of behavior" appears.
+
+### What to practice
+
+**Pass behavior as a parameter.** Any time two methods differ only in one step, that step is a function parameter:
+
+```java
+// Instead of two near-identical methods, parameterize the varying step
+static <T> List<T> retain(List<T> items, Predicate<T> keep) {
+    return items.stream().filter(keep).toList();
+}
+
+List<Order> paid    = retain(orders, o -> o.status() == PAID);
+List<Order> overdue = retain(orders, Order::isOverdue);
+```
+
+**Return functions from methods.** A method that returns a `Function` or `Predicate` is a factory for configured behavior — this is partial application, and it replaces a surprising number of small classes.
+
+**Get fluent with `Function`, `Predicate`, `Supplier`, `Consumer`** and the method-reference syntax (`Class::method`). These four interfaces cover most day-to-day needs.
+
+### How you know you are ready for Stage 3
+
+You reach for a lambda or a method reference before you reach for a new class when the "thing" you need is really just one behavior. You are comfortable reading a method whose return type is `Function<A, B>`.
+
+**Read:** [Higher-Order Functions Explained with Real Examples](/dmx-fun/blog/higher-order-functions-real-examples) and [Currying and Partial Application in Practice](/dmx-fun/blog/currying-and-partial-application-in-practice).
+
+---
+
+## Stage 3: Modeling with Types
+
+**Goal:** Make illegal states unrepresentable and make outcomes explicit in signatures.
+
+This is the stage where functional programming starts paying for itself in fewer production bugs. It builds directly on records (Stage 1) by adding their counterpart: sealed interfaces.
+
+### What to practice
+
+**Replace nullable returns with `Option<T>`.** A method that might not find something should say so in its type, not return `null`:
+
+```java
+// The signature now tells the truth
+Option<Customer> findByEmail(String email);
+```
+
+**Replace exceptions-for-expected-failures with `Result<V, E>`.** When a method can fail for a reason the caller should handle, encode the failure in the type:
+
+```java
+Result<Order, OrderError> placeOrder(OrderRequest request);
+```
+
+**Model your domain with sealed interfaces.** A value that is "one of several shapes" becomes a sealed interface with a record per shape, and you branch on it with an exhaustive `switch`:
+
+```java
+sealed interface PaymentMethod permits Card, BankTransfer, StoreCredit {}
+record Card(String last4, YearMonth expiry) implements PaymentMethod {}
+record BankTransfer(String iban)            implements PaymentMethod {}
+record StoreCredit(Money balance)           implements PaymentMethod {}
+```
+
+This is where you learn Algebraic Data Types in practice — records are "AND" types, sealed interfaces are "OR" types. The compiler starts catching whole categories of bugs for you.
+
+### How you know you are ready for Stage 4
+
+Your method signatures no longer lie. You instinctively model "this might be absent" as `Option` and "this might fail" as `Result`. You use exhaustive `switch` and you are glad when adding a new case breaks compilation at every call site.
+
+**Read:** [Algebraic Data Types Explained for Business Software Developers](/dmx-fun/blog/algebraic-data-types-for-business-developers), [Designing More Expressive APIs with Functional Types](/dmx-fun/blog/expressive-apis-with-functional-types), and [Pattern Matching and Domain Modeling](/dmx-fun/blog/pattern-matching-domain-modeling).
+
+---
+
+## Stage 4: Composition
+
+**Goal:** Connect small typed functions into pipelines without losing the type safety from Stage 3.
+
+Once your functions return `Option` and `Result`, you need a way to chain them that does not collapse into nested `if` checks. That tool is `map` and `flatMap`.
+
+### What to practice
+
+**Chain transformations with `map`.** When the next step cannot fail, `map` it:
+
+```java
+Option<String> city = findByEmail(email)
+    .map(Customer::address)
+    .map(Address::city);
+```
+
+**Sequence fallible steps with `flatMap`.** When the next step itself returns a `Result` or `Option`, `flatMap` it — this is the move that keeps a multi-step operation flat and readable:
+
+```java
+Result<Receipt, OrderError> checkout(Cart cart) {
+    return validate(cart)
+        .flatMap(this::reserveStock)
+        .flatMap(this::chargePayment)
+        .map(this::buildReceipt);
+}
+```
+
+This is "railway-oriented programming" — the pipeline stays on the success track and short-circuits to the error track at the first failure. It is also, precisely, what people mean by "monad" — but you have arrived at it by needing it, not by studying it abstractly.
+
+**Accumulate independent errors with `Validated`.** When validating multiple fields that do not depend on each other, switch from fail-fast `Result` to error-accumulating `Validated` so the user sees every problem at once.
+
+### How you know you are ready for Stage 5
+
+You can read and write a `flatMap` chain without translating it back into `if`/`else` in your head. You know when to reach for `map` versus `flatMap` versus `Validated`. The word "monad" no longer intimidates you, because you have been using one.
+
+**Read:** [Railway-Oriented Programming in Java (Without Frameworks)](/dmx-fun/blog/railway-oriented-programming-in-java), [Functional Composition Patterns](/dmx-fun/blog/functional-composition-patterns), and [Monads Without the Smoke and Mirrors](/dmx-fun/blog/monads-without-smoke-and-mirrors).
+
+---
+
+## Stage 5: Architecture
+
+**Goal:** Organize a whole application around a pure core and a thin impure shell.
+
+The final stage is not a new concept — it is the disciplined application of everything above at the scale of a service or a system.
+
+### What to practice
+
+**Functional core, imperative shell.** Push all your decisions — the business logic — into pure functions that take data and return data (or `Result`). Keep all your I/O — database, HTTP, messaging, logging — in a thin outer layer that calls the pure core and then executes its decisions.
+
+```java
+// Pure core: decides WHAT should happen
+static Result<List<Command>, BookingError> decide(BookingRequest req, Availability now) { ... }
+
+// Imperative shell: reads state, calls the core, performs the effects
+void handle(BookingRequest req) {
+    Availability now = repository.currentAvailability();   // impure read
+    switch (decide(req, now)) {                            // pure decision
+        case Result.Ok<List<Command>, BookingError> ok -> ok.value().forEach(bus::publish); // impure write
+        case Result.Err<List<Command>, BookingError> e -> respondWithError(e.error());
+    }
+}
+```
+
+**Encode business rules as composable values.** Validation rules, pricing rules, and policies become data you can combine, test, and reuse rather than scattered `if` statements.
+
+### How you know you have arrived
+
+New features mostly add pure functions and new sealed-type variants. Your tests for business logic run in milliseconds with no framework. The infrastructure code is boring and thin, because all the interesting decisions live in code that is trivial to test.
+
+**Read:** [Functional Core, Imperative Shell](/dmx-fun/blog/functional-core-imperative-shell) and [Functional Design of Business Rules](/dmx-fun/blog/functional-design-of-business-rules).
+
+---
+
+## The Path at a Glance
+
+| Stage | Skill | New tools | Payoff |
+|---|---|---|---|
+| 0 | Mindset: values over actions | none | A lens for everything below |
+| 1 | Pure functions, immutability | `record`, streams | Testable logic, no mocks |
+| 2 | Functions as values | lambdas, `Function`/`Predicate` | Less boilerplate, configurable behavior |
+| 3 | Modeling with types | `Option`, `Result`, sealed types | Illegal states unrepresentable |
+| 4 | Composition | `map`, `flatMap`, `Validated` | Readable multi-step pipelines |
+| 5 | Architecture | functional core / imperative shell | Fast tests, thin infrastructure |
+
+---
+
+## Common Mistakes Along the Way
+
+**Skipping to Stage 4.** Learning `flatMap` before you are comfortable with pure functions and typed outcomes is exactly the "monad tutorial" trap. The composition only makes sense once you have types worth composing.
+
+**Treating it as all-or-nothing.** You do not convert a codebase overnight. Each stage produces shippable improvements. A team can sit comfortably at Stage 3 for a year and be far better off than when it started.
+
+**Importing a heavy library too early.** Stages 1–3 need almost nothing beyond modern Java. Add a focused functional library when you feel the absence of its types — not before. Adopting the vocabulary without the habits just adds noise.
+
+**Forcing purity where it does not belong.** The goal is a pure *core*, not a pure *everything*. Code that sends an email must send an email. Separate the decision from the effect; do not try to eliminate the effect.
+
+---
+
+## Where to Start This Week
+
+Pick one method in your current codebase that mixes a calculation with side effects. Extract the calculation into a pure, static function. Write a test for it that uses no mocks. That single refactor is Stage 1, and it is the entire path in miniature: find the value being computed, separate it from the actions, and make it easy to reason about.
+
+Do that ten times and Stage 1 is a habit. Then, and only then, move to Stage 2.
+
+---
+
+## Further reading
+
+- [Pure Functions and Side Effects](/dmx-fun/blog/pure-functions-and-side-effects) — the bedrock skill of Stage 1
+- [Designing More Expressive APIs with Functional Types](/dmx-fun/blog/expressive-apis-with-functional-types) — the Stage 3 toolkit applied to real signatures
+- [Railway-Oriented Programming in Java (Without Frameworks)](/dmx-fun/blog/railway-oriented-programming-in-java) — the Stage 4 composition model in depth
+- [Do You Need a Functional Library or Just Better Habits?](/dmx-fun/blog/library-vs-habits) — deciding when to add a library as you progress through the stages

--- a/site/src/data/blog/practical-learning-path-functional-programming-java.md
+++ b/site/src/data/blog/practical-learning-path-functional-programming-java.md
@@ -20,7 +20,7 @@ They read a monad tutorial first. They bounce off the burrito analogies, conclud
 
 This post lays out a learning path that starts where the practical payoff is largest and the prerequisites are smallest, then builds upward. Each stage uses only Java — no new language, no heavy library — and each one produces code you can ship the same week you learn it.
 
-The path has five stages. You should feel comfortable at each one before moving to the next. Resist the urge to skip ahead; the later stages only make sense once the earlier habits are automatic.
+The path has six stages. You should feel comfortable at each one before moving to the next. Resist the urge to skip ahead; the later stages only make sense once the earlier habits are automatic.
 
 ---
 
@@ -239,7 +239,7 @@ New features mostly add pure functions and new sealed-type variants. Your tests 
 
 ## Common Mistakes Along the Way
 
-**Skipping to Stage 4.** Learning `flatMap` before you are comfortable with pure functions and typed outcomes is exactly the "monad tutorial" trap. The composition only makes sense once you have types worth composing.
+**Skipping to Stage 4.** Learning `flatMap` before you are comfortable with pure functions and typed outcomes is precisely the "monad tutorial" trap. The composition only makes sense once you have types worth composing.
 
 **Treating it as all-or-nothing.** You do not convert a codebase overnight. Each stage produces shippable improvements. A team can sit comfortably at Stage 3 for a year and be far better off than when it started.
 


### PR DESCRIPTION
  Lay out a five-stage path — mindset, pure functions and immutability,
  functions as values, modeling with types, composition, and architecture
  — with readiness checks and common mistakes between stages, building
  each skill on the previous one and deferring monads until they are
  needed rather than studied up front.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published a comprehensive learning guide for functional programming in Java with structured stages, practical examples, code snippets, and progress checkpoints.

* **Updates**
  * Updated the product roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->