### PR TITLE
feat(reactor): add Flux interop and Result railway operators (#473)

### DIFF
--- a/reactor/src/main/java/dmx/fun/reactor/ReactorFlux.java
+++ b/reactor/src/main/java/dmx/fun/reactor/ReactorFlux.java
@@ -1,0 +1,245 @@
+package dmx.fun.reactor;
+
+import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Validated;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Idiomatic conversions between Project Reactor's {@link Flux} and dmx-fun's
+ * {@link Option}, {@link Result}, {@link Try}, and {@link NonEmptyList}.
+ *
+ * <p>Where {@link ReactorFun} handles a single value ({@code Mono}), this facade
+ * handles streams ({@code Flux}):
+ *
+ * <ul>
+ *   <li><b>{@code sequence} / {@code collectResult} / {@code collectValidated}</b>
+ *       fold a stream of outcomes into a single {@code Mono<Result<List<…>, …>>} —
+ *       the reactive equivalent of {@link Result#sequence(Iterable)} — choosing
+ *       fail-fast or error-accumulating semantics.</li>
+ *   <li><b>{@code flattenOption}</b> drops absent elements from a
+ *       {@code Flux<Option<T>>}.</li>
+ *   <li><b>{@code toFlux}</b> emits a dmx-fun container or collection as a
+ *       {@code Flux}.</li>
+ * </ul>
+ *
+ * <p>Backpressure and cancellation are preserved by the underlying Reactor operators.
+ */
+@NullMarked
+public final class ReactorFlux {
+
+    private ReactorFlux() {
+    }
+
+    // ── Aggregation: Flux -> Mono<Result<List>> ────────────────────────────────
+
+    /**
+     * Folds a {@code Flux<Result<T, E>>} into a single {@code Mono<Result<List<T>, E>>},
+     * fail-fast: the first {@code Err} short-circuits and cancels the upstream, and an
+     * empty stream yields {@code Ok([])}. A Reactor error signal from the source is not
+     * absorbed — it propagates as a Reactor error.
+     *
+     * @param results the stream of results
+     * @param <T>     the value type
+     * @param <E>     the error type
+     * @return a {@code Mono} emitting the sequenced {@link Result}
+     */
+    public static <T, E> Mono<Result<List<T>, E>> sequence(Flux<Result<T, E>> results) {
+        Objects.requireNonNull(results, "results");
+        return results
+            .concatMap(result -> switch (result) {
+                case Result.Ok<T, E> ok -> Mono.just(ok.value());
+                case Result.Err<T, E> err -> Mono.<T>error(new ResultError(err.error()));
+            })
+            .collectList()
+            .<Result<List<T>, E>>map(Result::ok)
+            .onErrorResume(ResultError.class, e -> Mono.just(Result.err(extractError(e))));
+    }
+
+    /**
+     * Collects every element of a {@code Flux<T>} into {@code Ok(list)} (empty stream →
+     * {@code Ok([])}), turning a Reactor error signal into {@code Err(cause)}.
+     *
+     * @param source the source stream
+     * @param <T>    the value type
+     * @return a {@code Mono} emitting the collected {@link Result}
+     */
+    public static <T> Mono<Result<List<T>, Throwable>> collectResult(Flux<T> source) {
+        Objects.requireNonNull(source, "source");
+        return source.collectList()
+            .<Result<List<T>, Throwable>>map(Result::ok)
+            .onErrorResume(throwable -> Mono.just(Result.err(throwable)));
+    }
+
+    /**
+     * Collects every element of a {@code Flux<T>} into {@code Ok(list)}, mapping a
+     * Reactor error signal through {@code errorMapper} to the typed error channel.
+     *
+     * @param source      the source stream
+     * @param errorMapper maps a {@link Throwable} error signal to the error type
+     * @param <T>         the value type
+     * @param <E>         the typed error type
+     * @return a {@code Mono} emitting the collected {@link Result}
+     */
+    public static <T, E> Mono<Result<List<T>, E>> collectResult(
+        Flux<T> source,
+        Function<? super Throwable, E> errorMapper
+    ) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(errorMapper, "errorMapper");
+        return source.collectList()
+            .<Result<List<T>, E>>map(Result::ok)
+            .onErrorResume(throwable -> Mono.just(Result.err(errorMapper.apply(throwable))));
+    }
+
+    /**
+     * Folds a {@code Flux<Result<T, E>>} into a {@code Mono<Validated<NonEmptyList<E>, List<T>>>},
+     * accumulating: every {@code Err} is gathered into the invalid channel (no
+     * short-circuit), and an all-{@code Ok} stream (including empty) is {@code Valid}.
+     *
+     * @param results the stream of results
+     * @param <T>     the value type
+     * @param <E>     the error type
+     * @return a {@code Mono} emitting the accumulated {@link Validated}
+     */
+    public static <T, E> Mono<Validated<NonEmptyList<E>, List<T>>> collectValidated(
+        Flux<Result<T, E>> results
+    ) {
+        Objects.requireNonNull(results, "results");
+        return results.collectList().map(ReactorFlux::accumulate);
+    }
+
+    // ── Per-element helpers ────────────────────────────────────────────────────
+
+    /**
+     * Drops the absent elements of a {@code Flux<Option<T>>}, keeping the values of the
+     * {@code Some} elements in source order.
+     *
+     * @param source the stream of options
+     * @param <T>    the value type
+     * @return a {@code Flux} of the present values
+     */
+    public static <T> Flux<T> flattenOption(Flux<Option<T>> source) {
+        Objects.requireNonNull(source, "source");
+        return source.handle((option, sink) -> option.match(() -> { }, sink::next));
+    }
+
+    // ── dmx-fun -> Flux ────────────────────────────────────────────────────────
+
+    /**
+     * Emits each element of a {@link NonEmptyList} as a {@code Flux} (1..N elements).
+     *
+     * @param list the non-empty list
+     * @param <T>  the element type
+     * @return a {@code Flux} over the list
+     */
+    public static <T> Flux<T> toFlux(NonEmptyList<T> list) {
+        Objects.requireNonNull(list, "list");
+        return Flux.fromIterable(list);
+    }
+
+    /**
+     * Emits an {@link Option} as a {@code Flux}: {@code Some} emits one element,
+     * {@code None} completes empty.
+     *
+     * @param option the option
+     * @param <T>    the value type
+     * @return a {@code Flux} of zero or one element
+     */
+    public static <T> Flux<T> toFlux(Option<T> option) {
+        Objects.requireNonNull(option, "option");
+        return option.fold(Flux::empty, Flux::just);
+    }
+
+    /**
+     * Emits a {@link Try} as a {@code Flux}: {@code Success} emits one element,
+     * {@code Failure} errors with the cause.
+     *
+     * @param aTry the try
+     * @param <T>  the value type
+     * @return a {@code Flux} of one element or an error
+     */
+    public static <T> Flux<T> toFlux(Try<T> aTry) {
+        Objects.requireNonNull(aTry, "aTry");
+        return aTry.fold(Flux::just, Flux::error);
+    }
+
+    /**
+     * Emits a {@link Result} whose error channel is already a {@link Throwable} as a
+     * {@code Flux}: {@code Ok} emits one element, {@code Err} errors with the error.
+     *
+     * @param result the result
+     * @param <T>    the value type
+     * @param <E>    the error type, which must be a {@link Throwable}
+     * @return a {@code Flux} of one element or an error
+     */
+    public static <T, E extends Throwable> Flux<T> toFlux(Result<T, E> result) {
+        Objects.requireNonNull(result, "result");
+        return switch (result) {
+            case Result.Ok<T, E> ok -> Flux.just(ok.value());
+            case Result.Err<T, E> err -> Flux.error(err.error());
+        };
+    }
+
+    /**
+     * Emits a {@link Result} as a {@code Flux}: {@code Ok} emits one element, {@code Err}
+     * errors with the error mapped to a {@link Throwable} by {@code errorMapper}.
+     *
+     * @param result      the result
+     * @param errorMapper maps the typed error to a {@link Throwable} error signal
+     * @param <T>         the value type
+     * @param <E>         the error type
+     * @return a {@code Flux} of one element or an error
+     */
+    public static <T, E> Flux<T> toFlux(
+        Result<T, E> result,
+        Function<? super E, ? extends Throwable> errorMapper
+    ) {
+        Objects.requireNonNull(result, "result");
+        Objects.requireNonNull(errorMapper, "errorMapper");
+        return switch (result) {
+            case Result.Ok<T, E> ok -> Flux.just(ok.value());
+            case Result.Err<T, E> err -> Flux.error(
+                () -> Objects.requireNonNull(errorMapper.apply(err.error()), "errorMapper returned null"));
+        };
+    }
+
+    // ── internals ──────────────────────────────────────────────────────────────
+
+    private static <T, E> Validated<NonEmptyList<E>, List<T>> accumulate(List<Result<T, E>> results) {
+        List<T> values = new ArrayList<>();
+        List<E> errors = new ArrayList<>();
+        for (Result<T, E> result : results) {
+            switch (result) {
+                case Result.Ok<T, E> ok -> values.add(ok.value());
+                case Result.Err<T, E> err -> errors.add(err.error());
+            }
+        }
+        return NonEmptyList.fromList(errors).fold(
+            () -> Validated.valid(values),
+            Validated::invalid);
+    }
+
+    /** Carries a typed {@code Result.Err} value through Reactor's error channel for {@link #sequence}. */
+    private static final class ResultError extends RuntimeException {
+        private final transient Object error;
+
+        ResultError(Object error) {
+            super(null, null, false, false);
+            this.error = error;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E> E extractError(ResultError signal) {
+        return (E) signal.error;
+    }
+}

--- a/reactor/src/main/java/dmx/fun/reactor/ReactorFlux.java
+++ b/reactor/src/main/java/dmx/fun/reactor/ReactorFlux.java
@@ -114,7 +114,10 @@ public final class ReactorFlux {
         Flux<Result<T, E>> results
     ) {
         Objects.requireNonNull(results, "results");
-        return results.collectList().map(ReactorFlux::accumulate);
+        // Stream straight into the value/error buffers instead of materializing the
+        // whole Flux into a List<Result> and re-walking it.
+        return results.collect(Accumulator<T, E>::new, Accumulator::add)
+            .map(Accumulator::toValidated);
     }
 
     // ── Per-element helpers ────────────────────────────────────────────────────
@@ -214,18 +217,23 @@ public final class ReactorFlux {
 
     // ── internals ──────────────────────────────────────────────────────────────
 
-    private static <T, E> Validated<NonEmptyList<E>, List<T>> accumulate(List<Result<T, E>> results) {
-        List<T> values = new ArrayList<>();
-        List<E> errors = new ArrayList<>();
-        for (Result<T, E> result : results) {
+    /** Aggregates a stream of {@code Result} into value and error buffers as it is consumed. */
+    private static final class Accumulator<T, E> {
+        private final List<T> values = new ArrayList<>();
+        private final List<E> errors = new ArrayList<>();
+
+        void add(Result<T, E> result) {
             switch (result) {
                 case Result.Ok<T, E> ok -> values.add(ok.value());
                 case Result.Err<T, E> err -> errors.add(err.error());
             }
         }
-        return NonEmptyList.fromList(errors).fold(
-            () -> Validated.valid(values),
-            Validated::invalid);
+
+        Validated<NonEmptyList<E>, List<T>> toValidated() {
+            return NonEmptyList.fromList(errors).fold(
+                () -> Validated.valid(values),
+                Validated::invalid);
+        }
     }
 
     /** Carries a typed {@code Result.Err} value through Reactor's error channel for {@link #sequence}. */

--- a/reactor/src/main/java/dmx/fun/reactor/ReactorResult.java
+++ b/reactor/src/main/java/dmx/fun/reactor/ReactorResult.java
@@ -1,0 +1,110 @@
+package dmx.fun.reactor;
+
+import dmx.fun.Result;
+import java.util.Objects;
+import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
+import reactor.core.publisher.Mono;
+
+/**
+ * Railway-style operators over a {@code Mono<Result<V, E>>}, so a reactive pipeline
+ * can stay on the {@link Result} track without unwrapping at every step.
+ *
+ * <p>Each operator threads through the {@code Ok} path and passes {@code Err} along
+ * untouched (or transforms only the error channel, for {@link #mapErr} and
+ * {@link #recover}):
+ *
+ * <ul>
+ *   <li>{@link #mapOk} — transform the success value;</li>
+ *   <li>{@link #flatMapOk} — chain a dependent reactive step on the success value;</li>
+ *   <li>{@link #mapErr} — transform the error channel;</li>
+ *   <li>{@link #recover} — turn an {@code Err} back into an {@code Ok} via a fallback.</li>
+ * </ul>
+ */
+@NullMarked
+public final class ReactorResult {
+
+    private ReactorResult() {
+    }
+
+    /**
+     * Maps the success value of a {@code Mono<Result<V, E>>}, leaving {@code Err} untouched.
+     *
+     * @param mono   the source
+     * @param mapper maps the {@code Ok} value
+     * @param <V>    the input value type
+     * @param <W>    the output value type
+     * @param <E>    the error type
+     * @return a {@code Mono} of the transformed {@link Result}
+     */
+    public static <V, W, E> Mono<Result<W, E>> mapOk(
+        Mono<Result<V, E>> mono,
+        Function<? super V, ? extends W> mapper
+    ) {
+        Objects.requireNonNull(mono, "mono");
+        Objects.requireNonNull(mapper, "mapper");
+        return mono.map(result -> result.map(value -> mapper.apply(value)));
+    }
+
+    /**
+     * Chains a dependent reactive step on the success value: when the result is
+     * {@code Ok}, the mapper's {@code Mono<Result<W, E>>} is sequenced; when it is
+     * {@code Err}, the error is passed through without invoking the mapper.
+     *
+     * @param mono   the source
+     * @param mapper maps the {@code Ok} value to the next reactive step
+     * @param <V>    the input value type
+     * @param <W>    the output value type
+     * @param <E>    the error type
+     * @return a {@code Mono} of the chained {@link Result}
+     */
+    public static <V, W, E> Mono<Result<W, E>> flatMapOk(
+        Mono<Result<V, E>> mono,
+        Function<? super V, Mono<Result<W, E>>> mapper
+    ) {
+        Objects.requireNonNull(mono, "mono");
+        Objects.requireNonNull(mapper, "mapper");
+        return mono.flatMap(result -> switch (result) {
+            case Result.Ok<V, E> ok -> mapper.apply(ok.value());
+            case Result.Err<V, E> err -> Mono.just(Result.err(err.error()));
+        });
+    }
+
+    /**
+     * Maps the error channel of a {@code Mono<Result<V, E>>}, leaving {@code Ok} untouched.
+     *
+     * @param mono   the source
+     * @param mapper maps the {@code Err} value
+     * @param <V>    the value type
+     * @param <E>    the input error type
+     * @param <F>    the output error type
+     * @return a {@code Mono} of the {@link Result} with the mapped error channel
+     */
+    public static <V, E, F> Mono<Result<V, F>> mapErr(
+        Mono<Result<V, E>> mono,
+        Function<? super E, ? extends F> mapper
+    ) {
+        Objects.requireNonNull(mono, "mono");
+        Objects.requireNonNull(mapper, "mapper");
+        return mono.map(result -> result.mapError(error -> mapper.apply(error)));
+    }
+
+    /**
+     * Recovers from {@code Err} by mapping the error to a fallback value, producing an
+     * {@code Ok}; an {@code Ok} is passed through unchanged.
+     *
+     * @param mono     the source
+     * @param fallback maps the {@code Err} value to a recovery value
+     * @param <V>      the value type
+     * @param <E>      the error type
+     * @return a {@code Mono} of the recovered {@link Result}
+     */
+    public static <V, E> Mono<Result<V, E>> recover(
+        Mono<Result<V, E>> mono,
+        Function<? super E, ? extends V> fallback
+    ) {
+        Objects.requireNonNull(mono, "mono");
+        Objects.requireNonNull(fallback, "fallback");
+        return mono.map(result -> result.recover(error -> fallback.apply(error)));
+    }
+}

--- a/reactor/src/test/java/dmx/fun/reactor/ReactorFluxTest.java
+++ b/reactor/src/test/java/dmx/fun/reactor/ReactorFluxTest.java
@@ -1,0 +1,209 @@
+package dmx.fun.reactor;
+
+import dmx.fun.NonEmptyList;
+import dmx.fun.Option;
+import dmx.fun.Result;
+import dmx.fun.Try;
+import dmx.fun.Validated;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReactorFluxTest {
+
+    private static final IllegalStateException BOOM = new IllegalStateException("boom");
+
+    // ── sequence ───────────────────────────────────────────────────────────────
+
+    @Test
+    void sequence_allOk_isOkList() {
+        Flux<Result<Integer, String>> src = Flux.just(Result.ok(1), Result.ok(2), Result.ok(3));
+        StepVerifier.create(ReactorFlux.sequence(src))
+            .assertNext(r -> assertThat(r).isOk().containsValue(List.of(1, 2, 3)))
+            .verifyComplete();
+    }
+
+    @Test
+    void sequence_empty_isOkEmptyList() {
+        StepVerifier.create(ReactorFlux.sequence(Flux.<Result<Integer, String>>empty()))
+            .assertNext(r -> assertThat(r).isOk().containsValue(List.of()))
+            .verifyComplete();
+    }
+
+    @Test
+    void sequence_firstErr_shortCircuitsAndCancelsUpstream() {
+        AtomicInteger tailSeen = new AtomicInteger();
+        Flux<Result<Integer, String>> src = Flux.concat(
+            Flux.just(Result.ok(1), Result.ok(2), Result.err("bad")),
+            Flux.just(Result.<Integer, String>ok(99)).doOnNext(x -> tailSeen.incrementAndGet()));
+
+        StepVerifier.create(ReactorFlux.sequence(src))
+            .assertNext(r -> assertThat(r).isErr().containsError("bad"))
+            .verifyComplete();
+
+        // Elements after the first Err are never requested.
+        org.assertj.core.api.Assertions.assertThat(tailSeen).hasValue(0);
+    }
+
+    @Test
+    void sequence_sourceError_propagates() {
+        StepVerifier.create(ReactorFlux.sequence(Flux.error(BOOM)))
+            .verifyError(IllegalStateException.class);
+    }
+
+    // ── collectResult ──────────────────────────────────────────────────────────
+
+    @Test
+    void collectResult_values_isOkList() {
+        StepVerifier.create(ReactorFlux.collectResult(Flux.just("a", "b")))
+            .assertNext(r -> assertThat(r).isOk().containsValue(List.of("a", "b")))
+            .verifyComplete();
+    }
+
+    @Test
+    void collectResult_empty_isOkEmptyList() {
+        StepVerifier.create(ReactorFlux.collectResult(Flux.<String>empty()))
+            .assertNext(r -> assertThat(r).isOk().containsValue(List.of()))
+            .verifyComplete();
+    }
+
+    @Test
+    void collectResult_sourceError_isErrWithCause() {
+        StepVerifier.create(ReactorFlux.collectResult(Flux.<String>error(BOOM)))
+            .assertNext(r -> assertThat(r).isErr().containsError(BOOM))
+            .verifyComplete();
+    }
+
+    @Test
+    void collectResult_withMapper_mapsError() {
+        StepVerifier.create(ReactorFlux.collectResult(Flux.<String>error(BOOM), Throwable::getMessage))
+            .assertNext(r -> assertThat(r).isErr().containsError("boom"))
+            .verifyComplete();
+    }
+
+    // ── collectValidated ───────────────────────────────────────────────────────
+
+    @Test
+    void collectValidated_allOk_isValidList() {
+        Flux<Result<String, String>> src = Flux.just(Result.ok("a"), Result.ok("b"));
+        StepVerifier.create(ReactorFlux.collectValidated(src))
+            .assertNext(v -> assertThat(v).isValid().containsValue(List.of("a", "b")))
+            .verifyComplete();
+    }
+
+    @Test
+    void collectValidated_mixed_accumulatesAllErrors() {
+        Flux<Result<String, String>> src =
+            Flux.just(Result.ok("a"), Result.err("e1"), Result.ok("b"), Result.err("e2"));
+        StepVerifier.create(ReactorFlux.collectValidated(src))
+            .assertNext(v -> {
+                assertThat(v).isInvalid();
+                org.assertj.core.api.Assertions.assertThat(
+                        ((Validated.Invalid<NonEmptyList<String>, List<String>>) v).error().toList())
+                    .containsExactly("e1", "e2");
+            })
+            .verifyComplete();
+    }
+
+    // ── flattenOption ──────────────────────────────────────────────────────────
+
+    @Test
+    void flattenOption_dropsNone_keepsOrder() {
+        Flux<Option<Integer>> src =
+            Flux.just(Option.some(1), Option.none(), Option.some(2), Option.none(), Option.some(3));
+        StepVerifier.create(ReactorFlux.flattenOption(src))
+            .expectNext(1, 2, 3)
+            .verifyComplete();
+    }
+
+    // ── toFlux ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void toFlux_nonEmptyList_emitsAllInOrder() {
+        StepVerifier.create(ReactorFlux.toFlux(NonEmptyList.of(1, List.of(2, 3))))
+            .expectNext(1, 2, 3)
+            .verifyComplete();
+    }
+
+    @Test
+    void toFlux_some_emitsOne() {
+        StepVerifier.create(ReactorFlux.toFlux(Option.some("x")))
+            .expectNext("x")
+            .verifyComplete();
+    }
+
+    @Test
+    void toFlux_none_isEmpty() {
+        StepVerifier.create(ReactorFlux.toFlux(Option.<String>none()))
+            .verifyComplete();
+    }
+
+    @Test
+    void toFlux_success_emitsOne() {
+        StepVerifier.create(ReactorFlux.toFlux(Try.success("x")))
+            .expectNext("x")
+            .verifyComplete();
+    }
+
+    @Test
+    void toFlux_failure_errors() {
+        StepVerifier.create(ReactorFlux.toFlux(Try.<String>failure(BOOM)))
+            .verifyErrorMatches(t -> t == BOOM);
+    }
+
+    @Test
+    void toFlux_okThrowableError_emitsOne() {
+        StepVerifier.create(ReactorFlux.toFlux(Result.<String, IllegalStateException>ok("x")))
+            .expectNext("x")
+            .verifyComplete();
+    }
+
+    @Test
+    void toFlux_errThrowableError_errors() {
+        StepVerifier.create(ReactorFlux.toFlux(Result.<String, IllegalStateException>err(BOOM)))
+            .verifyErrorMatches(t -> t == BOOM);
+    }
+
+    @Test
+    void toFlux_errWithMapper_errorsWithMapped() {
+        StepVerifier.create(ReactorFlux.toFlux(Result.<String, String>err("bad"), IllegalStateException::new))
+            .verifyError(IllegalStateException.class);
+    }
+
+    @Test
+    void toFlux_errMapperReturnsNull_flowsAsOnError() {
+        StepVerifier.create(ReactorFlux.toFlux(Result.<String, String>err("bad"), e -> null))
+            .verifyError(NullPointerException.class);
+    }
+
+    // ── backpressure ───────────────────────────────────────────────────────────
+
+    @Test
+    void toFlux_honorsBackpressure() {
+        StepVerifier.create(ReactorFlux.toFlux(NonEmptyList.of(1, List.of(2, 3))), 0)
+            .thenRequest(1).expectNext(1)
+            .thenRequest(2).expectNext(2, 3)
+            .verifyComplete();
+    }
+
+    // ── null guards ────────────────────────────────────────────────────────────
+
+    @Test
+    void sequence_null_throws() {
+        assertThatThrownBy(() -> ReactorFlux.sequence(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("results");
+    }
+
+    @Test
+    void toFlux_nullResult_throws() {
+        assertThatThrownBy(() -> ReactorFlux.toFlux((Result<String, IllegalStateException>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("result");
+    }
+}

--- a/reactor/src/test/java/dmx/fun/reactor/ReactorResultTest.java
+++ b/reactor/src/test/java/dmx/fun/reactor/ReactorResultTest.java
@@ -1,0 +1,128 @@
+package dmx.fun.reactor;
+
+import dmx.fun.Result;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static dmx.fun.assertj.DmxFunAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReactorResultTest {
+
+    private static Mono<Result<Integer, String>> ok(int v) {
+        return Mono.just(Result.ok(v));
+    }
+
+    private static Mono<Result<Integer, String>> err(String e) {
+        return Mono.just(Result.err(e));
+    }
+
+    // ── mapOk ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void mapOk_onOk_transformsValue() {
+        StepVerifier.create(ReactorResult.mapOk(ok(2), v -> v * 10))
+            .assertNext(r -> assertThat(r).isOk().containsValue(20))
+            .verifyComplete();
+    }
+
+    @Test
+    void mapOk_onErr_passesThrough() {
+        StepVerifier.create(ReactorResult.mapOk(err("bad"), v -> v * 10))
+            .assertNext(r -> assertThat(r).isErr().containsError("bad"))
+            .verifyComplete();
+    }
+
+    // ── flatMapOk ──────────────────────────────────────────────────────────────
+
+    @Test
+    void flatMapOk_onOk_chainsNextOk() {
+        StepVerifier.create(ReactorResult.flatMapOk(ok(2), v -> Mono.just(Result.ok(v + 1))))
+            .assertNext(r -> assertThat(r).isOk().containsValue(3))
+            .verifyComplete();
+    }
+
+    @Test
+    void flatMapOk_onOk_chainsNextErr() {
+        StepVerifier.create(ReactorResult.flatMapOk(ok(2), v -> Mono.just(Result.err("downstream"))))
+            .assertNext(r -> assertThat(r).isErr().containsError("downstream"))
+            .verifyComplete();
+    }
+
+    @Test
+    void flatMapOk_onErr_passesThroughWithoutInvokingMapper() {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        StepVerifier.create(ReactorResult.flatMapOk(err("bad"), v -> {
+                invoked.set(true);
+                return Mono.just(Result.ok(v));
+            }))
+            .assertNext(r -> assertThat(r).isErr().containsError("bad"))
+            .verifyComplete();
+        org.assertj.core.api.Assertions.assertThat(invoked).isFalse();
+    }
+
+    // ── mapErr ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void mapErr_onErr_transformsError() {
+        StepVerifier.create(ReactorResult.mapErr(err("bad"), String::length))
+            .assertNext(r -> assertThat(r).isErr().containsError(3))
+            .verifyComplete();
+    }
+
+    @Test
+    void mapErr_onOk_passesThrough() {
+        StepVerifier.create(ReactorResult.mapErr(ok(7), String::length))
+            .assertNext(r -> assertThat(r).isOk().containsValue(7))
+            .verifyComplete();
+    }
+
+    // ── recover ────────────────────────────────────────────────────────────────
+
+    @Test
+    void recover_onErr_becomesOk() {
+        StepVerifier.create(ReactorResult.recover(err("bad"), e -> e.length()))
+            .assertNext(r -> assertThat(r).isOk().containsValue(3))
+            .verifyComplete();
+    }
+
+    @Test
+    void recover_onOk_unchanged() {
+        StepVerifier.create(ReactorResult.recover(ok(7), e -> -1))
+            .assertNext(r -> assertThat(r).isOk().containsValue(7))
+            .verifyComplete();
+    }
+
+    // ── composition ────────────────────────────────────────────────────────────
+
+    @Test
+    void chain_composesOnTheResultTrack() {
+        Mono<Result<Integer, String>> pipeline =
+            ReactorResult.mapErr(
+                ReactorResult.flatMapOk(
+                    ReactorResult.mapOk(ok(2), v -> v + 1),       // Ok(3)
+                    v -> Mono.just(Result.ok(v * 10))),           // Ok(30)
+                e -> "mapped:" + e);                              // no-op on Ok
+        StepVerifier.create(pipeline)
+            .assertNext(r -> assertThat(r).isOk().containsValue(30))
+            .verifyComplete();
+    }
+
+    // ── null guards ────────────────────────────────────────────────────────────
+
+    @Test
+    void mapOk_nullMono_throws() {
+        assertThatThrownBy(() -> ReactorResult.mapOk(null, v -> v))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mono");
+    }
+
+    @Test
+    void flatMapOk_nullMapper_throws() {
+        assertThatThrownBy(() -> ReactorResult.flatMapOk(ok(1), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("mapper");
+    }
+}

--- a/site/src/data/guide/reactor.mdx
+++ b/site/src/data/guide/reactor.mdx
@@ -70,6 +70,31 @@ A `Mono` that completes without a value is treated as a missing value:
 `toMonoOption` is the one conversion that does **not** absorb errors — since
 `Option` has no error channel, an error signal propagates as a Reactor error.
 
+### Composing on the `Result` track
+
+Once you have a `Mono<Result<V, E>>`, `ReactorResult` lets you keep composing
+without unwrapping at every step — `Err` is threaded through untouched:
+
+| Operator | Behavior |
+|---|---|
+| `mapOk(mono, fn)` | transform the `Ok` value |
+| `flatMapOk(mono, fn)` | chain a dependent reactive step on the `Ok` value (`fn` returns `Mono<Result<W,E>>`) |
+| `mapErr(mono, fn)` | transform the error channel |
+| `recover(mono, fn)` | turn an `Err` into an `Ok` via a fallback |
+
+```java
+Mono<Result<Receipt, ApiError>> receipt =
+    ReactorResult.flatMapOk(
+        ReactorResult.mapOk(
+            ReactorFun.toMonoResult(userClient.findById(id), ApiError::fromThrowable),
+            User::accountId),                          // Mono<Result<AccountId, ApiError>>
+        accountId -> ReactorFun.toMonoResult(          // dependent reactive step
+            billingClient.charge(accountId), ApiError::fromThrowable));
+```
+
+`flatMapOk` only invokes its mapper on the `Ok` path; a failure short-circuits the
+rest of the chain, exactly like a synchronous `Result.flatMap`.
+
 ## dmx-fun → Reactor
 
 Going the other way turns a domain outcome back into a `Mono`:
@@ -109,6 +134,37 @@ Mono<String> tenantAware = Mono.deferContextual(ctx ->
 > Reactor 3.4 or later. The `ReactorFun` conversions themselves work on any
 > supported 3.x release.
 
+## Streaming with `Flux`
+
+Where `ReactorFun` handles a single value, `ReactorFlux` handles a stream. Its
+centerpiece folds a `Flux` of outcomes into one `Mono<Result<List<…>, …>>` — the
+reactive equivalent of `Result.sequence`.
+
+| Method | Behavior |
+|---|---|
+| `sequence(flux)` | `Flux<Result<T,E>>` → `Mono<Result<List<T>,E>>`, fail-fast (first `Err` short-circuits and cancels upstream) |
+| `collectResult(flux[, errorMapper])` | `Flux<T>` → `Mono<Result<List<T>,…>>`; a source error becomes `Err` |
+| `collectValidated(flux)` | `Flux<Result<T,E>>` → `Mono<Validated<NonEmptyList<E>, List<T>>>`, accumulating **all** errors |
+| `flattenOption(flux)` | `Flux<Option<T>>` → `Flux<T>`, dropping `None` |
+| `toFlux(...)` | emit a `NonEmptyList`, `Option`, `Result`, or `Try` as a `Flux` |
+
+```java
+// Fail-fast: stop at the first failure
+Mono<Result<List<Order>, Failure>> all = ReactorFlux.sequence(orderResultsFlux);
+
+// Accumulate: report every failure at once
+Mono<Validated<NonEmptyList<Failure>, List<Order>>> validated =
+    ReactorFlux.collectValidated(orderResultsFlux);
+
+// Collect a raw stream, folding a Reactor error into the typed channel
+Mono<Result<List<Order>, Failure>> collected =
+    ReactorFlux.collectResult(orderFlux, Failure::fromThrowable);
+```
+
+`sequence` and `collectResult` treat an empty stream as `Ok([])`; only `sequence`
+short-circuits, cancelling the upstream as soon as it sees an `Err`. Backpressure
+and cancellation are preserved throughout.
+
 ## Migrating from manual conversion code
 
 Hand-rolled `Mono` → outcome conversions usually look like this — a `map`, an
@@ -132,6 +188,25 @@ Mono<Result<User, ApiError>> result = ReactorFun.toMonoResult(
     userClient.findById(id),
     ApiError::fromThrowable,
     () -> ApiError.notFound(id));
+```
+
+Streaming aggregation collapses the same way. The manual `collectList` plus
+error handling:
+
+```java
+// Before: collect, then rebuild the error case by hand
+Mono<Result<List<Order>, ApiError>> orders = orderClient.findAll(query)
+    .collectList()
+    .map(Result::<List<Order>, ApiError>ok)
+    .onErrorResume(ex -> Mono.just(Result.err(ApiError.fromThrowable(ex))));
+```
+
+becomes a single `collectResult`:
+
+```java
+// After
+Mono<Result<List<Order>, ApiError>> orders =
+    ReactorFlux.collectResult(orderClient.findAll(query), ApiError::fromThrowable);
 ```
 
 ## Blocking vs reactive


### PR DESCRIPTION
Add two facades to fun-reactor:

ReactorFlux — Flux interop:
- sequence(Flux<Result>) -> Mono<Result<List>>, fail-fast with real upstream
  cancellation on the first Err;
- collectResult(Flux) (+ typed error mapper) folding a stream into a Result;
- collectValidated accumulating every Err into a Validated<NonEmptyList<E>, List>;
- flattenOption dropping None from a Flux<Option>;
- toFlux for NonEmptyList, Option, Result (+errorMapper), and Try.

ReactorResult — railway operators over Mono<Result<V, E>>:
- mapOk / flatMapOk / mapErr / recover, threading Err through untouched so a
  reactive pipeline stays on the Result track without unwrapping per step.

Tests cover success, empty, first-error short-circuit, error accumulation,
source-error, cancellation, backpressure, and Err pass-through. The guide gains
a Flux section, a "Composing on the Result track" section, and a before/after
collectList migration. reactor-core stays compileOnly; the existing
compatibility matrix covers the new code. Verified green on Reactor 3.4.29 and
3.8.6.

Closes #473

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reactive utilities for `Mono<Result<...>>` with “result track” operators (map OK, map error, flatMap OK, recover from error).
  * Added stream helpers for `Flux` of outcome types, including sequencing/collecting, fail-fast vs error-accumulating validation, and conversions between `Flux` and common containers (`Option`, `Try`, `Result`).
* **Documentation**
  * Updated the Reactor integration guide with new composition and streaming examples, including migration guidance.
* **Tests**
  * Added tests covering success, error, empty-stream behavior, backpressure/cancellation, and null-guard checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->