### PR TITLE
docs: changelog, docs, and blog post for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-01
+
+First-anniversary release. The headline additions are two new reactive modules —
+`fun-reactor` (Project Reactor interop) and `fun-spring-webflux` (Spring WebFlux
+adapters) — extending dmx-fun's railway-oriented style to `Mono`/`Flux` and HTTP.
+
+### Added
+
+- **`fun-reactor` — Project Reactor interop (new module):**
+  - `Mono` interop — convert `Option`, `Result`, and `Try` to/from `Mono`, plus
+    railway operators to stay on the Result/Try track inside reactive pipelines (#274).
+  - `Flux` interop and Result railway operators — `sequence` (fail-fast) and
+    `collectValidated` (error-accumulating) aggregation over a `Flux<Result>` (#473, #475).
+- **`fun-spring-webflux` — Spring WebFlux adapters (new module):**
+  - `WebfluxFun` maps `Option`, `Result`, `Try`, and `Validated` to a
+    `Mono<ServerResponse>` for functional endpoints, with documented, overridable HTTP
+    conventions (#275).
+  - Accumulating and streaming `Flux` responses — `fromResultStream`,
+    `fromResultStreamAccumulating`, and `stream` (NDJSON/SSE) (#482).
+  - Customizable success responses via `SuccessHttpMapper` — e.g. `201 Created` with a
+    `Location` header (#483).
+  - `WebfluxProblem` renders failures as RFC 7807 `application/problem+json`
+    `ProblemDetail` documents (#484).
+  - `WebfluxEntity` maps outcomes to `Mono<ResponseEntity<…>>` for annotation
+    controllers (`@RestController`) (#486).
+- **`fun-spring-boot`** — auto-configures a default WebFlux `ProblemDetail`
+  `ThrowableHttpMapper` bean, configurable and conditional (#485).
+- **`Result`** — `mapCatching(CheckedFunction)`, a `map` variant that captures thrown
+  checked exceptions as an `Err` (#476).
+- **`NonEmptyList`** — `reduce(BinaryOperator)` and `joinToString(...)` (#477).
+
+### Changed
+
+- Dependency bumps: Spring Boot 4.1.0 (#490), Jackson 2.22.0 (#463), JUnit BOM 6.1.1
+  (#468), Micrometer 1.17.0 and Micrometer Tracing 1.7.0 (#470), Quarkus 3.37.0 (#471),
+  Hibernate Validator 9.1.1.Final (#487), PostgreSQL JDBC 42.7.12 (#491), jakarta-jaxb
+  runtime patches (#489), Gradle wrapper 9.6.1 (#469).
+
+### Removed
+
+### Fixed
+
+- **Build** — the aggregated Javadoc (`aggregateJavadoc`) now includes the `fun-reactor`
+  and `fun-spring-webflux` modules; previously it failed to resolve modules because
+  `fun-spring-boot`'s `module-info` requires `dmx.fun.spring.webflux` (#497).
+
 ## [0.1.0] - 2026-05-10
 
 ### Added
@@ -630,7 +676,8 @@ Initial development: `Result`, `Try`, `Option`, and `Tuple2` types; interoperabi
 between all four types; monadic laws test suite (Spock); Java 24 toolchain; Maven
 Central publication setup.
 
-[Unreleased]: https://github.com/domix/dmx-fun/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/domix/dmx-fun/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/domix/dmx-fun/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/domix/dmx-fun/compare/v0.0.15...v0.1.0
 [0.0.15]: https://github.com/domix/dmx-fun/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/domix/dmx-fun/compare/v0.0.13...v0.0.14

--- a/site/src/data/blog/release-0.2.0.md
+++ b/site/src/data/blog/release-0.2.0.md
@@ -1,0 +1,157 @@
+---
+title: "dmx-fun 0.2.0 — Reactive, and One Year Old"
+description: "0.2.0 is dmx-fun's first-anniversary release: two new reactive modules — fun-reactor (Project Reactor interop) and fun-spring-webflux (Spring WebFlux adapters) — plus a year of 17 releases building a functional programming ecosystem for Java backends."
+pubDate: 2026-07-01
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Release"
+tags: ["Release", "0.2.0", "Anniversary", "Reactive", "Project Reactor", "Spring WebFlux", "Functional Programming", "Result", "Option", "Try", "Validated"]
+image: "https://images.pexels.com/photos/12966794/pexels-photo-12966794.jpeg"
+imageCredit:
+    author: "Marek Piwnicki"
+    authorUrl: "https://www.pexels.com/@marek-piwnicki-3907296/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/es-es/foto/hombre-silueta-cascada-sin-camisa-12966794/"
+---
+
+`dmx-fun 0.2.0` is out — and this one is special.
+
+**It is our first-anniversary release.** The first commit landed on June 30th, 2025. One year
+later, dmx-fun has grown from a handful of core types into a coordinated ecosystem of functional
+programming modules for Java backends — shipped across **17 releases** in that first year, from
+`0.0.1` all the way to the one you are reading about now.
+
+Thank you to everyone who filed an issue, opened a pull request, or put dmx-fun into a real
+backend. This release is a celebration of that year — and a big step forward.
+
+---
+
+## The headline: dmx-fun goes reactive
+
+Until now, dmx-fun's railway-oriented style lived in synchronous code. `0.2.0` extends it to the
+reactive world with **two new modules**:
+
+- **`fun-reactor`** — Project Reactor interop: convert `Option`, `Result`, and `Try` to and from
+  `Mono` and `Flux`, and keep composing on the Result/Try track inside reactive pipelines.
+- **`fun-spring-webflux`** — Spring WebFlux adapters: map your domain outcomes straight to HTTP
+  responses, for both functional endpoints and annotation controllers.
+
+Same idea you already know — failures, absence, and validation stay explicit in the type system —
+now flowing through `Mono` and `Flux`.
+
+---
+
+## `fun-reactor` — interop and railway operators
+
+`fun-reactor` bridges dmx-fun and Project Reactor in both directions, and adds railway operators
+so a `Mono<Result<V, E>>` stays on the happy path without unwrapping:
+
+```java
+Mono<Result<User, ApiError>> user =
+    ReactorResult.fromMono(userRepository.findById(id), ApiError::fromThrowable)
+        .flatMapOk(u -> ReactorResult.fromMono(enrich(u), ApiError::fromThrowable))
+        .mapOk(User::redactSecrets);
+```
+
+For collections, `sequence` aggregates a `Flux<Result<V, E>>` fail-fast, while `collectValidated`
+accumulates **every** error instead of stopping at the first — the reactive counterpart of
+`Validated`'s error accumulation.
+
+---
+
+## `fun-spring-webflux` — outcomes to HTTP
+
+`fun-spring-webflux` maps `Option`, `Result`, `Try`, and `Validated` to WebFlux responses with
+documented, overridable HTTP conventions. Use `WebfluxFun` for **functional endpoints**:
+
+```java
+RouterFunction<ServerResponse> routes() {
+    return RouterFunctions.route()
+        .GET("/users/{id}", request ->
+            WebfluxFun.fromResult(
+                userService.findById(request.pathVariable("id")),   // Mono<Result<User, ApiError>>
+                error -> ServerResponse.status(error.status()).bodyValue(error.detail())))
+        .build();
+}
+```
+
+…or `WebfluxEntity` for **annotation controllers** (`@RestController`), returning a
+`Mono<ResponseEntity<…>>`:
+
+```java
+@GetMapping("/users/{id}")
+Mono<ResponseEntity<User>> user(@PathVariable String id) {
+    return WebfluxEntity.fromOption(userService.find(id));   // Some -> 200, None/empty -> 404
+}
+```
+
+The module goes well beyond a single mapping:
+
+- **Streaming and aggregation** — collect a `Flux<Result>` fail-fast, accumulate every error, or
+  stream a `Flux<V>` element-by-element as NDJSON/SSE.
+- **Customizable success responses** — a `SuccessHttpMapper` lets you return `201 Created` with a
+  `Location` header, `202 Accepted`, caching headers, and so on.
+- **RFC 7807 problem responses** — `WebfluxProblem` renders failures as standard
+  `application/problem+json` `ProblemDetail` documents.
+- **Spring Boot auto-configuration** — with `fun-spring-boot` on the classpath, a ready-made
+  `ProblemDetail` mapper bean is auto-configured, configurable and conditional.
+
+Both `fun-reactor` and `fun-spring-webflux` declare Reactor and Spring as `compileOnly` — you
+bring your own versions. `spring-webflux` is tested in CI against Spring Framework 6.0.x through
+7.0.x on every pull request.
+
+---
+
+## Also in 0.2.0
+
+- **`Result.mapCatching(CheckedFunction)`** — a `map` variant that captures thrown checked
+  exceptions as an `Err`, so throwing mappers no longer force you out of the Result track.
+- **`NonEmptyList.reduce(...)` and `joinToString(...)`** — ergonomic folds over a guaranteed
+  non-empty list.
+- **Dependency refresh** — Spring Boot 4.1.0, Jackson 2.22.0, JUnit 6.1.1, Micrometer 1.17.0,
+  Micrometer Tracing 1.7.0, Quarkus 3.37.0, Hibernate Validator 9.1.1.Final, and more.
+
+See the [full changelog](https://github.com/domix/dmx-fun/blob/main/CHANGELOG.md) for the complete list.
+
+---
+
+## A year in numbers
+
+- **17 releases** — `0.0.1` → `0.2.0`
+- **1 stable milestone** — `0.1.0`, our first production-ready release
+- **13 modules** — core types plus serialization, observability, resilience, HTTP, framework, and
+  now reactive integrations
+- **1 interoperability audit** across every core type
+
+From four types in a single artifact to a reactive-ready ecosystem — in twelve months.
+
+---
+
+## Getting started
+
+```kotlin
+// Gradle (Kotlin DSL) — reactive stack
+implementation(platform("codes.domix:fun-bom:0.2.0"))
+implementation("codes.domix:fun")
+implementation("codes.domix:fun-reactor")
+implementation("codes.domix:fun-spring-webflux")
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+    <groupId>codes.domix</groupId>
+    <artifactId>fun-spring-webflux</artifactId>
+    <version>0.2.0</version>
+</dependency>
+```
+
+The [Reactor guide](/dmx-fun/guide/reactor) and the
+[Spring WebFlux guide](/dmx-fun/guide/spring-webflux) walk through both new modules with
+real-world examples. Full Javadoc is at [/dmx-fun/javadoc/](/dmx-fun/javadoc/index.html).
+
+Here's to the next year.
+
+---
+
+*Found a bug or have a suggestion? Open an issue on [GitHub](https://github.com/domix/dmx-fun).*

--- a/site/src/data/code/getting-started/gradle.mdx
+++ b/site/src/data/code/getting-started/gradle.mdx
@@ -3,5 +3,5 @@ fileName: 'build.gradle'
 ---
 
 ```groovy title="build.gradle"
-implementation 'codes.domix:fun:0.1.0'
+implementation 'codes.domix:fun:0.2.0'
 ```

--- a/site/src/data/code/getting-started/maven.mdx
+++ b/site/src/data/code/getting-started/maven.mdx
@@ -6,6 +6,6 @@ fileName: 'pom.xml'
 <dependency>
   <groupId>codes.domix</groupId>
   <artifactId>fun</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
 </dependency>
 ```

--- a/site/src/data/code/guide/assertj/dependency.mdx
+++ b/site/src/data/code/guide/assertj/dependency.mdx
@@ -4,7 +4,7 @@ fileName: 'build.gradle / pom.xml'
 
 ```groovy
 // Gradle — test scope only
-testImplementation("codes.domix:fun-assertj:0.1.0")
+testImplementation("codes.domix:fun-assertj:0.2.0")
 // AssertJ itself — bring your own version (3.21.x – 3.27.x)
 testImplementation("org.assertj:assertj-core:3.27.7")
 ```
@@ -14,7 +14,7 @@ testImplementation("org.assertj:assertj-core:3.27.7")
 <dependency>
     <groupId>codes.domix</groupId>
     <artifactId>fun-assertj</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>

--- a/site/src/data/code/guide/introduction/bom-gradle.mdx
+++ b/site/src/data/code/guide/introduction/bom-gradle.mdx
@@ -5,7 +5,7 @@ fileName: 'build.gradle.kts'
 ```kotlin
 // Kotlin DSL — import the BOM, then declare modules without versions
 dependencies {
-    implementation(platform("codes.domix:fun-bom:0.1.0"))
+    implementation(platform("codes.domix:fun-bom:0.2.0"))
 
     implementation("codes.domix:fun")
     implementation("codes.domix:fun-jackson")      // version managed by BOM
@@ -16,7 +16,7 @@ dependencies {
 ```groovy
 // Groovy DSL
 dependencies {
-    implementation platform('codes.domix:fun-bom:0.1.0')
+    implementation platform('codes.domix:fun-bom:0.2.0')
 
     implementation 'codes.domix:fun'
     implementation 'codes.domix:fun-jackson'

--- a/site/src/data/code/guide/introduction/bom-maven.mdx
+++ b/site/src/data/code/guide/introduction/bom-maven.mdx
@@ -9,7 +9,7 @@ fileName: 'pom.xml'
     <dependency>
       <groupId>codes.domix</groupId>
       <artifactId>fun-bom</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/site/src/data/code/guide/jackson/dependency.mdx
+++ b/site/src/data/code/guide/jackson/dependency.mdx
@@ -4,7 +4,7 @@ fileName: 'build.gradle / pom.xml'
 
 ```groovy
 // Gradle
-implementation("codes.domix:fun-jackson:0.1.0")
+implementation("codes.domix:fun-jackson:0.2.0")
 // Jackson itself — bring your own version (2.14.x – 2.22.x)
 implementation("com.fasterxml.jackson.core:jackson-databind:2.22.0")
 ```
@@ -14,7 +14,7 @@ implementation("com.fasterxml.jackson.core:jackson-databind:2.22.0")
 <dependency>
     <groupId>codes.domix</groupId>
     <artifactId>fun-jackson</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 </dependency>
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Add the [0.2.0] CHANGELOG section (new fun-reactor and fun-spring-webflux
modules, Result.mapCatching, NonEmptyList.reduce/joinToString, dependency
bumps, aggregateJavadoc fix) and its compare links.

Bump the hardcoded dependency snippets (fun, fun-bom, fun-assertj,
fun-jackson) from 0.1.0 to 0.2.0; leave the illustrative versions in the
release-process docs untouched.

Add the release-0.2.0 blog post — the first-anniversary release (17
releases in the first year) headlined by the new reactive modules.

Closes #499

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
