### PR TITLE
docs(blog): add post on pragmatic functional programming in Java

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -163,7 +163,7 @@
 * **Immutability in real systems: fewer bugs, fewer surprises**
 * **Error handling without exceptions: a functional approach**
 * **Option, Result, and Try explained pragmatically**
-* **Functional programming in Java without losing pragmatism**
+* ~~**Functional programming in Java without losing pragmatism**~~
 * **Functional core, imperative shell applied to a real service**
 * **The day a NullPointerException taught me to use Option**
 * **Rewriting a tangled service method into a pure pipeline**

--- a/site/src/data/blog/functional-programming-in-java-without-losing-pragmatism.md
+++ b/site/src/data/blog/functional-programming-in-java-without-losing-pragmatism.md
@@ -1,0 +1,200 @@
+---
+title: "Functional Programming in Java Without Losing Pragmatism"
+description: "Adopting functional programming in Java goes wrong when you try to turn Java into Haskell. Done pragmatically, it is a handful of concrete habits that fit the language you already have — records, sealed types, the JDK — and pay off on the first bug they prevent. Here is how to get the benefits without the dogma."
+pubDate: 2026-07-10
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Article"
+tags: ["Functional Programming", "Java", "Pragmatism", "Architecture", "Result", "Option", "Backend"]
+image: "https://images.pexels.com/photos/1108101/pexels-photo-1108101.jpeg"
+imageCredit:
+    author: "Chevanon Photography"
+    authorUrl: "https://www.pexels.com/@chevanon/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/photo/woman-wears-yellow-hard-hat-holding-vehicle-part-1108101/"
+---
+
+Functional programming in Java has an image problem, and it is largely self-inflicted. The
+loudest examples tend to be the ones that treat Java as a broken Haskell — reconstructing
+typeclasses out of interfaces, chaining twelve combinators where an `if` would do, importing a
+vocabulary that makes a code review feel like a category-theory exam. A pragmatic engineer sees
+that and reasonably concludes the whole thing is not worth it.
+
+It does not have to look like that. The useful part of functional programming is small, concrete,
+and fits the grain of the Java you already write. The trick is knowing which parts to take and,
+just as importantly, which to leave. This post is about staying on the pragmatic side of that line.
+
+---
+
+## Work with the language, not against it
+
+Java in 2026 is not the language the "Java can't do FP" complaints were written about. Records give
+you immutable value types in one line. Sealed interfaces plus pattern matching give you closed sets
+with exhaustive `switch`. These are functional tools shipped in the JDK, and they read like normal
+Java because they *are* normal Java.
+
+```java
+sealed interface PaymentResult {
+    record Captured(String reference)        implements PaymentResult {}
+    record Declined(String reason)           implements PaymentResult {}
+    record Pending(Instant retryAfter)       implements PaymentResult {}
+}
+
+String describe(PaymentResult r) {
+    return switch (r) {                          // compiler enforces every case
+        case PaymentResult.Captured c -> "captured " + c.reference();
+        case PaymentResult.Declined d -> "declined: " + d.reason();
+        case PaymentResult.Pending p  -> "retry after " + p.retryAfter();
+    };
+}
+```
+
+No library, no ceremony, no imported abstractions. This is algebraic data types and pattern
+matching — the heart of functional modeling — expressed in plain Java a teammate reads at a glance.
+The pragmatic move is to reach for these *first*, because the cost of adoption is zero: they are
+already on the classpath and already familiar.
+
+---
+
+## Use the JDK before you use a library
+
+The second pragmatic reflex is to check what the standard library already gives you. `Optional`,
+`Stream`, and `CompletableFuture` are functional types — values that model absence, sequences, and
+async results, composable with `map` and `flatMap`. If a `stream().filter().map().toList()` reads
+better than a loop, use it. You do not need anything beyond the JDK to think functionally about
+collections and optional values.
+
+A library earns its place only where the JDK has a genuine gap. There are two that matter for
+backend work, and they are the reason a library like dmx-fun exists at all:
+
+- **Typed errors.** `Optional` models absence but has no error channel — it cannot tell you *why*
+  something is missing. Exceptions can, but they vanish from the type signature. `Result<V, E>`
+  fills the gap: a return value that carries a typed failure the compiler makes the caller handle.
+- **Accumulating validation.** Nothing in the JDK collects multiple failures into one answer.
+  `Validated` does, so a form with three bad fields comes back with all three, not just the first.
+
+```java
+// JDK where it fits: absence, no reason needed.
+Optional<User> cached = cache.get(id);
+
+// Library where the JDK has a gap: failure with a typed reason.
+Result<User, LookupError> user = repository.findById(id);
+```
+
+The line is not "functional library good, JDK bad." It is: use the smallest thing that does the
+job. Most of the time that is the JDK. Sometimes it is one extra type. It is almost never a whole
+new paradigm imported wholesale.
+
+---
+
+## Adopt at the boundaries, one return type at a time
+
+The failed version of FP adoption is the big rewrite — someone reads a book and tries to convert
+the whole service to a pure core in a sprint. The pragmatic version is boring: change one return
+type, at one boundary, where it earns its keep, and leave everything else alone.
+
+A repository method that returns `null` and throws is the classic first candidate. Make it honest:
+
+```java
+interface OrderRepository {
+    Option<Order> findById(OrderId id);                 // absence is explicit
+    Result<Order, PersistenceError> save(Order order);  // failure is a value
+}
+```
+
+Now the one service that calls it can compose the outcome instead of guarding it, and the rest of
+the codebase does not have to know or care:
+
+```java
+Result<Order, OrderError> confirmOrder(OrderId id) {
+    return orders.findById(id)
+        .toResult(new OrderError.NotFound(id))   // Option -> Result at the boundary
+        .flatMap(Order::confirm)
+        .flatMap(order -> orders.save(order).mapError(OrderError::persistence));
+}
+```
+
+This is adoption you can do in one pull request, review in ten minutes, and revert if it does not
+pay off. No framework buy-in, no team-wide migration, no meeting. That is what pragmatic looks
+like: value delivered per unit of disruption, not purity per unit of code.
+
+---
+
+## Keep the seam to the exception world
+
+Pragmatism means not pretending the exception-based world does not exist. The JDK throws, your ORM
+throws, your HTTP client throws — and that is fine. You do not fight it; you put one small seam
+where the throwing world becomes the value world, and you compose on the value side after that.
+
+```java
+Result<Config, ConfigError> parse(String raw) {
+    return Try.of(() -> objectMapper.readValue(raw, Config.class))   // may throw
+              .toResult(ConfigError::malformed);                      // Throwable -> domain error
+}
+```
+
+Inside your code, failures are typed values. At the edges, exceptions do what they are good at.
+Neither side has to win. (The same principle is why exceptions remain the right tool for genuine
+surprises — bugs, unrecoverable failures, framework protocols — a line worth drawing deliberately
+rather than by reflex in either direction.)
+
+---
+
+## Know when to stop
+
+The most pragmatic skill of all is recognizing when a functional dressing makes code *worse*. A few
+honest limits:
+
+- **Don't build abstractions Java can't carry.** Higher-kinded types, typeclass hierarchies, and
+  generic "monad" interfaces fight the type system every step. If a pattern needs three layers of
+  generics to express, it is not pragmatic in Java — write the concrete version.
+- **Don't chain for the sake of chaining.** A ten-step `flatMap` pipeline that a plain `if`/`return`
+  would express more clearly is showing off, not simplifying. Composition earns its place when it
+  removes branching, not when it hides it.
+- **Don't make trivial code total.** A private helper that cannot fail does not need a `Result`.
+  Wrapping certainty in an error type is noise the next reader has to unwrap.
+
+The test is always the same, and it is not "is this functional." It is: *will the person paged at
+3am understand this faster than the alternative?* If yes, keep it. If the functional version is
+cleverer but harder to read, the imperative version was the pragmatic one all along.
+
+---
+
+## Pragmatism is the point, not a compromise
+
+There is a temptation to treat "pragmatic FP" as a watered-down version of the real thing — as if
+the pure, combinator-heavy style were the ideal and the pragmatic version a concession. It is the
+other way around. The goal was never functional purity; it was code that is easier to reason about,
+harder to break, and honest about what it does. Functional techniques are means to that end, and
+you take exactly as many of them as move you toward it.
+
+In Java that turns out to be a short list: model your data with records and sealed types, make
+absence and failure into values the compiler tracks, push effects to the edges, and lean on the JDK
+before anything else. Skip the parts that fight the language. What is left is not a diluted
+functional programming — it is the functional programming that actually survives contact with a
+production Java codebase.
+
+The [dmx-fun](/dmx-fun/) library is built around exactly this stance: plain Java types — `Option`,
+`Result`, `Validated`, and the rest — you adopt one return type at a time, no paradigm purchase
+required. The [Developer Guide](/dmx-fun/guide/) walks through each with backend-shaped examples.
+
+---
+
+## Further reading
+
+- [Pragmatic FP vs. Academic Purism](/dmx-fun/blog/pragmatic-fp-vs-academic-purism) — the fuller
+  argument for taking the useful parts and leaving the dogma.
+- [JDK-First Functional Programming](/dmx-fun/blog/jdk-first-functional-programming) — how far the
+  standard library gets you before any dependency.
+- [When Making It Functional Makes It Worse](/dmx-fun/blog/when-making-it-functional-makes-it-worse)
+  — concrete cases where the functional version is the wrong call.
+- [How to Introduce Functional Programming into a Legacy Codebase](/dmx-fun/blog/introducing-fp-into-legacy-codebase)
+  — adopting these ideas one return type at a time, in code that already exists.
+- [A Library or a Set of Habits?](/dmx-fun/blog/library-vs-habits) — why most of the value is in the
+  habits, not the imports.
+- [Functional Thinking for Backend Engineers](/dmx-fun/blog/functional-thinking-for-backend-engineers)
+  — the mindset these habits come from, framed for people who build services.
+
+---
+
+*Found a bug or have a suggestion? Open an issue on [GitHub](https://github.com/domix/dmx-fun).*

--- a/site/src/data/blog/functional-programming-in-java-without-losing-pragmatism.md
+++ b/site/src/data/blog/functional-programming-in-java-without-losing-pragmatism.md
@@ -29,7 +29,7 @@ just as importantly, which to leave. This post is about staying on the pragmatic
 ## Work with the language, not against it
 
 Java in 2026 is not the language the "Java can't do FP" complaints were written about. Records give
-you immutable value types in one line. Sealed interfaces plus pattern matching give you closed sets
+you shallowly immutable value carriers in one line. Sealed interfaces plus pattern matching give you closed sets
 with exhaustive `switch`. These are functional tools shipped in the JDK, and they read like normal
 Java because they *are* normal Java.
 
@@ -60,7 +60,7 @@ already on the classpath and already familiar.
 
 The second pragmatic reflex is to check what the standard library already gives you. `Optional`,
 `Stream`, and `CompletableFuture` are functional types — values that model absence, sequences, and
-async results, composable with `map` and `flatMap`. If a `stream().filter().map().toList()` reads
+async results, composable with `map`/`flatMap` (and `thenApply`/`thenCompose` for futures). If a `stream().filter().map().toList()` reads
 better than a loop, use it. You do not need anything beyond the JDK to think functionally about
 collections and optional values.
 
@@ -69,7 +69,7 @@ backend work, and they are the reason a library like dmx-fun exists at all:
 
 - **Typed errors.** `Optional` models absence but has no error channel — it cannot tell you *why*
   something is missing. Exceptions can, but they vanish from the type signature. `Result<V, E>`
-  fills the gap: a return value that carries a typed failure the compiler makes the caller handle.
+  fills the gap: a return value that makes the typed failure visible in the signature and to the caller.
 - **Accumulating validation.** Nothing in the JDK collects multiple failures into one answer.
   `Validated` does, so a form with three bad fields comes back with all three, not just the first.
 


### PR DESCRIPTION
Add "Functional Programming in Java Without Losing Pragmatism" — argues the
useful part of FP is a short list that fits Java's grain: model data with
records and sealed types, use the JDK (Optional/Stream) before any library,
reach for Result/Validated only where the JDK has a real gap, adopt one
return type at a time at the boundaries, keep a single seam to the exception
world, and know when a functional dressing makes code worse.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new blog article on adopting functional programming practices pragmatically in Java.
  * Covers modern Java features, typed error handling, incremental adoption, practical limits, and further reading.

* **Documentation**
  * Marked the corresponding topic as completed in the development plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->