### PR TITLE
fix(deps): override Jackson 3 BOM to 3.1.5 in spring-boot-sample

### DIFF
--- a/samples/spring-boot-sample/build.gradle
+++ b/samples/spring-boot-sample/build.gradle
@@ -22,6 +22,12 @@ dependencies {
         constraints {
             implementation "org.apache.tomcat.embed:tomcat-embed-core:11.0.22"
         }
+        // Boot 4.1.0 manages jackson-bom 3.1.4, which is vulnerable to the @JsonView /
+        // @JsonUnwrapped deserialization bypass (Dependabot alert #90, fixed in 3.1.5).
+        // Gradle picks the highest version among platforms, so this wins over the Boot BOM.
+        // Remove once Spring Boot manages jackson-bom >= 3.1.5. See issue #517.
+        implementation     platform("tools.jackson:jackson-bom:3.1.5")
+        testImplementation platform("tools.jackson:jackson-bom:3.1.5")
     }
 
     // dmx-fun modules


### PR DESCRIPTION
Spring Boot 4.1.0 manages jackson-bom 3.1.4, which is vulnerable to the
`@JsonView` / `@JsonUnwrapped` deserialization bypass (Dependabot alert #90).
Add a jackson-bom 3.1.5 platform inside the Boot 4 conditional so Gradle
resolves the patched line; the Boot 3.x compatibility matrix is
unaffected. Remove once Spring Boot manages jackson-bom >= 3.1.5.

Closes #517

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
