### PR TITLE
feat(spring-webflux): customizable success responses via SuccessHttpMapper (#483)

### DIFF
--- a/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/SuccessHttpMapper.java
+++ b/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/SuccessHttpMapper.java
@@ -1,0 +1,29 @@
+package dmx.fun.spring.webflux;
+
+import org.jspecify.annotations.NullMarked;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Maps a success value of type {@code V} to an HTTP {@link ServerResponse}.
+ *
+ * <p>Supplied to the success-customizing overloads of {@link WebfluxFun} so the
+ * {@code Ok} / {@code Some} / {@code Success} / {@code Valid} branch can control the
+ * status, headers, and body — for example {@code 201 Created} with a {@code Location}
+ * header on a {@code POST} — instead of the default {@code 200 OK} with the value as
+ * the body.
+ *
+ * @param <V> the success value type
+ */
+@NullMarked
+@FunctionalInterface
+public interface SuccessHttpMapper<V> {
+
+    /**
+     * Renders the given success value as an HTTP response.
+     *
+     * @param value the success value
+     * @return the response to send for this value
+     */
+    Mono<ServerResponse> apply(V value);
+}

--- a/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
+++ b/frameworks/spring-webflux/src/main/java/dmx/fun/spring/webflux/WebfluxFun.java
@@ -68,6 +68,32 @@ public final class WebfluxFun {
     }
 
     /**
+     * Maps a {@code Mono<Result<V, E>>} to a response with full control over the success
+     * branch: {@code Ok} → {@code successMapper} (e.g. {@code 201 Created} with a
+     * {@code Location} header), {@code Err} → {@code errorMapper}, empty → {@code 404}.
+     *
+     * @param source        the upstream outcome
+     * @param successMapper renders a {@code Result.Ok} value as a response
+     * @param errorMapper   renders a {@code Result.Err} value as a response
+     * @param <V>           the success value type
+     * @param <E>           the error type
+     * @return the HTTP response
+     */
+    public static <V, E> Mono<ServerResponse> fromResult(
+        Mono<Result<V, E>> source,
+        SuccessHttpMapper<V> successMapper,
+        ErrorHttpMapper<E> errorMapper
+    ) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(successMapper, "successMapper");
+        Objects.requireNonNull(errorMapper, "errorMapper");
+        return source.flatMap(result -> switch (result) {
+            case Result.Ok<V, E> ok -> successMapper.apply(ok.value());
+            case Result.Err<V, E> err -> errorMapper.apply(err.error());
+        }).switchIfEmpty(notFound());
+    }
+
+    /**
      * Maps a {@code Mono<Option<V>>} to a response: {@code Some} → {@code 200} with the
      * value, {@code None} (or empty) → {@code 404}.
      *
@@ -78,6 +104,22 @@ public final class WebfluxFun {
     public static <V> Mono<ServerResponse> fromOption(Mono<Option<V>> source) {
         Objects.requireNonNull(source, "source");
         return source.<ServerResponse>flatMap(option -> option.fold(WebfluxFun::notFound, WebfluxFun::okBody))
+            .switchIfEmpty(notFound());
+    }
+
+    /**
+     * Maps a {@code Mono<Option<V>>} to a response with full control over the present branch:
+     * {@code Some} → {@code successMapper}, {@code None} (or empty) → {@code 404}.
+     *
+     * @param source        the upstream option
+     * @param successMapper renders the present value as a response
+     * @param <V>           the value type
+     * @return the HTTP response
+     */
+    public static <V> Mono<ServerResponse> fromOption(Mono<Option<V>> source, SuccessHttpMapper<V> successMapper) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(successMapper, "successMapper");
+        return source.<ServerResponse>flatMap(option -> option.fold(WebfluxFun::notFound, successMapper::apply))
             .switchIfEmpty(notFound());
     }
 
@@ -101,6 +143,29 @@ public final class WebfluxFun {
     }
 
     /**
+     * Maps a {@code Mono<Try<V>>} to a response with full control over the success branch:
+     * {@code Success} → {@code successMapper}, {@code Failure} → {@code failureMapper},
+     * empty → {@code 404}.
+     *
+     * @param source        the upstream try
+     * @param successMapper renders a {@code Try.Success} value as a response
+     * @param failureMapper renders a {@code Try.Failure} cause as a response
+     * @param <V>           the value type
+     * @return the HTTP response
+     */
+    public static <V> Mono<ServerResponse> fromTry(
+        Mono<Try<V>> source,
+        SuccessHttpMapper<V> successMapper,
+        ThrowableHttpMapper failureMapper
+    ) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(successMapper, "successMapper");
+        Objects.requireNonNull(failureMapper, "failureMapper");
+        return source.<ServerResponse>flatMap(aTry -> aTry.fold(successMapper::apply, failureMapper::apply))
+            .switchIfEmpty(notFound());
+    }
+
+    /**
      * Maps a {@code Mono<Validated<NonEmptyList<E>, V>>} to a response: {@code Valid} →
      * {@code 200} with the value, {@code Invalid} → {@code 400} with the accumulated errors
      * as the body, empty → {@code 404}.
@@ -115,6 +180,27 @@ public final class WebfluxFun {
     ) {
         Objects.requireNonNull(source, "source");
         return source.flatMap(WebfluxFun::validatedToResponse).switchIfEmpty(notFound());
+    }
+
+    /**
+     * Maps a {@code Mono<Validated<NonEmptyList<E>, V>>} to a response with full control over the
+     * valid branch: {@code Valid} → {@code successMapper}, {@code Invalid} → {@code 400} with the
+     * accumulated errors as the body, empty → {@code 404}.
+     *
+     * @param source        the upstream validated value
+     * @param successMapper renders a {@code Valid} value as a response
+     * @param <V>           the value type
+     * @param <E>           the element type of the accumulated errors
+     * @return the HTTP response
+     */
+    public static <V, E> Mono<ServerResponse> fromValidated(
+        Mono<Validated<NonEmptyList<E>, V>> source,
+        SuccessHttpMapper<V> successMapper
+    ) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(successMapper, "successMapper");
+        return source.flatMap(validated -> validatedToResponse(validated, successMapper))
+            .switchIfEmpty(notFound());
     }
 
     /**
@@ -209,8 +295,16 @@ public final class WebfluxFun {
 
     /** Maps a {@code Validated} to {@code 200} with the valid value, or {@code 400} with the accumulated errors. */
     private static <E, A> Mono<ServerResponse> validatedToResponse(Validated<NonEmptyList<E>, A> validated) {
+        return validatedToResponse(validated, WebfluxFun::okBody);
+    }
+
+    /** Maps a {@code Validated} to {@code successMapper} on valid, or {@code 400} with the accumulated errors. */
+    private static <E, A> Mono<ServerResponse> validatedToResponse(
+        Validated<NonEmptyList<E>, A> validated,
+        SuccessHttpMapper<A> successMapper
+    ) {
         return switch (validated) {
-            case Validated.Valid<NonEmptyList<E>, A> valid -> okBody(valid.value());
+            case Validated.Valid<NonEmptyList<E>, A> valid -> successMapper.apply(valid.value());
             case Validated.Invalid<NonEmptyList<E>, A> invalid ->
                 ServerResponse.badRequest().bodyValue(invalid.error().toList());
         };

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunRouteTest.java
@@ -4,6 +4,7 @@ import dmx.fun.NonEmptyList;
 import dmx.fun.Option;
 import dmx.fun.Result;
 import dmx.fun.Validated;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -38,6 +39,10 @@ class WebfluxFunRouteTest {
             .GET("/stream-error", request -> WebfluxFun.stream(
                 Flux.just("a").concatWith(Flux.error(new IllegalStateException("boom"))),
                 MediaType.APPLICATION_NDJSON, String.class, throwable -> "FALLBACK"))
+            .POST("/things", request -> WebfluxFun.fromResult(
+                Mono.just(Result.<String, String>ok("42")),
+                id -> ServerResponse.created(URI.create("/things/" + id)).build(),
+                error -> ServerResponse.badRequest().bodyValue(error)))
             .build();
     }
 
@@ -93,5 +98,12 @@ class WebfluxFunRouteTest {
             .expectStatus().isOk()
             .expectBody(String.class).returnResult().getResponseBody();
         assertThat(body).contains("a", "FALLBACK");
+    }
+
+    @Test
+    void successMapper_returns201WithLocationHeader() {
+        client.post().uri("/things").exchange()
+            .expectStatus().isCreated()
+            .expectHeader().valueEquals("Location", "/things/42");
     }
 }

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
@@ -6,6 +6,7 @@ import dmx.fun.Result;
 import dmx.fun.Try;
 import dmx.fun.Validated;
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,8 @@ class WebfluxFunTest {
         e -> ServerResponse.badRequest().bodyValue(e);
     private static final ThrowableHttpMapper FAILURE_500 =
         t -> ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).bodyValue(String.valueOf(t.getMessage()));
+    private static final SuccessHttpMapper<String> CREATED =
+        v -> ServerResponse.created(URI.create("/things/" + v)).build();
 
     private static HttpStatus status(Mono<ServerResponse> response) {
         return HttpStatus.valueOf(response.block().statusCode().value());
@@ -134,6 +137,48 @@ class WebfluxFunTest {
             WebfluxFun.stream(Flux.just("a", "b"), MediaType.APPLICATION_NDJSON, String.class).block();
         assertThat(HttpStatus.valueOf(response.statusCode().value())).isEqualTo(HttpStatus.OK);
         assertThat(response.headers().getContentType()).isEqualTo(MediaType.APPLICATION_NDJSON);
+    }
+
+    // ── success mappers (custom status/headers) ────────────────────────────────
+
+    @Test
+    void fromResult_ok_usesSuccessMapper() {
+        Mono<Result<String, String>> source = Mono.just(Result.ok("x"));
+        assertThat(status(WebfluxFun.fromResult(source, CREATED, ERROR_400))).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void fromResult_err_stillUsesErrorMapper_withSuccessMapper() {
+        Mono<Result<String, String>> source = Mono.just(Result.err("bad"));
+        assertThat(status(WebfluxFun.fromResult(source, CREATED, ERROR_400))).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void fromOption_some_usesSuccessMapper() {
+        assertThat(status(WebfluxFun.fromOption(Mono.just(Option.some("x")), CREATED))).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void fromOption_none_withSuccessMapper_is404() {
+        assertThat(status(WebfluxFun.fromOption(Mono.just(Option.<String>none()), CREATED))).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void fromTry_success_usesSuccessMapper() {
+        assertThat(status(WebfluxFun.fromTry(Mono.just(Try.success("x")), CREATED, FAILURE_500))).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void fromValidated_valid_usesSuccessMapper() {
+        Mono<Validated<NonEmptyList<String>, String>> valid = Mono.just(Validated.valid("x"));
+        assertThat(status(WebfluxFun.fromValidated(valid, CREATED))).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void fromValidated_invalid_withSuccessMapper_is400() {
+        Mono<Validated<NonEmptyList<String>, String>> invalid =
+            Mono.just(Validated.invalid(NonEmptyList.of("bad", List.of())));
+        assertThat(status(WebfluxFun.fromValidated(invalid, CREATED))).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     // ── null guards ────────────────────────────────────────────────────────────

--- a/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
+++ b/frameworks/spring-webflux/src/test/java/dmx/fun/spring/webflux/WebfluxFunTest.java
@@ -196,4 +196,33 @@ class WebfluxFunTest {
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("errorMapper");
     }
+
+    @Test
+    void fromResult_nullSuccessMapper_throws() {
+        assertThatThrownBy(() -> WebfluxFun.fromResult(Mono.just(Result.<String, String>ok("x")), null, ERROR_400))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("successMapper");
+    }
+
+    @Test
+    void fromOption_nullSuccessMapper_throws() {
+        assertThatThrownBy(() -> WebfluxFun.fromOption(Mono.just(Option.some("x")), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("successMapper");
+    }
+
+    @Test
+    void fromTry_nullSuccessMapper_throws() {
+        assertThatThrownBy(() -> WebfluxFun.fromTry(Mono.just(Try.success("x")), null, FAILURE_500))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("successMapper");
+    }
+
+    @Test
+    void fromValidated_nullSuccessMapper_throws() {
+        Mono<Validated<NonEmptyList<String>, String>> valid = Mono.just(Validated.valid("x"));
+        assertThatThrownBy(() -> WebfluxFun.fromValidated(valid, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("successMapper");
+    }
 }

--- a/site/src/data/guide/spring-webflux.mdx
+++ b/site/src/data/guide/spring-webflux.mdx
@@ -33,6 +33,11 @@ Each adapter takes the upstream reactive outcome and returns a `Mono<ServerRespo
 | `fromResultStreamAccumulating(flux)` | aggregate a `Flux<Result>` accumulating; all `Ok` → `200` + list; any `Err` → `400` with **every** error |
 | `stream(flux, mediaType, type)` | stream a `Flux<V>` as the body (NDJSON / SSE); `200`, each element encoded as it arrives |
 
+The success branch defaults to `200 OK`. To return a different status or headers (e.g.
+`201 Created` + `Location`), `fromResult`, `fromOption`, `fromTry`, and `fromValidated` each
+have an overload taking a `SuccessHttpMapper<V>` — see
+[Customizing the success response](#customizing-the-success-response-201-created-headers).
+
 ```java
 RouterFunction<ServerResponse> routes() {
     return RouterFunctions.route()

--- a/site/src/data/guide/spring-webflux.mdx
+++ b/site/src/data/guide/spring-webflux.mdx
@@ -58,6 +58,26 @@ RouterFunction<ServerResponse> routes() {
 The success body is written with `ServerResponse.ok().bodyValue(v)`, so the value must be
 encodable by your WebFlux codecs.
 
+## Customizing the success response (`201 Created`, headers)
+
+The default success branch is `200 OK` with the value as the body. When you need a
+different status or headers — `201 Created` with a `Location` on a `POST`, `202 Accepted`,
+caching headers — pass a `SuccessHttpMapper<V>` to the overload of `fromResult`,
+`fromOption`, `fromTry`, or `fromValidated`. It controls the `Ok`/`Some`/`Success`/`Valid`
+branch; the failure branches are unchanged.
+
+```java
+.POST("/orders", request ->
+    WebfluxFun.fromResult(
+        orderService.place(request),                    // Mono<Result<Order, ApiError>>
+        order -> ServerResponse.created(location(order))    // Ok -> 201 Created + Location
+                     .bodyValue(order),
+        error -> ServerResponse.status(error.status()).bodyValue(error.detail())))
+```
+
+`SuccessHttpMapper<V>` mirrors `ErrorHttpMapper<E>` and `ThrowableHttpMapper` — it maps a
+success value to any `Mono<ServerResponse>` you build.
+
 ## Validating a request body → `400` with every error
 
 `Validated` accumulates errors, and `fromValidated` turns an `Invalid` into a single


### PR DESCRIPTION
Add SuccessHttpMapper<V> and success-mapper overloads of fromResult, fromOption,
fromTry, and fromValidated so the Ok/Some/Success/Valid branch can set a custom
status and headers — e.g. 201 Created with a Location header on a POST — while the
failure branches are unchanged. The default 200 overloads stay. Generalize the
private validatedToResponse helper to take the success mapper (no-arg delegates to
okBody). Covered by status unit tests and an end-to-end WebTestClient test
asserting 201 + Location; verified on Spring 6.0.23 and 7.0.8.

Closes #483

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing successful HTTP responses, including status codes and headers, across several response-mapping helpers.
  * Enabled responses like `201 Created` with a `Location` header for successful values.
* **Documentation**
  * Added guidance and an example for customizing success responses in the Spring WebFlux integration.
* **Tests**
  * Expanded coverage for custom success responses and added a route test for creating resources with the expected `Location` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->