### PR TITLE
chore(deps): update Quarkus to 3.37.0

### DIFF
--- a/.github/workflows/quarkus-compatibility.yaml
+++ b/.github/workflows/quarkus-compatibility.yaml
@@ -29,6 +29,7 @@ jobs:
           - '3.21.4'
           - '3.31.4'
           - '3.35.1'
+          - '3.37.0'
     name: Quarkus ${{ matrix.quarkus-version }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ yasson = "3.0.4"
 jaxbImpl = "4.0.8"
 jakartaJsonApi = "2.1.3"
 parsson = "1.1.7"
-quarkus = "3.35.1"
+quarkus = "3.37.0"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/site/src/data/guide/quarkus.mdx
+++ b/site/src/data/guide/quarkus.mdx
@@ -202,6 +202,7 @@ the `frameworks/quarkus/` module:
 | 3.21.4 | tested |
 | 3.31.4 | tested |
 | 3.35.1 | tested |
+| 3.37.0 | tested |
 
 To test locally against a specific version:
 


### PR DESCRIPTION
Bump Quarkus 3.35.1 -> 3.37.0 (latest release) in the version catalog. Add
3.37.0 to the compatibility matrix and the guide table; the 3.35.x LTS line
stays in both. Note this moves the default off the LTS line onto the latest
non-LTS release. Verified the quarkus runtime, deployment, and integration-test
modules build and test green.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
