### PR TITLE
chore(deps): bump jackson-databind to 2.22.0 and refresh compatibility matrix

### DIFF
--- a/.github/workflows/jackson-compatibility.yaml
+++ b/.github/workflows/jackson-compatibility.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # Covers the nine most recent minor release lines still in wide use.
         # Update this list when a new minor is released or an old one is EOL.
-        jackson-version: ['2.13.5', '2.14.3', '2.15.4', '2.16.2', '2.17.3', '2.18.7', '2.19.4', '2.20.2', '2.21.3']
+        jackson-version: ['2.14.3', '2.15.4', '2.16.2', '2.17.3', '2.18.7', '2.19.4', '2.20.2', '2.21.4', '2.22.0']
     name: Jackson ${{ matrix.jackson-version }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 [versions]
 java = "25"
 assertj = "3.27.7"
-jackson = "2.21.3"
+jackson = "2.22.0"
 aspectj = "1.9.25.1"
 spring = "7.0.7"
 springBoot = "4.0.6"

--- a/serialization/jackson/README.md
+++ b/serialization/jackson/README.md
@@ -20,7 +20,7 @@ implementation("codes.domix:fun-jackson:${dmxFunVersion}")
 
 Jackson itself is declared `compileOnly` in this module — you must provide
 `com.fasterxml.jackson.core:jackson-databind` on your own classpath.
-Compatible versions: **2.13.x – 2.21.x**.
+Compatible versions: **2.14.x – 2.22.x**.
 
 ## Registration
 
@@ -93,7 +93,6 @@ The module is tested against the following Jackson versions in CI:
 
 | Version | Status |
 |---------|--------|
-| 2.13.x  | tested |
 | 2.14.x  | tested |
 | 2.15.x  | tested |
 | 2.16.x  | tested |
@@ -102,6 +101,7 @@ The module is tested against the following Jackson versions in CI:
 | 2.19.x  | tested |
 | 2.20.x  | tested |
 | 2.21.x  | tested |
+| 2.22.x  | tested |
 
 To run the tests locally against a specific version:
 

--- a/site/src/data/code/guide/jackson/dependency.mdx
+++ b/site/src/data/code/guide/jackson/dependency.mdx
@@ -5,8 +5,8 @@ fileName: 'build.gradle / pom.xml'
 ```groovy
 // Gradle
 implementation("codes.domix:fun-jackson:0.1.0")
-// Jackson itself — bring your own version (2.13.x – 2.21.x)
-implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
+// Jackson itself — bring your own version (2.14.x – 2.22.x)
+implementation("com.fasterxml.jackson.core:jackson-databind:2.22.0")
 ```
 
 ```xml
@@ -19,6 +19,6 @@ implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.21.2</version>
+    <version>2.22.0</version>
 </dependency>
 ```

--- a/site/src/data/guide/contributing.mdx
+++ b/site/src/data/guide/contributing.mdx
@@ -216,7 +216,7 @@ the version catalog entry when the property is absent (safe for local developmen
 | Workflow                         | Gradle property      | Tested range            |
 |----------------------------------|----------------------|-------------------------|
 | `assertj-compatibility.yaml`     | `-PassertjVersion`   | `3.21.0` – `3.27.7`    |
-| `jackson-compatibility.yaml`     | `-PjacksonVersion`   | `2.13.5` – `2.21.2`    |
+| `jackson-compatibility.yaml`     | `-PjacksonVersion`   | `2.14.3` – `2.22.0`    |
 | `spring-compatibility.yaml`      | `-PspringVersion`    | `6.0.23` – `7.0.6`     |
 
 To run a specific version locally:

--- a/site/src/data/guide/jackson.mdx
+++ b/site/src/data/guide/jackson.mdx
@@ -24,7 +24,7 @@ runtime dependency on Jackson.
 
 `fun-jackson` declares `jackson-databind` as `compileOnly`. You must add
 `jackson-databind` explicitly to your own classpath. Any version from
-**2.13.x through 2.21.x** is supported (see [version compatibility](#version-compatibility) below).
+**2.14.x through 2.22.x** is supported (see [version compatibility](#version-compatibility) below).
 
 <Dependency/>
 
@@ -97,7 +97,6 @@ request that touches the `jackson/` module:
 
 | Jackson version | Status  |
 |-----------------|---------|
-| 2.13.x          | tested  |
 | 2.14.x          | tested  |
 | 2.15.x          | tested  |
 | 2.16.x          | tested  |
@@ -106,6 +105,7 @@ request that touches the `jackson/` module:
 | 2.19.x          | tested  |
 | 2.20.x          | tested  |
 | 2.21.x          | tested  |
+| 2.22.x          | tested  |
 
 To test locally against a specific version:
 

--- a/site/src/data/guide/pipelines.mdx
+++ b/site/src/data/guide/pipelines.mdx
@@ -16,7 +16,7 @@ All CI/CD is handled by GitHub Actions. The workflows live in `.github/workflows
 | `gradle.yml`                 | push / PR to `main` (code paths)       | Full build, tests, coverage, Javadoc, dependency graph submission       |
 | `publish.yml`                | push to `main` — stable version only   | Publish all modules to Maven Central, create git tag and GitHub Release |
 | `publish-snapshot.yml`       | push to `main` — SNAPSHOT version only | Publish SNAPSHOT artifacts to Maven Central                             |
-| `jackson-compatibility.yaml` | PR touching `jackson/**`               | Matrix test against Jackson 2.13.x – 2.21.x                             |
+| `jackson-compatibility.yaml` | PR touching `jackson/**`               | Matrix test against Jackson 2.14.x – 2.22.x                             |
 | `assertj-compatibility.yaml`             | PR touching `assertj/**`                           | Matrix test against AssertJ 3.21.x – 3.27.x                              |
 | `spring-boot-compatibility.yaml`         | PR touching `spring-boot/**` or `spring/**`        | Matrix test of `fun-spring-boot` against Spring Boot 3.3.x – 4.0.x       |
 | `spring-boot-sample-compatibility.yaml`  | PR touching `spring-boot-sample/**` or `spring/**` | Matrix test of the Spring Boot sample app against Boot 3.4.x – 4.0.x     |
@@ -106,15 +106,15 @@ Runs only on pull requests — not on push to `main`.
 
 | Jackson version | Status |
 |-----------------|--------|
-| 2.13.5          | tested |
 | 2.14.3          | tested |
 | 2.15.4          | tested |
 | 2.16.2          | tested |
 | 2.17.3          | tested |
-| 2.18.2          | tested |
+| 2.18.7          | tested |
 | 2.19.4          | tested |
 | 2.20.2          | tested |
-| 2.21.2          | tested |
+| 2.21.4          | tested |
+| 2.22.0          | tested |
 
 **Local equivalent**:
 ```bash


### PR DESCRIPTION
Resolve open Dependabot alerts for jackson-databind (PolymorphicTypeValidator
bypasses, @JsonView/@JsonIgnore bypasses, SSRF via InetSocketAddress DNS
resolution). The 2.21.x line tops out at 2.21.4, which leaves one advisory
(case-insensitive @JsonIgnoreProperties bypass, fixed in 2.21.5) unpatched,
so move the catalog version to 2.22.0.

Roll the CI compatibility matrix forward to keep the nine most recent minor
lines: drop 2.13.x, bump the 2.21 entry to 2.21.4, and add 2.22.0. Update the
module README compatibility range and table to match.

Tests pass on the jackson, spring-boot, and samples modules.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
