### PR TITLE
feat(spring-boot): auto-configure a default WebFlux ProblemDetail mapper (#485)

### DIFF
--- a/frameworks/spring-boot/build.gradle
+++ b/frameworks/spring-boot/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     compileOnly "io.micrometer:micrometer-tracing:${micrometerTracingVersion}" // Tracer (for @ConditionalOnClass guard)
     compileOnly project(':observability:observation')                                        // DmxObservation (for @ConditionalOnClass guard)
     compileOnly "io.micrometer:micrometer-core:${micrometerVersion}"           // ObservationRegistry (for @ConditionalOnClass guard)
+    compileOnly project(':frameworks:spring-webflux')  // WebfluxProblem, ThrowableHttpMapper (for the WebFlux auto-config)
+    compileOnly libs.spring.webflux                    // ServerResponse (for @ConditionalOnClass guard)
+    compileOnly libs.reactor.core                      // Mono (referenced by ThrowableHttpMapper)
 
     // Tests run against the version passed via -PspringBootVersion=X.Y.Z,
     // falling back to the catalog version locally.
@@ -46,6 +49,9 @@ dependencies {
     testImplementation project(':observability:observation')
     testImplementation "io.micrometer:micrometer-core:${micrometerVersion}"
     testImplementation "io.micrometer:micrometer-observation-test:${micrometerVersion}"
+    testImplementation project(':frameworks:spring-webflux')
+    testImplementation libs.spring.webflux
+    testImplementation libs.reactor.core
 
     // Integration tests — real transaction commit/rollback against H2 embedded database.
     testImplementation libs.h2
@@ -56,8 +62,8 @@ dependencies {
 // explicitly so the JVM resolves it into the module graph during tests.
 jpmsTest {
     moduleName   = 'dmx.fun.spring.boot'
-    extraModules = ['spring.boot.autoconfigure', 'org.aspectj.weaver', 'java.sql', 'spring.webmvc', 'spring.web', 'jakarta.servlet', 'dmx.fun.jackson', 'com.fasterxml.jackson.databind', 'micrometer.tracing', 'dmx.fun.tracing', 'micrometer.core', 'dmx.fun.observation']
-    extraOpens   = ['ALL-UNNAMED', 'spring.core', 'spring.beans', 'spring.context', 'spring.aop', 'spring.boot.autoconfigure', 'spring.webmvc', 'spring.web', 'com.fasterxml.jackson.databind']
+    extraModules = ['spring.boot.autoconfigure', 'org.aspectj.weaver', 'java.sql', 'spring.webmvc', 'spring.web', 'jakarta.servlet', 'dmx.fun.jackson', 'com.fasterxml.jackson.databind', 'micrometer.tracing', 'dmx.fun.tracing', 'micrometer.core', 'dmx.fun.observation', 'dmx.fun.spring.webflux', 'spring.webflux', 'reactor.core']
+    extraOpens   = ['ALL-UNNAMED', 'spring.core', 'spring.beans', 'spring.context', 'spring.aop', 'spring.boot.autoconfigure', 'spring.webmvc', 'spring.web', 'spring.webflux', 'com.fasterxml.jackson.databind']
 }
 
 mavenPublishing {

--- a/frameworks/spring-boot/src/main/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfiguration.java
+++ b/frameworks/spring-boot/src/main/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfiguration.java
@@ -39,7 +39,8 @@ public class DmxFunWebFluxAutoConfiguration {
      * Registers a default {@link ThrowableHttpMapper} rendering failures as an RFC 7807 problem
      * response with the configured status (default {@code 500}).
      *
-     * @param status the HTTP status code for the problem, from {@code dmx.fun.webflux.problem.status}
+     * @param status the HTTP status code for the problem, from {@code dmx.fun.webflux.problem.status};
+     *               must be a valid HTTP status code or startup fails with a clear message
      * @return the default problem-detail throwable mapper
      */
     @Bean
@@ -48,6 +49,11 @@ public class DmxFunWebFluxAutoConfiguration {
     ThrowableHttpMapper dmxFunProblemDetailMapper(
         @Value("${dmx.fun.webflux.problem.status:500}") int status
     ) {
-        return WebfluxProblem.problemDetail(HttpStatus.valueOf(status));
+        HttpStatus resolved = HttpStatus.resolve(status);
+        if (resolved == null) {
+            throw new IllegalStateException(
+                "Invalid dmx.fun.webflux.problem.status: " + status + " — must be a valid HTTP status code");
+        }
+        return WebfluxProblem.problemDetail(resolved);
     }
 }

--- a/frameworks/spring-boot/src/main/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfiguration.java
+++ b/frameworks/spring-boot/src/main/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfiguration.java
@@ -1,0 +1,53 @@
+package dmx.fun.spring.boot.web;
+
+import dmx.fun.spring.webflux.ThrowableHttpMapper;
+import dmx.fun.spring.webflux.WebfluxProblem;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+/**
+ * Spring Boot autoconfiguration for {@code fun-spring-webflux}.
+ *
+ * <p>{@code WebfluxFun}/{@code WebfluxProblem} are static utilities, so there are no adapters to
+ * register. What this contributes is a ready-made default: a {@link ThrowableHttpMapper} bean
+ * that renders any failure as an RFC 7807 {@code application/problem+json} response, so reactive
+ * handlers can inject one (and pass it to {@code WebfluxFun.fromTry(...)}) instead of constructing
+ * it at each call site.
+ *
+ * <p>The status defaults to {@code 500} and is configurable via
+ * {@code dmx.fun.webflux.problem.status}. The bean is guarded by {@code @ConditionalOnMissingBean}
+ * (declare your own {@code ThrowableHttpMapper} to override it) and can be disabled with
+ * {@code dmx.fun.webflux.problem.enabled=false}.
+ */
+@AutoConfiguration
+@ConditionalOnClass({ServerResponse.class, WebfluxProblem.class})
+@NullMarked
+public class DmxFunWebFluxAutoConfiguration {
+
+    /** Default constructor required for Spring Boot auto-configuration instantiation. */
+    public DmxFunWebFluxAutoConfiguration() {
+    }
+
+    /**
+     * Registers a default {@link ThrowableHttpMapper} rendering failures as an RFC 7807 problem
+     * response with the configured status (default {@code 500}).
+     *
+     * @param status the HTTP status code for the problem, from {@code dmx.fun.webflux.problem.status}
+     * @return the default problem-detail throwable mapper
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "dmx.fun.webflux.problem.enabled", havingValue = "true", matchIfMissing = true)
+    ThrowableHttpMapper dmxFunProblemDetailMapper(
+        @Value("${dmx.fun.webflux.problem.status:500}") int status
+    ) {
+        return WebfluxProblem.problemDetail(HttpStatus.valueOf(status));
+    }
+}

--- a/frameworks/spring-boot/src/main/java/module-info.java
+++ b/frameworks/spring-boot/src/main/java/module-info.java
@@ -26,6 +26,9 @@ module dmx.fun.spring.boot {
     requires static micrometer.core;
     requires org.jspecify;
     requires static micrometer.observation;
+    requires static dmx.fun.spring.webflux;
+    requires static spring.webflux;
+    requires static reactor.core;
 
     exports dmx.fun.spring.boot;
     exports dmx.fun.spring.boot.web;

--- a/frameworks/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/frameworks/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -58,7 +58,7 @@
       "name": "dmx.fun.webflux.problem.status",
       "type": "java.lang.Integer",
       "defaultValue": 500,
-      "description": "HTTP status code for the auto-configured default WebFlux ProblemDetail ThrowableHttpMapper."
+      "description": "HTTP status code for the auto-configured default WebFlux ProblemDetail ThrowableHttpMapper. Must be a valid HTTP status code; an unknown value fails startup with a clear message."
     }
   ]
 }

--- a/frameworks/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/frameworks/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -47,6 +47,18 @@
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Whether to auto-configure a DmxObservation bean. When enabled, registers Micrometer Observation instrumentation for Try and Result operations (timers and low-cardinality tags are always recorded; distributed tracing spans are emitted only if a tracing bridge and matching ObservationHandler are configured). Set to false to disable this instrumentation entirely."
+    },
+    {
+      "name": "dmx.fun.webflux.problem.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Whether to auto-configure a default WebFlux ThrowableHttpMapper that renders failures as an RFC 7807 application/problem+json response. Set to false to skip registering the default; a user-declared ThrowableHttpMapper bean also disables it."
+    },
+    {
+      "name": "dmx.fun.webflux.problem.status",
+      "type": "java.lang.Integer",
+      "defaultValue": 500,
+      "description": "HTTP status code for the auto-configured default WebFlux ProblemDetail ThrowableHttpMapper."
     }
   ]
 }

--- a/frameworks/spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/frameworks/spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,6 @@
 dmx.fun.spring.boot.DmxFunSpringAutoConfiguration
 dmx.fun.spring.boot.web.DmxFunWebMvcAutoConfiguration
+dmx.fun.spring.boot.web.DmxFunWebFluxAutoConfiguration
 dmx.fun.spring.boot.jackson.DmxFunJacksonAutoConfiguration
 dmx.fun.spring.boot.tracing.DmxFunTracingAutoConfiguration
 dmx.fun.spring.boot.observation.DmxFunObservationAutoConfiguration

--- a/frameworks/spring-boot/src/test/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfigurationTest.java
+++ b/frameworks/spring-boot/src/test/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfigurationTest.java
@@ -1,0 +1,64 @@
+package dmx.fun.spring.boot.web;
+
+import dmx.fun.spring.webflux.ThrowableHttpMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DmxFunWebFluxAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(DmxFunWebFluxAutoConfiguration.class));
+
+    @Test
+    void registersDefaultProblemMapper_byDefault() {
+        runner.run(ctx -> assertThat(ctx).hasSingleBean(ThrowableHttpMapper.class)
+            .hasBean("dmxFunProblemDetailMapper"));
+    }
+
+    @Test
+    void defaultMapper_rendersConfiguredStatus() {
+        runner.run(ctx -> {
+            ThrowableHttpMapper mapper = ctx.getBean(ThrowableHttpMapper.class);
+            ServerResponse response = mapper.apply(new RuntimeException("boom")).block();
+            assertThat(response.statusCode().value()).isEqualTo(500);
+        });
+    }
+
+    @Test
+    void status_isConfigurable() {
+        runner.withPropertyValues("dmx.fun.webflux.problem.status=404").run(ctx -> {
+            ThrowableHttpMapper mapper = ctx.getBean(ThrowableHttpMapper.class);
+            ServerResponse response = mapper.apply(new RuntimeException("boom")).block();
+            assertThat(response.statusCode().value()).isEqualTo(404);
+        });
+    }
+
+    @Test
+    void disabled_byProperty() {
+        runner.withPropertyValues("dmx.fun.webflux.problem.enabled=false")
+            .run(ctx -> assertThat(ctx).doesNotHaveBean(ThrowableHttpMapper.class));
+    }
+
+    @Test
+    void backsOff_whenUserDeclaresOwnMapper() {
+        runner.withUserConfiguration(CustomMapperConfig.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(ThrowableHttpMapper.class).hasBean("customMapper");
+            assertThat(ctx).doesNotHaveBean("dmxFunProblemDetailMapper");
+        });
+    }
+
+    @Configuration
+    static class CustomMapperConfig {
+        @Bean
+        ThrowableHttpMapper customMapper() {
+            return cause -> ServerResponse.status(HttpStatus.I_AM_A_TEAPOT).build();
+        }
+    }
+}

--- a/frameworks/spring-boot/src/test/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfigurationTest.java
+++ b/frameworks/spring-boot/src/test/java/dmx/fun/spring/boot/web/DmxFunWebFluxAutoConfigurationTest.java
@@ -3,6 +3,7 @@ package dmx.fun.spring.boot.web;
 import dmx.fun.spring.webflux.ThrowableHttpMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,6 +52,21 @@ class DmxFunWebFluxAutoConfigurationTest {
         runner.withUserConfiguration(CustomMapperConfig.class).run(ctx -> {
             assertThat(ctx).hasSingleBean(ThrowableHttpMapper.class).hasBean("customMapper");
             assertThat(ctx).doesNotHaveBean("dmxFunProblemDetailMapper");
+        });
+    }
+
+    @Test
+    void backsOff_whenWebFluxClassesAbsent() {
+        runner.withClassLoader(new FilteredClassLoader(ServerResponse.class))
+            .run(ctx -> assertThat(ctx).doesNotHaveBean(ThrowableHttpMapper.class));
+    }
+
+    @Test
+    void invalidStatus_failsStartupWithClearMessage() {
+        runner.withPropertyValues("dmx.fun.webflux.problem.status=999").run(ctx -> {
+            assertThat(ctx).hasFailed();
+            assertThat(ctx).getFailure().rootCause()
+                .hasMessageContaining("dmx.fun.webflux.problem.status");
         });
     }
 

--- a/site/src/data/guide/spring-webflux.mdx
+++ b/site/src/data/guide/spring-webflux.mdx
@@ -124,6 +124,25 @@ problem whose `errors` property lists every violation:
 // 400 application/problem+json — {"status":400,"detail":"Validation failed","errors":[...]}
 ```
 
+### Spring Boot auto-configuration
+
+With `fun-spring-boot` on the classpath, a default `ThrowableHttpMapper` bean
+(`dmxFunProblemDetailMapper`) is auto-configured — a ready-made RFC 7807 renderer you can
+inject and reuse instead of building one per handler:
+
+```java
+RouterFunction<ServerResponse> routes(ThrowableHttpMapper problems) {   // injected
+    return RouterFunctions.route()
+        .POST("/orders", request -> WebfluxFun.fromTry(orderService.place(request), problems))
+        .build();
+}
+```
+
+The status defaults to `500` (set `dmx.fun.webflux.problem.status`), the bean backs off if
+you declare your own `ThrowableHttpMapper`, and it can be disabled with
+`dmx.fun.webflux.problem.enabled=false`. The adapters themselves stay static — this only
+provides the default bean.
+
 ## Aggregating a stream
 
 `fromResultStream` sequences a `Flux<Result<V, E>>` fail-fast (via `fun-reactor`'s

--- a/site/src/data/guide/spring.mdx
+++ b/site/src/data/guide/spring.mdx
@@ -73,6 +73,7 @@ explicit `@Bean` declarations required:
 | `DmxTracing` | `micrometer-tracing` **and** `fun-tracing` on classpath **and** a `Tracer` bean is present |
 | `optionReturnValueHandlerPostProcessor` | `spring-webmvc` on classpath (enabled by default, see [MVC handlers](#spring-mvc-return-value-handlers)) |
 | `resultReturnValueHandlerPostProcessor` | `spring-webmvc` on classpath (enabled by default, see [MVC handlers](#spring-mvc-return-value-handlers)) |
+| `dmxFunProblemDetailMapper` (a `ThrowableHttpMapper`) | `fun-spring-webflux` + WebFlux on classpath — a default RFC 7807 problem renderer for reactive handlers to inject |
 
 `PlatformTransactionManager` is auto-configured by Spring Boot for every registered `DataSource`; if you add a `DataSource` (e.g. via `spring-boot-starter-data-jpa` or `spring-boot-starter-jdbc`), no explicit transaction manager declaration is needed.
 
@@ -120,6 +121,8 @@ dmx.fun.aspect.enabled=false             # disable DmxTransactionalAspect
 dmx.fun.tracing.enabled=false            # disable DmxTracing (requires fun-tracing on classpath)
 dmx.fun.mvc.option-handler.enabled=false # disable Option MVC handler
 dmx.fun.mvc.result-handler.enabled=false # disable Result/Try/Validated MVC handler
+dmx.fun.webflux.problem.enabled=false    # disable the default WebFlux ProblemDetail ThrowableHttpMapper
+dmx.fun.webflux.problem.status=422       # status for the default WebFlux ProblemDetail mapper (default 500)
 ```
 
 All properties default to `true`, so existing applications are not affected.


### PR DESCRIPTION
Add DmxFunWebFluxAutoConfiguration to fun-spring-boot: when fun-spring-webflux and
Spring WebFlux are on the classpath, register a default ThrowableHttpMapper
(dmxFunProblemDetailMapper) that renders failures as RFC 7807 application/problem
+json, so reactive handlers can inject one instead of constructing it per call
site. Status is configurable via dmx.fun.webflux.problem.status (default 500);
guarded by @ConditionalOnMissingBean and dmx.fun.webflux.problem.enabled.

WebfluxFun/WebfluxProblem stay static (no adapters to register, and functional
endpoints can't be intercepted) — this only provides the default bean. Wire the
AutoConfiguration.imports, config metadata, and module-info; document the bean and
properties in the spring and spring-webflux guides. 5 ApplicationContextRunner
tests; verified on Spring Boot 3.4.13 and 4.1.0.

Closes #485

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spring WebFlux support for automatic error-to-response mapping in Spring Boot apps.
  * Introduced configurable RFC 7807 `ProblemDetail` handling with a default HTTP status of 500.
  * Added support for disabling the auto-configured mapper or overriding it with a custom one.

* **Documentation**
  * Updated Spring WebFlux and Spring Boot guides with setup, configuration, and customization examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->