### PR TITLE
docs(blog): add post on functional thinking for backend engineers

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -61,7 +61,7 @@
 46. How functional programming improves maintainability
 47. Coupling and cohesion from a functional perspective
 48. Functional programming for microservices
-49. Functional thinking for backend engineers
+49. ~~Functional thinking for backend engineers~~
 50. How to document functional flows in complex systems
 
 ### Language and ecosystem topics

--- a/site/src/data/blog/functional-thinking-for-backend-engineers.md
+++ b/site/src/data/blog/functional-thinking-for-backend-engineers.md
@@ -1,0 +1,209 @@
+---
+title: "Functional Thinking for Backend Engineers"
+description: "Functional thinking is not about monads or category theory. For backend engineers it is a practical shift: model the things a service actually deals with — missing rows, failed calls, invalid input, side effects — as ordinary values you can pass, compose, and let the compiler check."
+pubDate: 2026-07-04
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Article"
+tags: ["Functional Programming", "Java", "Backend", "Result", "Option", "Validated", "Architecture"]
+image: "https://images.pexels.com/photos/7179425/pexels-photo-7179425.jpeg"
+imageCredit:
+    author: "cottonbro studio"
+    authorUrl: "https://www.pexels.com/@cottonbro/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/es-es/foto/mesa-herramientas-velas-naturaleza-muerta-7179425/"
+---
+
+"Functional programming" sounds like something that happens in Haskell, on a whiteboard, with the
+word *monad* on it. That reputation keeps a lot of backend engineers away from ideas that would
+make their day job noticeably easier — because the useful part of functional thinking has almost
+nothing to do with the theory.
+
+Strip away the vocabulary and functional thinking is a single habit: **model the things your
+service deals with as values, and let those values flow through your code instead of controlling
+it from the outside.** A backend spends its whole life dealing with four things that Java, left to
+its defaults, keeps *implicit*: a row that might not exist, a call that might fail, input that
+might be invalid, and effects on the outside world. Functional thinking makes each of those
+explicit. That is the whole move.
+
+Let us take them one at a time, from the perspective of someone who builds services, not proofs.
+
+---
+
+## Absence is a value, not a `null`
+
+Every backend does lookups, and every lookup can miss. The default Java answer is `null` — and
+`null` is invisible. Nothing in `User findById(String id)` tells the caller that `null` is on the
+table. The knowledge lives in your head, or in a Javadoc line nobody reads, until an NPE finds it
+for you in production.
+
+Functional thinking makes absence a value you can see:
+
+```java
+Option<User> findById(String id);
+```
+
+Now "there might be no such user" is in the type. The caller cannot ignore it, because there is no
+`User` to accidentally dereference — there is an `Option<User>`, and getting the `User` out means
+deciding what to do when it is not there:
+
+```java
+String displayName = findById(id)
+    .map(User::name)
+    .getOrElse("unknown user");
+```
+
+Nothing here is academic. You have moved a runtime surprise into a decision the compiler makes you
+take. That is the entire value proposition, and it repeats for each of the next three.
+
+---
+
+## Failure is a value, not a thrown exception
+
+Backends fail for two very different reasons, and conflating them is the source of a lot of bad
+error handling. A database being down is *infrastructure* failure. A transfer being declined for
+insufficient funds is a *domain* outcome — a completely normal thing your business logic has an
+opinion about. Java's `throw` treats both as the same kind of event: an exception that unwinds the
+stack and gets caught somewhere far away, by a handler that has lost all the context.
+
+Functional thinking separates them. Infrastructure failures can stay exceptions — they are
+genuinely exceptional. Domain outcomes become **values with a type**:
+
+```java
+Result<Receipt, TransferError> transfer(Account from, Account to, Money amount);
+```
+
+`TransferError` is a real part of the API now — `InsufficientFunds`, `AccountFrozen`,
+`LimitExceeded` — not a string buried in an exception message. The caller handles it in the same
+straight line as the success, no `try/catch` detour:
+
+```java
+return transfer(from, to, amount)
+    .map(receipt -> Response.ok(receipt))
+    .recover(error -> Response.unprocessable(error.code()));
+```
+
+The happy path reads top to bottom. The failure path is right next to it, typed, and impossible to
+forget — a `Result` you never inspect is a compile-time smell, not a silent swallow.
+
+---
+
+## Validation accumulates
+
+Here is a scenario every API author knows. A signup form comes in with a bad email *and* a weak
+password *and* a missing name. What does your endpoint return? Too often: the first error, because
+validation was a chain of `if (bad) throw`. The user fixes it, resubmits, and gets the *second*
+error. Three round-trips for one form.
+
+The reason is that exceptions are fail-fast by nature — the first `throw` ends the story.
+Functional thinking reaches for a type whose whole job is to *accumulate*:
+
+```java
+Validated<NonEmptyList<String>, Customer> validate(SignupForm form) {
+    return Validated.combine3(
+        validateName(form.name()),
+        validateEmail(form.email()),
+        validatePassword(form.password()),
+        NonEmptyList::concat,   // merge the errors when more than one fails
+        Customer::new);         // build the Customer only if all three pass
+}
+```
+
+`Valid(Customer)` when everything checks out; `Invalid([...])` with **every** problem when it does
+not. One round-trip, the complete list. Same underlying idea as before — the outcome is a value —
+but chosen for a job (`Result` stops at the first error; `Validated` collects them all) that a
+backend hits constantly.
+
+---
+
+## Push the effects to the edges
+
+This is the one that changes how a whole service is shaped, and it is where "functional" stops
+being about individual return types and starts being about architecture.
+
+An effect is anything that touches the outside world: a database write, an HTTP call, reading the
+clock, publishing a message. Effects are where bugs hide, because they make code impossible to
+reason about in isolation — a function that saves to the database *and* decides a business rule
+can only be tested by standing up a database.
+
+Functional thinking says: keep the decisions pure, and push the effects to the edges. The core of
+your service becomes plain functions — take values, return values, no I/O — surrounded by a thin
+shell that does the talking to the world.
+
+```java
+// Core: pure. Given the state, decide. No I/O, trivially testable.
+Result<Order, OrderError> confirm(Order order) {
+    if (order.status() != PENDING)  return Result.err(new OrderError.NotPending());
+    if (order.items().isEmpty())    return Result.err(new OrderError.Empty());
+    return Result.ok(order.withStatus(CONFIRMED));
+}
+
+// Shell: effects only. Load, delegate to the pure core, persist.
+Result<Order, OrderError> confirmOrder(OrderId id) {
+    return orders.findById(id)                       // effect (read)
+        .toResult(new OrderError.NotFound(id))
+        .flatMap(this::confirm)                       // pure decision
+        .flatMap(orders::save);                       // effect (write)
+}
+```
+
+The business rule — the part that actually encodes what your company does — is a pure function you
+can test with three lines and no infrastructure. The effects are quarantined at the boundary. This
+is often called *functional core, imperative shell*, and it is the highest-leverage idea in this
+whole post: it survives long after you have forgotten which type is called what.
+
+---
+
+## Composition replaces control flow
+
+Notice what happened across all four examples: the `if` ladders, the `try/catch` blocks, the null
+checks, the early returns — they thinned out and got replaced by a chain of small steps. `map`,
+`flatMap`, `recover`, `getOrElse`. That is not a cosmetic preference. Control flow (branch, throw,
+return) describes *how* the computation moves; composition describes *what* the computation is, as
+a pipeline of transformations over values.
+
+Composition scales better because each step is independent and total — it handles its own absence
+and failure — so you can read, test, and reorder them without holding the whole method in your
+head. A 40-line method with five exit points becomes a five-line pipeline where each line does one
+honest thing.
+
+---
+
+## You are probably already doing it
+
+The punchline is that none of this is exotic. Java's own `Optional`, `Stream`, and
+`CompletableFuture` are all functional: values that model absence, sequences, and async results,
+with `map`/`flatMap` to compose them. If you have ever chained a `stream().filter().map().collect()`
+instead of writing a loop with a mutable accumulator, you have already done functional thinking.
+The shift is just applying that same instinct to the rest of what a backend does — failure,
+validation, effects — instead of only to collections.
+
+You do not need a new language or a category-theory course. You need to stop letting absence,
+failure, and validation live implicitly in `null`, exceptions, and the first `if` that throws —
+and start letting them be values that flow through your code where the compiler can watch them.
+That is functional thinking, and it earns its keep on the first NPE it prevents.
+
+The [dmx-fun](/dmx-fun/) library provides these types — `Option`, `Result`, `Validated`, and the
+rest — as plain Java you can drop into an existing service one return type at a time. The
+[Developer Guide](/dmx-fun/guide/) walks through each with backend-shaped examples.
+
+---
+
+## Further reading
+
+- [Pure Functions and Side Effects](/dmx-fun/blog/pure-functions-and-side-effects) — the deeper
+  version of the "push effects to the edges" idea.
+- [Writing Predictable Code with Functional Programming](/dmx-fun/blog/predictable-code-with-fp) —
+  why total, composable functions are easier to reason about.
+- [Algebraic Data Types Explained for Business Software Developers](/dmx-fun/blog/algebraic-data-types-for-business-developers)
+  — how `Result`, `Option`, and `Validated` are built, in plain terms.
+- [Designing More Expressive APIs with Functional Types](/dmx-fun/blog/expressive-apis-with-functional-types)
+  — service and repository signatures that tell the truth.
+- [How to Introduce Functional Programming into a Legacy Codebase](/dmx-fun/blog/introducing-fp-into-legacy-codebase)
+  — adopting these ideas one return type at a time.
+- [Domain-Driven Design and Functional Programming: Allies or Rivals?](/dmx-fun/blog/ddd-and-functional-programming-allies-or-rivals)
+  — the same tools applied to modeling a domain.
+
+---
+
+*Found a bug or have a suggestion? Open an issue on [GitHub](https://github.com/domix/dmx-fun).*


### PR DESCRIPTION
Add "Functional Thinking for Backend Engineers" — frames FP as making the
four things a service handles implicitly (absence, failure, validation,
effects) explicit as values: Option over null, Result with typed domain
errors, Validated for accumulating validation, and functional core /
imperative shell. Closes with a "Further reading" section.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new blog post on functional thinking for backend engineers, covering practical ways to model missing data, failures, validation, and side effects more clearly.
  * Included examples of composing logic with typed values and pipelines, plus links to related reading.
* **Documentation**
  * Marked one outdated plan topic as removed/obsolete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->