### PR TITLE
feat(non-empty-list): add reduce and joinToString (#477)

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SequencedCollection;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -264,6 +265,83 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
             newTail.add(Objects.requireNonNull(mapper.apply(element), "mapper must not return null"));
         }
         return new NonEmptyList<>(newHead, Collections.unmodifiableList(newTail));
+    }
+
+    /**
+     * Combines all elements into a single value using {@code accumulator}, left to right,
+     * starting from the head. Because a {@code NonEmptyList} always has at least one element,
+     * this returns a {@code T} directly — there is no {@code Optional} and no emptiness check,
+     * unlike {@link Stream#reduce(java.util.function.BinaryOperator)}.
+     *
+     * <p>For a single-element list the {@code accumulator} is never invoked and the head is
+     * returned as-is.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * NonEmptyList.of(1, List.of(2, 3)).reduce(Integer::sum);      // 6
+     * errors.reduce((a, b) -> a + "; " + b);                       // joined messages
+     * }</pre>
+     *
+     * @param accumulator an associative function combining two elements; must not be {@code null}
+     * @return the combined value
+     * @throws NullPointerException if {@code accumulator} is {@code null}
+     */
+    public T reduce(BinaryOperator<T> accumulator) {
+        Objects.requireNonNull(accumulator, "accumulator must not be null");
+        T result = head;
+        for (T element : tail) {
+            result = accumulator.apply(result, element);
+        }
+        return result;
+    }
+
+    /**
+     * Joins the elements into a single {@link String}, separated by {@code ", "}.
+     *
+     * <p>Equivalent to {@code joinToString(", ")}.
+     *
+     * @return the joined string
+     */
+    public String joinToString() {
+        return joinToString(", ");
+    }
+
+    /**
+     * Joins the elements into a single {@link String}, separated by {@code delimiter}, using
+     * {@link String#valueOf(Object)} to render each element.
+     *
+     * @param delimiter the separator placed between elements; must not be {@code null}
+     * @return the joined string
+     * @throws NullPointerException if {@code delimiter} is {@code null}
+     */
+    public String joinToString(CharSequence delimiter) {
+        return joinToString(delimiter, String::valueOf);
+    }
+
+    /**
+     * Joins the elements into a single {@link String}, separated by {@code delimiter}, rendering
+     * each element with {@code transform}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * NonEmptyList.of("must not be blank", List.of("too short")).joinToString("; ");
+     * // "must not be blank; too short"
+     * users.joinToString(",", User::name);
+     * }</pre>
+     *
+     * @param delimiter the separator placed between elements; must not be {@code null}
+     * @param transform renders each element as a {@link CharSequence}; must not be {@code null}
+     * @return the joined string
+     * @throws NullPointerException if {@code delimiter} or {@code transform} is {@code null}
+     */
+    public String joinToString(CharSequence delimiter, Function<? super T, ? extends CharSequence> transform) {
+        Objects.requireNonNull(delimiter, "delimiter must not be null");
+        Objects.requireNonNull(transform, "transform must not be null");
+        StringBuilder sb = new StringBuilder().append(transform.apply(head));
+        for (T element : tail) {
+            sb.append(delimiter).append(transform.apply(element));
+        }
+        return sb.toString();
     }
 
     /**

--- a/core/lib/src/main/java/dmx/fun/NonEmptyList.java
+++ b/core/lib/src/main/java/dmx/fun/NonEmptyList.java
@@ -331,15 +331,19 @@ public final class NonEmptyList<T> implements SequencedCollection<T> {
      *
      * @param delimiter the separator placed between elements; must not be {@code null}
      * @param transform renders each element as a {@link CharSequence}; must not be {@code null}
+     *                  and must not return {@code null}
      * @return the joined string
-     * @throws NullPointerException if {@code delimiter} or {@code transform} is {@code null}
+     * @throws NullPointerException if {@code delimiter} or {@code transform} is {@code null},
+     *                              or if {@code transform} returns {@code null} for any element
      */
     public String joinToString(CharSequence delimiter, Function<? super T, ? extends CharSequence> transform) {
         Objects.requireNonNull(delimiter, "delimiter must not be null");
         Objects.requireNonNull(transform, "transform must not be null");
-        StringBuilder sb = new StringBuilder().append(transform.apply(head));
+        StringBuilder sb = new StringBuilder()
+            .append(Objects.requireNonNull(transform.apply(head), "transform must not return null"));
         for (T element : tail) {
-            sb.append(delimiter).append(transform.apply(element));
+            sb.append(delimiter)
+                .append(Objects.requireNonNull(transform.apply(element), "transform must not return null"));
         }
         return sb.toString();
     }

--- a/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -179,6 +179,72 @@ class NonEmptyListTest {
     }
 
     // -------------------------------------------------------------------------
+    // reduce()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void reduce_shouldCombineAllElements() {
+        assertThat(NonEmptyList.of(1, List.of(2, 3)).reduce(Integer::sum)).isEqualTo(6);
+    }
+
+    @Test
+    void reduce_shouldFoldLeftToRight() {
+        // ((1 - 2) - 3) == -4 proves left-to-right order
+        assertThat(NonEmptyList.of(1, List.of(2, 3)).reduce((a, b) -> a - b)).isEqualTo(-4);
+    }
+
+    @Test
+    void reduce_onSingleton_shouldReturnHead_withoutInvokingAccumulator() {
+        NonEmptyList<Integer> nel = NonEmptyList.of(5, List.of());
+        assertThat(nel.reduce((a, b) -> {
+            throw new AssertionError("accumulator must not be called for a single element");
+        })).isEqualTo(5);
+    }
+
+    @Test
+    void reduce_shouldThrowNPE_whenAccumulatorIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of(1, List.of(2)).reduce(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // joinToString()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void joinToString_noArg_shouldUseCommaSpace() {
+        assertThat(NonEmptyList.of("a", List.of("b", "c")).joinToString()).isEqualTo("a, b, c");
+    }
+
+    @Test
+    void joinToString_withDelimiter_shouldRenderWithValueOf() {
+        assertThat(NonEmptyList.of(1, List.of(2, 3)).joinToString("-")).isEqualTo("1-2-3");
+    }
+
+    @Test
+    void joinToString_singleton_shouldReturnHeadWithoutDelimiter() {
+        assertThat(NonEmptyList.of("only", List.of()).joinToString("; ")).isEqualTo("only");
+    }
+
+    @Test
+    void joinToString_withTransform_shouldRenderEachElement() {
+        assertThat(NonEmptyList.of("ab", List.of("cde")).joinToString(",", s -> String.valueOf(s.length())))
+            .isEqualTo("2,3");
+    }
+
+    @Test
+    void joinToString_shouldThrowNPE_whenDelimiterIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of("a", List.of("b")).joinToString(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void joinToString_shouldThrowNPE_whenTransformIsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of("a", List.of("b")).joinToString(",", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
     // append()
     // -------------------------------------------------------------------------
 

--- a/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonEmptyListTest.java
@@ -244,6 +244,13 @@ class NonEmptyListTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    void joinToString_shouldThrowNPE_whenTransformReturnsNull() {
+        assertThatThrownBy(() -> NonEmptyList.of("a", List.of("b")).joinToString(",", s -> null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("transform must not return null");
+    }
+
     // -------------------------------------------------------------------------
     // append()
     // -------------------------------------------------------------------------

--- a/site/src/data/guide/non-empty-list.mdx
+++ b/site/src/data/guide/non-empty-list.mdx
@@ -85,6 +85,26 @@ that may be empty (for singletons).
 All transformation methods (`map`, `append`, `prepend`, `concat`) return a **new
 `NonEmptyList`** — the original is unchanged.
 
+### Folding — `reduce` and `joinToString`
+
+Because a `NonEmptyList` always has at least one element, `reduce` combines them into a
+single `T` and returns it **directly** — no `Optional`, no emptiness check, unlike
+`Stream.reduce(BinaryOperator)`. For a single-element list the accumulator is never called.
+
+```java
+NonEmptyList.of(1, List.of(2, 3)).reduce(Integer::sum);   // 6
+```
+
+`joinToString` renders the elements into one `String` — handy for accumulated error
+messages. The no-arg overload defaults the delimiter to `", "`; overloads take a custom
+delimiter and an optional per-element transform:
+
+```java
+errors.joinToString();                 // "must not be blank, too short"
+errors.joinToString("; ");             // "must not be blank; too short"
+users.joinToString(", ", User::name);  // "alice, bob"
+```
+
 ## SequencedCollection integration (Java 21)
 
 `NonEmptyList<T>` implements `java.util.SequencedCollection<T>`, the Java 21


### PR DESCRIPTION
Add NonEmptyList.reduce(BinaryOperator) returning T directly (no Optional, no
emptiness check, unlike Stream.reduce) and three joinToString overloads: no-arg
(", " default), custom delimiter, and delimiter + per-element transform. Both
leverage the non-empty guarantee. Covered by unit tests (left-to-right fold,
single-element shortcut, transform rendering, null guards), Javadoc with
examples, and a guide entry.

Closes #477

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added list reduction and string-joining capabilities for non-empty lists, including customizable separators and per-item formatting.
  * These helpers make it easier to combine values into a single result or readable text.

* **Documentation**
  * Expanded the guide with examples and usage notes for the new folding and joining options.

* **Bug Fixes**
  * Improved validation so invalid inputs are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->