### PR TITLE
feat(spring-webflux): add accumulating and streaming Flux responses (#482)

### DIFF
--- a/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
+++ b/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
@@ -114,11 +114,7 @@ public final class WebfluxFun {
         Mono<Validated<NonEmptyList<E>, V>> source
     ) {
         Objects.requireNonNull(source, "source");
-        return source.<ServerResponse>flatMap(validated -> switch (validated) {
-            case Validated.Valid<NonEmptyList<E>, V> valid -> okBody(valid.value());
-            case Validated.Invalid<NonEmptyList<E>, V> invalid ->
-                ServerResponse.badRequest().bodyValue(invalid.error().toList());
-        }).switchIfEmpty(notFound());
+        return source.flatMap(WebfluxFun::validatedToResponse).switchIfEmpty(notFound());
     }
 
     /**
@@ -158,11 +154,7 @@ public final class WebfluxFun {
      */
     public static <V, E> Mono<ServerResponse> fromResultStreamAccumulating(Flux<Result<V, E>> source) {
         Objects.requireNonNull(source, "source");
-        return ReactorFlux.collectValidated(source).flatMap(validated -> switch (validated) {
-            case Validated.Valid<NonEmptyList<E>, List<V>> valid -> okBody(valid.value());
-            case Validated.Invalid<NonEmptyList<E>, List<V>> invalid ->
-                ServerResponse.badRequest().bodyValue(invalid.error().toList());
-        });
+        return ReactorFlux.collectValidated(source).flatMap(WebfluxFun::validatedToResponse);
     }
 
     /**
@@ -213,6 +205,15 @@ public final class WebfluxFun {
         Objects.requireNonNull(onError, "onError");
         Flux<V> withFallback = source.onErrorResume(throwable -> Mono.just(onError.apply(throwable)));
         return ServerResponse.ok().contentType(mediaType).body(withFallback, elementType);
+    }
+
+    /** Maps a {@code Validated} to {@code 200} with the valid value, or {@code 400} with the accumulated errors. */
+    private static <E, A> Mono<ServerResponse> validatedToResponse(Validated<NonEmptyList<E>, A> validated) {
+        return switch (validated) {
+            case Validated.Valid<NonEmptyList<E>, A> valid -> okBody(valid.value());
+            case Validated.Invalid<NonEmptyList<E>, A> invalid ->
+                ServerResponse.badRequest().bodyValue(invalid.error().toList());
+        };
     }
 
     private static Mono<ServerResponse> okBody(Object value) {

--- a/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
+++ b/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
@@ -8,7 +8,9 @@ import dmx.fun.Validated;
 import dmx.fun.reactor.ReactorFlux;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -140,6 +142,77 @@ public final class WebfluxFun {
             case Result.Ok<List<V>, E> ok -> okBody(ok.value());
             case Result.Err<List<V>, E> err -> errorMapper.apply(err.error());
         });
+    }
+
+    /**
+     * Aggregates a {@code Flux<Result<V, E>>} into a single response by accumulating it (via
+     * {@code fun-reactor}'s {@code ReactorFlux.collectValidated}): all {@code Ok} → {@code 200}
+     * with the list of values, any {@code Err} → {@code 400} with <em>every</em> accumulated
+     * error as the body. Unlike {@link #fromResultStream}, this does not short-circuit on the
+     * first failure — it reports them all.
+     *
+     * @param source the stream of outcomes
+     * @param <V>    the success value type
+     * @param <E>    the error type
+     * @return the HTTP response
+     */
+    public static <V, E> Mono<ServerResponse> fromResultStreamAccumulating(Flux<Result<V, E>> source) {
+        Objects.requireNonNull(source, "source");
+        return ReactorFlux.collectValidated(source).flatMap(validated -> switch (validated) {
+            case Validated.Valid<NonEmptyList<E>, List<V>> valid -> okBody(valid.value());
+            case Validated.Invalid<NonEmptyList<E>, List<V>> invalid ->
+                ServerResponse.badRequest().bodyValue(invalid.error().toList());
+        });
+    }
+
+    /**
+     * Streams a {@code Flux<V>} as the response body with the given {@code mediaType} (for
+     * example {@link MediaType#APPLICATION_NDJSON} or {@link MediaType#TEXT_EVENT_STREAM}),
+     * encoding each element as it arrives instead of collecting first.
+     *
+     * <p><strong>HTTP note:</strong> the {@code 200} status and headers are sent before the body
+     * streams, so a terminal error cannot change the status. Use {@link #stream(Flux, MediaType,
+     * Class, java.util.function.Function)} to append a typed fallback element on error, or collect
+     * first with {@link #fromResultStream} / {@link #fromResultStreamAccumulating} when the
+     * outcome must drive the status code.
+     *
+     * @param source      the stream of elements
+     * @param mediaType   the response content type (e.g. NDJSON or SSE)
+     * @param elementType the element class, required by the WebFlux encoder
+     * @param <V>         the element type
+     * @return the streaming HTTP response
+     */
+    public static <V> Mono<ServerResponse> stream(Flux<V> source, MediaType mediaType, Class<V> elementType) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(mediaType, "mediaType");
+        Objects.requireNonNull(elementType, "elementType");
+        return ServerResponse.ok().contentType(mediaType).body(source, elementType);
+    }
+
+    /**
+     * Streams a {@code Flux<V>} as the response body, appending a typed fallback element produced
+     * by {@code onError} if the stream terminates with an error — a graceful degradation that
+     * keeps the (already-sent) {@code 200} status instead of abruptly closing the connection.
+     *
+     * @param source      the stream of elements
+     * @param mediaType   the response content type (e.g. NDJSON or SSE)
+     * @param elementType the element class, required by the WebFlux encoder
+     * @param onError     maps a terminal error to a final fallback element
+     * @param <V>         the element type
+     * @return the streaming HTTP response
+     */
+    public static <V> Mono<ServerResponse> stream(
+        Flux<V> source,
+        MediaType mediaType,
+        Class<V> elementType,
+        Function<? super Throwable, V> onError
+    ) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(mediaType, "mediaType");
+        Objects.requireNonNull(elementType, "elementType");
+        Objects.requireNonNull(onError, "onError");
+        Flux<V> withFallback = source.onErrorResume(throwable -> Mono.just(onError.apply(throwable)));
+        return ServerResponse.ok().contentType(mediaType).body(withFallback, elementType);
     }
 
     private static Mono<ServerResponse> okBody(Object value) {

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
@@ -6,10 +6,12 @@ import dmx.fun.Result;
 import dmx.fun.Validated;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +29,13 @@ class WebfluxFunRouteTest {
             .GET("/missing", request -> WebfluxFun.fromOption(Mono.just(Option.<String>none())))
             .GET("/invalid", request -> WebfluxFun.fromValidated(
                 Mono.just(Validated.invalid(NonEmptyList.of("must not be blank", List.of("too short"))))))
+            .GET("/accumulate", request -> WebfluxFun.fromResultStreamAccumulating(
+                Flux.just(Result.<Integer, String>ok(1), Result.err("e1"), Result.err("e2"))))
+            .GET("/stream", request -> WebfluxFun.stream(
+                Flux.just("a", "b", "c"), MediaType.APPLICATION_NDJSON, String.class))
+            .GET("/stream-error", request -> WebfluxFun.stream(
+                Flux.just("a").concatWith(Flux.error(new IllegalStateException("boom"))),
+                MediaType.APPLICATION_NDJSON, String.class, throwable -> "FALLBACK"))
             .build();
     }
 
@@ -49,5 +58,30 @@ class WebfluxFunRouteTest {
             .expectStatus().isBadRequest()
             .expectBody(String.class).returnResult().getResponseBody();
         assertThat(body).contains("must not be blank", "too short");
+    }
+
+    @Test
+    void accumulate_returns400WithEveryError() {
+        String body = client.get().uri("/accumulate").exchange()
+            .expectStatus().isBadRequest()
+            .expectBody(String.class).returnResult().getResponseBody();
+        assertThat(body).contains("e1", "e2");
+    }
+
+    @Test
+    void stream_returns200WithNdjsonBody() {
+        String body = client.get().uri("/stream").exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_NDJSON)
+            .expectBody(String.class).returnResult().getResponseBody();
+        assertThat(body).contains("a", "b", "c");
+    }
+
+    @Test
+    void stream_onError_appendsFallbackElement() {
+        String body = client.get().uri("/stream-error").exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).returnResult().getResponseBody();
+        assertThat(body).contains("a", "FALLBACK");
     }
 }

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
@@ -31,6 +31,8 @@ class WebfluxFunRouteTest {
                 Mono.just(Validated.invalid(NonEmptyList.of("must not be blank", List.of("too short"))))))
             .GET("/accumulate", request -> WebfluxFun.fromResultStreamAccumulating(
                 Flux.just(Result.<Integer, String>ok(1), Result.err("e1"), Result.err("e2"))))
+            .GET("/accumulate-ok", request -> WebfluxFun.fromResultStreamAccumulating(
+                Flux.just(Result.<Integer, String>ok(1), Result.ok(2))))
             .GET("/stream", request -> WebfluxFun.stream(
                 Flux.just("a", "b", "c"), MediaType.APPLICATION_NDJSON, String.class))
             .GET("/stream-error", request -> WebfluxFun.stream(
@@ -66,6 +68,14 @@ class WebfluxFunRouteTest {
             .expectStatus().isBadRequest()
             .expectBody(String.class).returnResult().getResponseBody();
         assertThat(body).contains("e1", "e2");
+    }
+
+    @Test
+    void accumulate_allOk_returns200WithList() {
+        String body = client.get().uri("/accumulate-ok").exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).returnResult().getResponseBody();
+        assertThat(body).contains("1", "2");
     }
 
     @Test

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -109,6 +110,30 @@ class WebfluxFunTest {
     void fromResultStream_firstErr_usesErrorMapper() {
         Flux<Result<Integer, String>> stream = Flux.just(Result.ok(1), Result.err("bad"));
         assertThat(status(WebfluxFun.fromResultStream(stream, ERROR_400))).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    // ── fromResultStreamAccumulating ───────────────────────────────────────────
+
+    @Test
+    void fromResultStreamAccumulating_allOk_is200() {
+        Flux<Result<Integer, String>> stream = Flux.just(Result.ok(1), Result.ok(2));
+        assertThat(status(WebfluxFun.fromResultStreamAccumulating(stream))).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void fromResultStreamAccumulating_withErrors_is400() {
+        Flux<Result<Integer, String>> stream = Flux.just(Result.ok(1), Result.err("e1"), Result.err("e2"));
+        assertThat(status(WebfluxFun.fromResultStreamAccumulating(stream))).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    // ── stream ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void stream_setsOkStatusAndContentType() {
+        ServerResponse response =
+            WebfluxFun.stream(Flux.just("a", "b"), MediaType.APPLICATION_NDJSON, String.class).block();
+        assertThat(HttpStatus.valueOf(response.statusCode().value())).isEqualTo(HttpStatus.OK);
+        assertThat(response.headers().getContentType()).isEqualTo(MediaType.APPLICATION_NDJSON);
     }
 
     // ── null guards ────────────────────────────────────────────────────────────

--- a/site/src/data/guide/spring-webflux.mdx
+++ b/site/src/data/guide/spring-webflux.mdx
@@ -30,6 +30,8 @@ Each adapter takes the upstream reactive outcome and returns a `Mono<ServerRespo
 | `fromTry(mono, failureMapper)` | `Success` → `200` + body; `Failure` → `failureMapper`; empty → `404` |
 | `fromValidated(mono)` | `Valid` → `200` + body; `Invalid` → `400` with all errors; empty → `404` |
 | `fromResultStream(flux, errorMapper)` | aggregate a `Flux<Result>` (fail-fast); all `Ok` → `200` + list; first `Err` → `errorMapper` |
+| `fromResultStreamAccumulating(flux)` | aggregate a `Flux<Result>` accumulating; all `Ok` → `200` + list; any `Err` → `400` with **every** error |
+| `stream(flux, mediaType, type)` | stream a `Flux<V>` as the body (NDJSON / SSE); `200`, each element encoded as it arrives |
 
 ```java
 RouterFunction<ServerResponse> routes() {
@@ -78,6 +80,34 @@ first `Err` is rendered by your `errorMapper`.
 .GET("/orders", request ->
     WebfluxFun.fromResultStream(orderService.findAll(query),   // Flux<Result<Order, ApiError>>
         error -> ServerResponse.status(error.status()).bodyValue(error.detail())))
+```
+
+To report **every** failure instead of stopping at the first, use the accumulating
+variant — all `Ok` become a `200` with the list, any `Err` makes a `400` carrying all the
+accumulated errors (backed by `fun-reactor`'s `ReactorFlux.collectValidated`):
+
+```java
+.GET("/orders", request ->
+    WebfluxFun.fromResultStreamAccumulating(orderService.findAll(query)))  // Flux<Result<Order, ApiError>>
+```
+
+## Streaming a response body
+
+When the response should stream element-by-element rather than collect first, `stream`
+renders a `Flux<V>` as the body with a chosen content type (NDJSON or SSE):
+
+```java
+.GET("/orders/stream", request ->
+    WebfluxFun.stream(orderService.findAll(), MediaType.APPLICATION_NDJSON, Order.class))
+```
+
+Because the `200` status and headers are sent before the body streams, a terminal error
+cannot change the status. The four-argument overload appends a typed fallback element on
+error instead of abruptly closing the connection:
+
+```java
+WebfluxFun.stream(orders, MediaType.APPLICATION_NDJSON, Order.class,
+    throwable -> Order.unavailable());   // graceful last element on failure
 ```
 
 ## Composing before responding


### PR DESCRIPTION
Add two Flux response shapes to WebfluxFun:
- fromResultStreamAccumulating(Flux<Result>): aggregate via ReactorFlux.
  collectValidated — all Ok -> 200 with the list, any Err -> 400 with every
  accumulated error (complements the fail-fast fromResultStream);
- stream(Flux<V>, MediaType, Class) and a 4-arg overload: stream a Flux as the
  response body (NDJSON/SSE), encoding each element as it arrives, with an
  optional typed fallback element appended on a terminal error.

The issue's onError ServerResponse mapper is replaced by a fallback-element
function: a streaming body's 200 status is sent before the body, so a terminal
error cannot change the status — appending a sentinel element is the HTTP-correct
graceful degradation. Tested with WebTestClient (accumulated 400 body, NDJSON
stream body, fallback element), verified on Spring 6.0.23 and 7.0.8.

Closes #482

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming responses as NDJSON.
  * Added a stream option that can append a fallback value if streaming ends with an error.
  * Added a new way to collect result streams and return either all successful values or all errors in one response.

* **Bug Fixes**
  * Improved error handling for streamed responses so failures can be reported without losing already-sent data.

* **Documentation**
  * Updated the WebFlux guide with examples for result aggregation and streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->