### PR TITLE
fix(build): include reactor and spring-webflux in aggregated javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ def moduleMap = [
     ':observability:tracing'            : 'dmx.fun.tracing',
     ':resilience:resilience4j'          : 'dmx.fun.resilience4j',
     ':protocols:http'                   : 'dmx.fun.http',
+    ':reactor'                          : 'dmx.fun.reactor',
     ':frameworks:spring'                : 'dmx.fun.spring',
+    ':frameworks:spring-webflux'        : 'dmx.fun.spring.webflux',
     ':frameworks:spring-boot'           : 'dmx.fun.spring.boot',
     ':frameworks:quarkus:runtime'       : 'dmx.fun.quarkus'
 ]


### PR DESCRIPTION
moduleMap drove aggregateJavadoc's --module-source-path/--module args but
omitted :reactor and :frameworks:spring-webflux. Since spring-boot's
module-info `requires dmx.fun.spring.webflux`, javadoc could not resolve
modules and the aggregate failed. Add both modules to the map.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
