### PR TITLE
feat(guard): variance, allOf/anyOf, mapMessages, narrow, ofCatching, field contramap

### DIFF
--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -1,5 +1,7 @@
 package dmx.fun;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -15,8 +17,9 @@ import org.jspecify.annotations.Nullable;
  * {@code Validated<NonEmptyList<String>, T>}: {@code Valid(value)} when the predicate passes,
  * or {@code Invalid(errors)} when it fails.
  * All composition operators ({@link #and}, {@link #or}, {@link #negate()}, {@link #andThen},
- * {@link #contramap}) are {@code default} methods, so guards can be defined as lambdas and
- * composed without inheritance. The choice to use {@code @FunctionalInterface} with
+ * {@link #contramap}, {@link #withMessage}) are {@code default} methods, so guards can be
+ * defined as lambdas and composed without inheritance; {@link #allOf} and {@link #anyOf}
+ * compose several guards at once. The choice to use {@code @FunctionalInterface} with
  * {@code default} methods rather than an abstract class is documented in
  * <a href="https://domix.github.io/dmx-fun/adr/adr-011-guard-functional-interface/">
  * ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods</a>.
@@ -68,6 +71,14 @@ public interface Guard<T> {
     /**
      * Applies this guard to {@code value}.
      *
+     * <p><strong>Contract:</strong> a guard is a validator, not a transformer — an
+     * implementation must return {@code Valid} of the checked value itself, never a
+     * substituted or normalized one. The composition operators rely on this: they re-wrap the
+     * original input, so any value produced by a contract-violating guard is discarded during
+     * composition. Note also that {@code Valid} rejects {@code null}, so a guard over a
+     * nullable type can never <em>pass</em> a {@code null} value — it must reject it (see
+     * {@link #nonNull()}).
+     *
      * @param value the value to validate
      * @return {@code Valid(value)} if the predicate passes, or
      *         {@code Invalid(errors)} if it fails
@@ -86,8 +97,15 @@ public interface Guard<T> {
      * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
      * }</pre>
      *
+     * <p>The predicate must not throw: any exception it raises escapes {@link #check(Object)}
+     * unwrapped, breaking the contract that a guard always returns a {@link Validated}. For
+     * predicates that would throw on {@code null} input, compose with
+     * {@link #nonNull()}{@code .andThen(...)} so the null check short-circuits first; for
+     * predicates that may throw on other inputs (parsing, regex on malformed data), use
+     * {@link #ofCatching(Predicate, String)}.
+     *
      * @param <T>          the value type
-     * @param predicate    the condition that must hold for the value to be valid
+     * @param predicate    the condition that must hold for the value to be valid; must not throw
      * @param errorMessage the error message produced when the predicate fails
      * @return a new {@code Guard<T>}
      * @throws NullPointerException if {@code predicate} or {@code errorMessage} is {@code null}
@@ -114,8 +132,16 @@ public interface Guard<T> {
      * );
      * }</pre>
      *
+     * <p>The predicate must not throw: any exception it raises escapes {@link #check(Object)}
+     * unwrapped, breaking the contract that a guard always returns a {@link Validated}. For
+     * predicates that would throw on {@code null} input, compose with
+     * {@link #nonNull()}{@code .andThen(...)} so the null check short-circuits first; for
+     * predicates that may throw on other inputs (parsing, regex on malformed data), use
+     * {@link #ofCatching(Predicate, String)}.
+     *
      * @param <T>            the value type
-     * @param predicate      the condition that must hold for the value to be valid
+     * @param predicate      the condition that must hold for the value to be valid; must not
+     *                       throw
      * @param errorMessageFn function that produces an error message from the failing value
      * @return a new {@code Guard<T>}
      * @throws NullPointerException if {@code predicate} or {@code errorMessageFn} is {@code null}
@@ -129,6 +155,182 @@ public interface Guard<T> {
         return value -> predicate.test(value)
             ? Validated.valid(value)
             : Validated.invalidNel(errorMessageFn.apply(value));
+    }
+
+    /**
+     * Creates a {@code Guard<T>} from a predicate that may throw, treating a thrown
+     * {@link RuntimeException} as a failed check.
+     *
+     * <p>Unlike {@link #of(Predicate, String)}, whose predicate must not throw, this factory
+     * preserves the contract that a guard always returns a {@link Validated}: if the predicate
+     * throws a {@code RuntimeException}, the guard returns {@code Invalid([errorMessage])}
+     * exactly as if the predicate had returned {@code false}. {@link Error}s and other
+     * {@link Throwable}s still propagate.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> numeric = Guard.ofCatching(
+     *     s -> Integer.parseInt(s) >= 0,       // parseInt throws on non-numeric input
+     *     "must be a non-negative number");
+     *
+     * numeric.check("42");   // Valid("42")
+     * numeric.check("abc");  // Invalid(["must be a non-negative number"]) — exception folded
+     * }</pre>
+     *
+     * @param <T>          the value type
+     * @param predicate    the condition to evaluate; a thrown {@code RuntimeException} counts
+     *                     as a failure
+     * @param errorMessage the error message produced when the predicate fails or throws
+     * @return a new {@code Guard<T>}
+     * @throws NullPointerException if {@code predicate} or {@code errorMessage} is {@code null}
+     */
+    static <T> Guard<T> ofCatching(Predicate<? super T> predicate, String errorMessage) {
+        Objects.requireNonNull(predicate, "predicate");
+        Objects.requireNonNull(errorMessage, "errorMessage");
+        return value -> {
+            try {
+                return predicate.test(value)
+                    ? Validated.valid(value)
+                    : Validated.invalidNel(errorMessage);
+            } catch (RuntimeException _) {
+                return Validated.invalidNel(errorMessage);
+            }
+        };
+    }
+
+    /**
+     * Creates and returns a Guard instance that ensures a value is non-null.
+     *
+     * @param <T> the type of the value to be guarded
+     * @return a Guard that validates the value is not null
+     */
+    static <T extends @Nullable Object> Guard<T> nonNull() {
+        return Guard.of(Objects::nonNull, "must not be null");
+    }
+
+    /**
+     * Returns a guard that passes only when <em>all</em> of the given guards pass.
+     *
+     * <p>Same semantics as chaining {@link #and(Guard) and}: every guard is always evaluated
+     * and errors from all failing guards are accumulated in order — not fail-fast. The first
+     * parameter is mandatory, so the composition is never empty. Unlike a manual {@code and}
+     * chain, the guards are evaluated in a single pass with one error list.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = Guard.allOf(notBlank, minLength3, alphanumeric);
+     *
+     * username.check("a?");   // Invalid(["must be at least 3 chars", "must be alphanumeric"])
+     * username.check("alice"); // Valid("alice")
+     * }</pre>
+     *
+     * @param <T>   the value type
+     * @param first the first guard; must not be {@code null}
+     * @param rest  the remaining guards; must not be {@code null} or contain {@code null}
+     * @return a composed {@code Guard<T>} requiring every guard to pass
+     * @throws NullPointerException if {@code first}, {@code rest}, or any element is {@code null}
+     */
+    @SafeVarargs
+    static <T> Guard<T> allOf(Guard<? super T> first, Guard<? super T>... rest) {
+        List<Guard<? super T>> guards = collectGuards(first, rest);
+        return value -> {
+            List<String> errors = null;
+            for (Guard<? super T> guard : guards) {
+                var result = guard.check(value);
+                if (result.isInvalid()) {
+                    if (errors == null) {
+                        errors = new ArrayList<>();
+                    }
+                    errors.addAll(result.getError().toList());
+                }
+            }
+            return errors == null ? Validated.valid(value) : Validated.invalid(nel(errors));
+        };
+    }
+
+    /**
+     * Returns a guard that passes when <em>at least one</em> of the given guards passes.
+     *
+     * <p>Same semantics as chaining {@link #or(Guard) or}: evaluation short-circuits on the
+     * first passing guard; if every guard fails, errors from all of them are accumulated in
+     * order. The first parameter is mandatory, so the composition is never empty.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> contact = Guard.anyOf(email, phone);
+     *
+     * contact.check("alice@example.com"); // Valid — phone never evaluated
+     * contact.check("hello");             // Invalid(["must contain @", "must be digits"])
+     * }</pre>
+     *
+     * @param <T>   the value type
+     * @param first the first guard; must not be {@code null}
+     * @param rest  the remaining guards; must not be {@code null} or contain {@code null}
+     * @return a composed {@code Guard<T>} requiring at least one guard to pass
+     * @throws NullPointerException if {@code first}, {@code rest}, or any element is {@code null}
+     */
+    @SafeVarargs
+    static <T> Guard<T> anyOf(Guard<? super T> first, Guard<? super T>... rest) {
+        List<Guard<? super T>> guards = collectGuards(first, rest);
+        return value -> {
+            List<String> errors = new ArrayList<>();
+            for (Guard<? super T> guard : guards) {
+                var result = guard.check(value);
+                if (result.isValid()) {
+                    return Validated.valid(value);
+                }
+                errors.addAll(result.getError().toList());
+            }
+            return Validated.invalid(nel(errors));
+        };
+    }
+
+    /**
+     * Validates and copies the varargs guards into one list at composition time.
+     */
+    @SafeVarargs
+    private static <T> List<Guard<? super T>> collectGuards(
+        Guard<? super T> first,
+        Guard<? super T>... rest
+    ) {
+        Objects.requireNonNull(first, "first");
+        Objects.requireNonNull(rest, "rest");
+        List<Guard<? super T>> guards = new ArrayList<>(rest.length + 1);
+        guards.add(first);
+        for (Guard<? super T> guard : rest) {
+            guards.add(Objects.requireNonNull(guard, "rest must not contain null"));
+        }
+        return guards;
+    }
+
+    /**
+     * Builds a {@code NonEmptyList} from a non-empty accumulation list.
+     */
+    private static NonEmptyList<String> nel(List<String> errors) {
+        return NonEmptyList.of(errors.getFirst(), errors.subList(1, errors.size()));
+    }
+
+    /**
+     * Adapts a {@code Guard<? super T>} to a {@code Guard<T>} by re-wrapping the checked value,
+     * preserving the accumulated errors on failure.
+     *
+     * <p>Use this when assigning or passing a guard written against a supertype where a
+     * {@code Guard<T>} is required outside the variance-aware combinators — the adaptation
+     * cannot be written as a plain lambda because the {@code Validated} value types differ:
+     *
+     * <pre>{@code
+     * Guard<CharSequence> notEmpty = Guard.of(cs -> !cs.isEmpty(), "must not be empty");
+     * Guard<String> forStrings = Guard.narrow(notEmpty);
+     * }</pre>
+     *
+     * @param <T>   the narrower value type
+     * @param guard the guard written against a supertype; must not be {@code null}
+     * @return a {@code Guard<T>} delegating to {@code guard}
+     * @throws NullPointerException if {@code guard} is {@code null}
+     */
+    static <T> Guard<T> narrow(Guard<? super T> guard) {
+        Objects.requireNonNull(guard, "guard");
+        return value -> guard.check(value).map(_ -> value);
     }
 
     // -------------------------------------------------------------------------
@@ -154,11 +356,15 @@ public interface Guard<T> {
      *                          //  — both guards evaluated, both errors collected
      * }</pre>
      *
+     * <p>The parameter is contravariant ({@code Guard<? super T>}), mirroring
+     * {@link Predicate#and(Predicate) Predicate.and}, so a guard written against a supertype
+     * (e.g. {@code Guard<CharSequence>}) can be composed into a {@code Guard<String>}.
+     *
      * @param other the guard that must also pass; must not be {@code null}
      * @return a composed {@code Guard<T>}
      * @throws NullPointerException if {@code other} is {@code null}
      */
-    default Guard<T> and(Guard<T> other) {
+    default Guard<T> and(Guard<? super T> other) {
         Objects.requireNonNull(other, "other");
         return value -> this.check(value)
             .combine(other.check(value), NonEmptyList::concat, (v1, _) -> v1);
@@ -188,15 +394,19 @@ public interface Guard<T> {
      * first result (error accumulation). Use {@code andThen} when the second guard must not
      * run until the first has passed.
      *
+     * <p>The parameter is contravariant ({@code Guard<? super T>}); the composed guard
+     * re-wraps the original value, so the result type stays {@code Guard<T>}.
+     *
      * @param next the guard to evaluate when this guard passes; must not be {@code null}
      * @return a composed {@code Guard<T>}
      * @throws NullPointerException if {@code next} is {@code null}
      */
-    default Guard<T> andThen(Guard<T> next) {
+    default Guard<T> andThen(Guard<? super T> next) {
         Objects.requireNonNull(next, "next");
+        Guard<T> narrowed = narrow(next);
         return value -> {
             var first = this.check(value);
-            return first.isValid() ? next.check(value) : first;
+            return first.isInvalid() ? first : narrowed.check(value);
         };
     }
 
@@ -218,18 +428,23 @@ public interface Guard<T> {
      * contact.check("hello");             // Invalid(["must contain @", "must be digits"])
      * }</pre>
      *
+     * <p>The parameter is contravariant ({@code Guard<? super T>}), mirroring
+     * {@link Predicate#or(Predicate) Predicate.or}; the composed guard re-wraps the original
+     * value, so the result type stays {@code Guard<T>}.
+     *
      * @param other the alternative guard; must not be {@code null}
      * @return a composed {@code Guard<T>}
      * @throws NullPointerException if {@code other} is {@code null}
      */
-    default Guard<T> or(Guard<T> other) {
+    default Guard<T> or(Guard<? super T> other) {
         Objects.requireNonNull(other, "other");
+        Guard<T> narrowed = narrow(other);
         return value -> {
             var left = this.check(value);
             if (left.isValid()) {
                 return left;
             }
-            var right = other.check(value);
+            var right = narrowed.check(value);
             if (right.isValid()) {
                 return right;
             }
@@ -382,10 +597,70 @@ public interface Guard<T> {
      */
     default <U> Guard<U> contramap(Function<? super U, ? extends T> mapper) {
         Objects.requireNonNull(mapper, "mapper");
-        return u -> {
-            var result = this.check(mapper.apply(u));
-            return result.isValid() ? Validated.valid(u) : Validated.invalid(result.getError());
-        };
+        return u -> this.check(mapper.apply(u)).map(_ -> u);
+    }
+
+    /**
+     * Returns a {@code Guard<U>} that applies {@code mapper} to its input before checking,
+     * prefixing every error message with {@code fieldName}.
+     *
+     * <p>Like {@link #contramap(Function)}, but each accumulated error is rewritten as
+     * {@code "fieldName: originalMessage"}, so messages stay unambiguous when several
+     * field-level guards are combined on the same object.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> notBlank = Guard.of(s -> !s.isBlank(), "must not be blank");
+     *
+     * Guard<User> userGuard = Guard.allOf(
+     *     notBlank.contramap(User::username, "username"),
+     *     notBlank.contramap(User::email,    "email"));
+     *
+     * userGuard.check(new User(" ", " "));
+     * // Invalid(["username: must not be blank", "email: must not be blank"])
+     * }</pre>
+     *
+     * @param <U>       the input type of the returned guard
+     * @param mapper    function that extracts the {@code T} value from a {@code U}; must not be
+     *                  {@code null}
+     * @param fieldName prefix identifying the projected field in error messages; must not be
+     *                  {@code null}
+     * @return a new {@code Guard<U>} that projects {@code U → T} before checking and prefixes
+     *         errors with {@code fieldName}
+     * @throws NullPointerException if {@code mapper} or {@code fieldName} is {@code null}
+     */
+    default <U> Guard<U> contramap(Function<? super U, ? extends T> mapper, String fieldName) {
+        Objects.requireNonNull(fieldName, "fieldName");
+        return this.<U>contramap(mapper).mapMessages(message -> fieldName + ": " + message);
+    }
+
+    /**
+     * Returns a guard that rewrites every error message produced by this guard with
+     * {@code transform}, leaving valid results untouched.
+     *
+     * <p>This is the general form behind {@link #contramap(Function, String)}'s field
+     * prefixing — use it directly for any other message convention: nested paths, i18n keys,
+     * suffixes, or structured formats.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = notBlank.and(minLength3)
+     *     .mapMessages(m -> "user.name: " + m);
+     *
+     * username.check("");  // Invalid(["user.name: must not be blank", ...])
+     * }</pre>
+     *
+     * <p>Unlike {@link #withMessage(String)}, which collapses all errors into one fixed
+     * message, {@code mapMessages} transforms each accumulated message individually.
+     *
+     * @param transform function applied to each error message; must not be {@code null} and
+     *                  must not return {@code null}
+     * @return a new {@code Guard<T>} with rewritten error messages
+     * @throws NullPointerException if {@code transform} is {@code null}
+     */
+    default Guard<T> mapMessages(Function<? super String, String> transform) {
+        Objects.requireNonNull(transform, "transform");
+        return value -> this.check(value).mapError(errors -> errors.map(transform));
     }
 
     /**
@@ -427,11 +702,13 @@ public interface Guard<T> {
      *         failure
      * @throws NullPointerException if {@code toError} is {@code null}
      */
-    default <E> Result<T, E> checkToResult(T value, Function<NonEmptyList<String>, E> toError) {
+    default <E> Result<T, E> checkToResult(
+        T value,
+        Function<? super NonEmptyList<String>, ? extends E> toError
+    ) {
         Objects.requireNonNull(toError, "toError");
-        return this.check(value)
-            .mapError(toError)
-            .toResult();
+        Validated<E, T> mapped = this.check(value).mapError(toError);
+        return mapped.toResult();
     }
 
     /**
@@ -451,6 +728,10 @@ public interface Guard<T> {
      *     .toList();
      * // ["alice", "bob"]
      * }</pre>
+     *
+     * <p>A guard can never produce {@code Valid(null)} — {@code Validated.Valid} rejects
+     * {@code null} at construction — so the returned {@code Option} never wraps {@code null};
+     * a guard over a nullable type must reject {@code null} (see {@link #check(Object)}).
      *
      * @param value the value to validate
      * @return {@code Option.some(value)} if the guard passes, or {@code Option.none()} if it
@@ -548,7 +829,7 @@ public interface Guard<T> {
      */
     default <X extends Throwable> Try<T> checkToTry(
         T value,
-        Function<NonEmptyList<String>, X> toThrowable
+        Function<? super NonEmptyList<String>, ? extends X> toThrowable
     ) {
         Objects.requireNonNull(toThrowable, "toThrowable");
         var result = this.check(value);
@@ -572,15 +853,12 @@ public interface Guard<T> {
      * Optional<String> empty   = notBlank.checkToOptional("   ");   // Optional.empty()
      * }</pre>
      *
-     * <p><strong>Not suitable when {@code null} is a valid success value.</strong>
-     * This method calls {@link Optional#of(Object) Optional.of(value)} on the validated value,
-     * which throws {@link NullPointerException} if {@code value} is {@code null}.
-     * Under {@code @NullMarked}, {@code T} is non-null by default, so this is safe for ordinary
-     * guards. However, if {@code T} is a nullable type (e.g., {@code Guard<@Nullable String>})
-     * and the guard can return {@code Valid(null)}, calling this method will throw
-     * {@code NullPointerException}. In that case, use {@link #check(Object) check(value)} and
-     * work with the resulting {@link Validated} directly, applying
-     * {@link Optional#ofNullable(Object)} to the extracted value when needed.
+     * <p>A guard can never produce {@code Valid(null)} — {@code Validated.Valid} rejects
+     * {@code null} at construction — so this method never passes {@code null} to
+     * {@link Optional#of(Object)}; a guard over a nullable type must reject {@code null}
+     * (see {@link #check(Object)}). Note that {@code Optional.of(value)} wraps the
+     * <em>input</em>: for a {@code Guard<@Nullable T>} checking a {@code null} input, the
+     * guard must return {@code Invalid}, which yields {@link Optional#empty()} here.
      *
      * @param value the value to validate
      * @return {@code Optional.of(value)} if the guard passes,
@@ -588,15 +866,5 @@ public interface Guard<T> {
      */
     default Optional<T> checkToOptional(T value) {
         return this.check(value).isValid() ? Optional.of(value) : Optional.empty();
-    }
-
-    /**
-     * Creates and returns a Guard instance that ensures a value is non-null.
-     *
-     * @param <T> the type of the value to be guarded
-     * @return a Guard that validates the value is not null
-     */
-    static <T extends @Nullable Object> Guard<T> nonNull() {
-        return Guard.of(Objects::nonNull, "must not be null");
     }
 }

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -692,4 +692,219 @@ class GuardTest {
         assertThat(combined.getError().toList())
             .containsExactly("must not be blank", "email must contain @");
     }
+
+    // -------------------------------------------------------------------------
+    // combinator variance — Guard<? super T>
+    // -------------------------------------------------------------------------
+
+    Guard<CharSequence> notEmptyCs = Guard.of(cs -> !cs.isEmpty(), "must not be empty");
+
+    @Test
+    void and_acceptsGuardOfSupertype() {
+        Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+
+        Guard<String> username = minLength3.and(notEmptyCs);
+
+        assertThat(username.check("alice").isValid()).isTrue();
+        assertThat(username.check("").getError().toList())
+            .containsExactly("must be at least 3 chars", "must not be empty");
+    }
+
+    @Test
+    void or_acceptsGuardOfSupertype_andRewrapsOriginalValue() {
+        Guard<String> digits = Guard.of(s -> s.matches("\\d+"), "must be digits");
+
+        Guard<String> contact = digits.or(notEmptyCs);
+
+        var valid = contact.check("hello");   // digits fails, notEmptyCs passes
+        assertThat(valid.isValid()).isTrue();
+        assertThat(valid.get()).isEqualTo("hello");
+
+        assertThat(contact.check("").getError().toList())
+            .containsExactly("must be digits", "must not be empty");
+    }
+
+    @Test
+    void andThen_acceptsGuardOfSupertype_andShortCircuits() {
+        var evaluated = new AtomicInteger();
+        Guard<CharSequence> counting = value -> {
+            evaluated.incrementAndGet();
+            return Validated.valid(value);
+        };
+
+        Guard<String> guarded = notBeBlank.andThen(counting);
+
+        assertThat(guarded.check("  ").isValid()).isFalse();
+        assertThat(evaluated.get()).isZero();          // short-circuit preserved
+
+        var valid = guarded.check("alice");
+        assertThat(valid.get()).isEqualTo("alice");    // original value re-wrapped
+        assertThat(evaluated.get()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // allOf / anyOf
+    // -------------------------------------------------------------------------
+
+    @Test
+    void allOf_accumulatesErrorsFromAllFailingGuards() {
+        Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+        Guard<String> alphanumeric = Guard.of(s -> s.matches("\\w+"), "must be alphanumeric");
+
+        Guard<String> username = Guard.allOf(notBeBlank, minLength3, alphanumeric);
+
+        assertThat(username.check("alice").isValid()).isTrue();
+        assertThat(username.check("a?").getError().toList())
+            .containsExactly("must be at least 3 chars", "must be alphanumeric");
+    }
+
+    @Test
+    void allOf_singleGuard_behavesLikeThatGuard() {
+        Guard<String> only = Guard.allOf(notBeBlank);
+
+        assertThat(only.check("alice").isValid()).isTrue();
+        assertThat(only.check("  ").getError().toList()).containsExactly("must not be blank");
+    }
+
+    @Test
+    void allOf_shouldThrowNPE_whenAnyGuardIsNull() {
+        assertThatThrownBy(() -> Guard.allOf(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("first");
+        assertThatThrownBy(() -> Guard.allOf(notBeBlank, (Guard<String>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("rest");
+    }
+
+    @Test
+    void anyOf_shortCircuitsOnFirstPass_andAccumulatesWhenAllFail() {
+        var evaluated = new AtomicInteger();
+        Guard<String> counting = value -> {
+            evaluated.incrementAndGet();
+            return Validated.valid(value);
+        };
+
+        Guard<String> contact = Guard.anyOf(email, counting);
+        assertThat(contact.check("alice@example.com").isValid()).isTrue();
+        assertThat(evaluated.get()).isZero();          // short-circuit preserved
+
+        Guard<String> strict = Guard.anyOf(email, phone);
+        assertThat(strict.check("hello").getError().toList())
+            .containsExactly("must contain @", "must be digits");
+    }
+
+    @Test
+    void anyOf_acceptsGuardsOfSupertype() {
+        Guard<String> contact = Guard.anyOf(notEmptyCs, email);
+
+        var valid = contact.check("hello");
+        assertThat(valid.isValid()).isTrue();
+        assertThat(valid.get()).isEqualTo("hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // contramap with field context
+    // -------------------------------------------------------------------------
+
+    record Account(String username, String email) {}
+
+    @Test
+    void contramap_withFieldName_prefixesEveryError() {
+        Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+
+        Guard<Account> accountGuard = Guard.allOf(
+            notBeBlank.and(minLength3).contramap(Account::username, "username"),
+            email.contramap(Account::email, "email"));
+
+        var invalid = accountGuard.check(new Account("  ", "not-an-email"));
+        assertThat(invalid.getError().toList()).containsExactly(
+            "username: must not be blank",
+            "username: must be at least 3 chars",
+            "email: must contain @");
+
+        var valid = accountGuard.check(new Account("alice", "alice@example.com"));
+        assertThat(valid.isValid()).isTrue();
+        assertThat(valid.get()).isEqualTo(new Account("alice", "alice@example.com"));
+    }
+
+    @Test
+    void contramap_withFieldName_shouldThrowNPE_whenFieldNameIsNull() {
+        assertThatThrownBy(() -> notBeBlank.contramap(Account::username, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("fieldName");
+    }
+
+    // -------------------------------------------------------------------------
+    // mapMessages
+    // -------------------------------------------------------------------------
+
+    @Test
+    void mapMessages_rewritesEachAccumulatedError() {
+        Guard<String> minLength3 = Guard.of(s -> s.length() >= 3, "must be at least 3 chars");
+
+        Guard<String> username = notBeBlank.and(minLength3)
+            .mapMessages(m -> "user.name: " + m);
+
+        assertThat(username.check("  ").getError().toList()).containsExactly(
+            "user.name: must not be blank",
+            "user.name: must be at least 3 chars");
+        assertThat(username.check("alice").isValid()).isTrue();
+    }
+
+    @Test
+    void mapMessages_shouldThrowNPE_whenTransformIsNull() {
+        assertThatThrownBy(() -> notBeBlank.mapMessages(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("transform");
+    }
+
+    // -------------------------------------------------------------------------
+    // ofCatching
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ofCatching_foldsThrownRuntimeExceptionIntoInvalid() {
+        Guard<String> numeric = Guard.ofCatching(
+            s -> Integer.parseInt(s) >= 0,
+            "must be a non-negative number");
+
+        assertThat(numeric.check("42").isValid()).isTrue();
+        assertThat(numeric.check("-1").getError().toList())
+            .containsExactly("must be a non-negative number");
+        assertThat(numeric.check("abc").getError().toList())
+            .containsExactly("must be a non-negative number");   // parseInt threw
+    }
+
+    @Test
+    void ofCatching_shouldThrowNPE_whenArgumentsAreNull() {
+        assertThatThrownBy(() -> Guard.ofCatching(null, "msg"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("predicate");
+        assertThatThrownBy(() -> Guard.ofCatching(s -> true, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("errorMessage");
+    }
+
+    // -------------------------------------------------------------------------
+    // narrow
+    // -------------------------------------------------------------------------
+
+    @Test
+    void narrow_adaptsSupertypeGuard_preservingValueAndErrors() {
+        Guard<String> forStrings = Guard.narrow(notEmptyCs);
+
+        var valid = forStrings.check("hello");
+        assertThat(valid.isValid()).isTrue();
+        assertThat(valid.get()).isEqualTo("hello");
+
+        assertThat(forStrings.check("").getError().toList())
+            .containsExactly("must not be empty");
+    }
+
+    @Test
+    void narrow_shouldThrowNPE_whenGuardIsNull() {
+        assertThatThrownBy(() -> Guard.narrow(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("guard");
+    }
 }

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -23,8 +23,11 @@ a predicate over `T` with an associated error message.
 Applying a guard via `check(value)` returns a
 `Validated<NonEmptyList<String>, T>` — `Valid(value)` when the rule passes,
 or `Invalid(errors)` when it fails.
-All composition operators (`and`, `or`, `negate`, `andThen`, `contramap`) are `default` methods
-on the interface, so guards can be defined as lambdas and composed without inheritance.
+All composition operators (`and`, `or`, `negate`, `andThen`, `contramap`, `withMessage`,
+`mapMessages`) are `default` methods on the interface, so guards can be defined as lambdas and
+composed without inheritance; the static factories `allOf` and `anyOf` compose several guards
+at once. The binary combinators accept `Guard<? super T>`, mirroring `Predicate.and`/`or`, so
+a guard written against a supertype composes into a narrower guard.
 This design decision is documented in <a href={`${base}adr/adr-011-guard-functional-interface`}>ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods</a>.
 
 The error type is fixed as `NonEmptyList<String>` — this keeps composition simple (no external
@@ -40,6 +43,19 @@ rule once as a `Guard` and compose them with `and`, `or`, and `negate`.
 <CreatingGuards/>
 
 Both factory overloads throw `NullPointerException` for `null` predicate or message arguments.
+The predicate itself must not throw — any exception escapes `check()` unwrapped. For a
+predicate that may throw on malformed input (parsing, regex), use
+`Guard.ofCatching(predicate, message)`, which folds a thrown `RuntimeException` into
+`Invalid([message])`:
+
+```java
+Guard<String> numeric = Guard.ofCatching(
+    s -> Integer.parseInt(s) >= 0,        // parseInt throws on non-numeric input
+    "must be a non-negative number");
+
+numeric.check("42");   // Valid("42")
+numeric.check("abc");  // Invalid(["must be a non-negative number"]) — exception folded
+```
 
 ## Built-in guards
 
@@ -89,6 +105,22 @@ If all guards fail, errors from all of them are accumulated.
 Use `or` when a value is allowed to satisfy any one of several alternative formats
 (e.g., email or phone number, UUID or slug).
 
+## `allOf(...)` / `anyOf(...)` — compose several guards at once
+
+Instead of chaining `.and()` or `.or()` calls, the varargs factories compose a set of rules in
+one expression. The first guard is a mandatory parameter, so an empty composition does not
+compile. `allOf` evaluates every guard and accumulates errors from all that fail (same
+semantics as chained `and`, in a single pass); `anyOf` short-circuits on the first pass and
+accumulates every error when all fail (same as chained `or`):
+
+```java
+Guard<String> username = Guard.allOf(notBlank, minLength3, alphanumeric);
+Guard<String> contact  = Guard.anyOf(email, phone);
+
+username.check("a?");             // Invalid(["must be at least 3 chars", "must be alphanumeric"])
+contact.check("alice@acme.com");  // Valid — phone never evaluated
+```
+
 ## `negate()` / `negate(message)` / `negate(messageFromValue)`
 
 Inverts the predicate. Three overloads are available:
@@ -116,6 +148,34 @@ username.check("a");   // Invalid(["invalid username"]) — not "min 3 chars"
 username.check("alice"); // Valid("alice")
 ```
 
+## `mapMessages(transform)`
+
+Rewrites each accumulated error message individually — the general form behind field
+prefixing. Where `withMessage` collapses everything into one fixed message, `mapMessages`
+keeps every error and transforms it:
+
+```java
+Guard<String> username = notBlank.and(minLength3)
+    .mapMessages(m -> "user.name: " + m);
+
+username.check("");  // Invalid(["user.name: must not be blank", "user.name: must be at least 3 chars"])
+```
+
+## `contramap(fn)` and `contramap(fn, fieldName)`
+
+`contramap` adapts a field-level guard to validate the enclosing object. The `fieldName`
+overload additionally prefixes each error with the field name, so accumulated messages stay
+unambiguous when several field guards are combined on one object:
+
+```java
+Guard<Account> accountGuard = Guard.allOf(
+    notBlank.contramap(Account::username, "username"),
+    email.contramap(Account::email, "email"));
+
+accountGuard.check(new Account(" ", "oops"));
+// Invalid(["username: must not be blank", "email: must contain @"])
+```
+
 ## Integrating with `Validated.combine`
 
 Guards produce `Validated<NonEmptyList<String>, T>` values, which compose naturally with
@@ -136,8 +196,11 @@ Validated<NonEmptyList<String>, Form> form =
 | Method                             | Returns                           | Use case                                                                |
 |------------------------------------|-----------------------------------|-------------------------------------------------------------------------|
 | `withMessage(message)`             | `Guard<T>`                        | Replace all errors with one fixed message (hides internal rule details) |
+| `mapMessages(transform)`           | `Guard<T>`                        | Rewrite each error message (prefixes, i18n keys, structured formats)    |
 | `asPredicate()`                    | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
 | `contramap(fn)`                    | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
+| `contramap(fn, fieldName)`         | `Guard<U>`                        | Same, prefixing each error with the field name                          |
+| `Guard.narrow(guard)`              | `Guard<T>`                        | Adapt a `Guard<? super T>` where a `Guard<T>` is required               |
 | `checkToResult(value)`             | `Result<T, NonEmptyList<String>>` | Direct integration into Result-based domain logic                       |
 | `checkToResult(value, mapper)`     | `Result<T, E>`                    | Map errors to a domain-specific error type at service boundaries        |
 | `checkToEither(value)`             | `Either<NonEmptyList<String>, T>` | Integrate with Either-based pipelines (left = errors, right = value)    |


### PR DESCRIPTION
Widen and/or/andThen to accept Guard<? super T>, mirroring Predicate,
and document the check() contract this relies on: a guard validates, it
does not transform, so composition re-wraps the original value. Add
single-pass allOf/anyOf varargs factories (mandatory first guard, one
error list, no nested-chain allocation), a general mapMessages operator
with contramap(mapper, fieldName) as its field-prefixing one-liner, a
public Guard.narrow adapter for supertype guards, and Guard.ofCatching
to fold throwing predicates into Invalid instead of escaping check().

Widen checkToResult/checkToTry mappers to JDK-conventional wildcards,
correct the checkToOption/checkToOptional notes (Valid(null) is
unconstructible), move nonNull() next to the factories, and sync the
Guard guide page with the new API surface.

Closes #506

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe guard creation that converts runtime predicate failures into validation errors.
  * Added support for composing guards across compatible types.
  * Added field-aware error prefixing and customizable error-message mapping.
  * Expanded guard composition with `allOf` and `anyOf`, including error accumulation and short-circuiting.
* **Documentation**
  * Added guidance and examples for guard composition, exception handling, message mapping, type adaptation, and interoperability.
* **Tests**
  * Added coverage for new guard factories, combinators, variance support, error handling, and null validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->