### PR TITLE
feat(result): add mapCatching for throwing map functions (#476)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Result.java
+++ b/core/lib/src/main/java/dmx/fun/Result.java
@@ -281,7 +281,9 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * plain value rather than another {@code Result} — it is the convenience for
      * {@code flatMap(v -> Try.of(() -> mapper.apply(v)).toResult().mapError(exceptionToError))}.
      *
-     * <p>{@link Throwable} is caught (matching {@code Try.of}). Because
+     * <p>The mapper is a {@link CheckedFunction}, so it may declare <em>checked</em>
+     * exceptions (e.g. a parser or I/O call) and still be passed as a lambda or method
+     * reference. {@link Throwable} is caught (matching {@code Try.of}). Because
      * {@code Ok} rejects a {@code null} value, a {@code mapper} that returns {@code null}
      * surfaces as a caught {@link NullPointerException} and is mapped through
      * {@code exceptionToError} like any other failure.
@@ -289,19 +291,20 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
      * <p>Example:
      * <pre>{@code
      * Result<Config, AppError> loaded = pathResult
-     *     .mapCatching(path -> parseConfig(path),   // parseConfig may throw
+     *     .mapCatching(path -> parseConfig(path),   // parseConfig may throw IOException
      *                  AppError::fromThrowable);
      * }</pre>
      *
      * @param <NewValue>       the type of the value after applying the mapping function
-     * @param mapper           the function to apply to the success value; may throw
+     * @param mapper           the function to apply to the success value; may throw, including
+     *                         checked exceptions
      * @param exceptionToError function mapping a thrown {@link Throwable} to the error type
      * @return {@code Ok(mapper(value))} on success, {@code Err(exceptionToError(t))} if the
      * mapper throws, or the original error if this instance is an error
      * @throws NullPointerException if {@code mapper} or {@code exceptionToError} is {@code null}
      */
     default <NewValue> Result<NewValue, Error> mapCatching(
-        Function<Value, NewValue> mapper,
+        CheckedFunction<Value, NewValue> mapper,
         Function<Throwable, Error> exceptionToError
     ) {
         Objects.requireNonNull(mapper, "mapper");

--- a/core/lib/src/main/java/dmx/fun/Result.java
+++ b/core/lib/src/main/java/dmx/fun/Result.java
@@ -271,6 +271,54 @@ public sealed interface Result<Value, Error> extends Bicontainer<Value, Error> p
     }
 
     /**
+     * Maps the value of a successful {@code Result} with a function that <em>may throw</em>,
+     * folding any thrown {@link Throwable} into the error channel via {@code exceptionToError}.
+     * If the instance is an error, the error is propagated and {@code mapper} is never invoked.
+     *
+     * <p>Unlike {@link #map(Function) map}, whose mapper must not throw (an exception would
+     * escape the call), {@code mapCatching} runs the mapper inside a try/catch and converts a
+     * throw into {@code Err}. Unlike {@link #flatMap(Function) flatMap}, the mapper returns a
+     * plain value rather than another {@code Result} — it is the convenience for
+     * {@code flatMap(v -> Try.of(() -> mapper.apply(v)).toResult().mapError(exceptionToError))}.
+     *
+     * <p>{@link Throwable} is caught (matching {@code Try.of}). Because
+     * {@code Ok} rejects a {@code null} value, a {@code mapper} that returns {@code null}
+     * surfaces as a caught {@link NullPointerException} and is mapped through
+     * {@code exceptionToError} like any other failure.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Result<Config, AppError> loaded = pathResult
+     *     .mapCatching(path -> parseConfig(path),   // parseConfig may throw
+     *                  AppError::fromThrowable);
+     * }</pre>
+     *
+     * @param <NewValue>       the type of the value after applying the mapping function
+     * @param mapper           the function to apply to the success value; may throw
+     * @param exceptionToError function mapping a thrown {@link Throwable} to the error type
+     * @return {@code Ok(mapper(value))} on success, {@code Err(exceptionToError(t))} if the
+     * mapper throws, or the original error if this instance is an error
+     * @throws NullPointerException if {@code mapper} or {@code exceptionToError} is {@code null}
+     */
+    default <NewValue> Result<NewValue, Error> mapCatching(
+        Function<Value, NewValue> mapper,
+        Function<Throwable, Error> exceptionToError
+    ) {
+        Objects.requireNonNull(mapper, "mapper");
+        Objects.requireNonNull(exceptionToError, "exceptionToError");
+        return switch (this) {
+            case Ok<Value, Error> ok -> {
+                try {
+                    yield Result.ok(mapper.apply(ok.value()));
+                } catch (Throwable t) {
+                    yield Result.err(exceptionToError.apply(t));
+                }
+            }
+            case Err<Value, Error> err -> Result.err(err.error());
+        };
+    }
+
+    /**
      * Executes the given action if the current {@code Result} instance represents a successful result.
      * If the instance is of type {@code Ok}, the provided action is applied to the contained value.
      * In both cases, the original {@code Result} instance is returned unchanged.

--- a/core/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResultTest.java
@@ -201,8 +201,18 @@ class ResultTest {
     @Test
     void mapCatching_shouldThrowNPE_whenExceptionToErrorIsNull() {
         assertThatThrownBy(() -> Result.<String, String>ok("v")
-            .mapCatching(Function.identity(), null))
+            .mapCatching(s -> s, null))
             .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapCatching_shouldCatchCheckedException() {
+        var result = Result.<String, String>ok("x")
+            .mapCatching(_ -> {
+                throw new IOException("disk");
+            }, Throwable::getMessage);
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("disk");
     }
 
     // ---------- flatMap ----------

--- a/core/lib/src/test/java/dmx/fun/ResultTest.java
+++ b/core/lib/src/test/java/dmx/fun/ResultTest.java
@@ -148,6 +148,63 @@ class ResultTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    // ---------- mapCatching ----------
+
+    @Test
+    void mapCatching_shouldTransformOkValue() {
+        var result = Result.<String, String>ok("hello")
+            .mapCatching(String::length, Throwable::getMessage);
+        assertThat(result.get()).isEqualTo(5);
+    }
+
+    @Test
+    void mapCatching_shouldFoldThrownExceptionIntoErr() {
+        var result = Result.<String, String>ok("x")
+            .mapCatching(
+                _ -> { throw new IllegalStateException("boom"); },
+                Throwable::getMessage
+            );
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("boom");
+    }
+
+    @Test
+    void mapCatching_shouldPropagateErr_withoutInvokingMapper() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        var result = Result.<String, String>err("orig")
+            .mapCatching(
+                s -> {
+                    called.set(true);
+                    return s.length();
+                },
+                Throwable::getMessage
+            );
+        assertThat(result.getError()).isEqualTo("orig");
+        assertThat(called).isFalse();
+    }
+
+    @Test
+    void mapCatching_shouldFoldNullMapperReturnAsCaughtNpe() {
+        var result = Result.<String, String>ok("x")
+            .mapCatching(_ -> null, t -> t.getClass().getSimpleName());
+        assertThat(result.isError()).isTrue();
+        assertThat(result.getError()).isEqualTo("NullPointerException");
+    }
+
+    @Test
+    void mapCatching_shouldThrowNPE_whenMapperIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v")
+            .mapCatching(null, Throwable::getMessage))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void mapCatching_shouldThrowNPE_whenExceptionToErrorIsNull() {
+        assertThatThrownBy(() -> Result.<String, String>ok("v")
+            .mapCatching(Function.identity(), null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
     // ---------- flatMap ----------
 
     @Test

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -97,6 +97,19 @@ Use this to chain fallible operations without nesting.
 
 <TransformingFlatMap/>
 
+### `mapCatching(mapper, exceptionToError)`
+
+Like `map`, but the mapper **may throw** — any `Throwable` is caught and folded into
+the error channel via `exceptionToError`, so you stay in `Result<R, E>` instead of
+letting the exception escape (as plain `map` would) or hand-writing a `Try` bridge.
+An `Err` is passed through and the mapper is never invoked.
+
+```java
+Result<Config, AppError> loaded = pathResult
+    .mapCatching(path -> parseConfig(path),   // parseConfig may throw
+                 AppError::fromThrowable);
+```
+
 ### `filter(predicate, error)`
 
 Converts an `Ok` to `Err` when the predicate fails.

--- a/site/src/data/guide/result.mdx
+++ b/site/src/data/guide/result.mdx
@@ -102,11 +102,13 @@ Use this to chain fallible operations without nesting.
 Like `map`, but the mapper **may throw** — any `Throwable` is caught and folded into
 the error channel via `exceptionToError`, so you stay in `Result<R, E>` instead of
 letting the exception escape (as plain `map` would) or hand-writing a `Try` bridge.
-An `Err` is passed through and the mapper is never invoked.
+The mapper is a `CheckedFunction`, so it can declare **checked** exceptions (a parser, an
+I/O call) and still be passed as a lambda. An `Err` is passed through and the mapper is
+never invoked.
 
 ```java
 Result<Config, AppError> loaded = pathResult
-    .mapCatching(path -> parseConfig(path),   // parseConfig may throw
+    .mapCatching(path -> parseConfig(path),   // parseConfig may throw IOException
                  AppError::fromThrowable);
 ```
 


### PR DESCRIPTION
Add Result.mapCatching(mapper, exceptionToError): like map, but the mapper may
throw — any Throwable is caught and folded into the error channel, keeping the
pipeline in Result<R, E> instead of letting the exception escape (as map does) or
hand-writing a flatMap + Try bridge. Err is passed through without invoking the
mapper.

Catches Throwable (matching Try.of); a null mapper return surfaces as a caught
NullPointerException mapped through exceptionToError. Signatures stay invariant to
match map/mapError/flatMap. Covered by unit tests (success, throw->Err, Err
pass-through, null-return, null guards), Javadoc contrasting map/flatMap, and a
guide entry.

Closes #476

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safe mapping option for results that can catch exceptions and convert them into errors.
  * Preserves existing errors without running the mapper when a result is already in an error state.

* **Bug Fixes**
  * Improved handling of null values and thrown exceptions during result mapping to keep failures consistent and predictable.

* **Documentation**
  * Expanded the result handling guide with an updated explanation and example for the new safe mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->