### PR TITLE
feat(guard): add name()/named() with decorator-preserving propagation

### DIFF
--- a/core/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
+++ b/core/assertj/src/main/java/dmx/fun/assertj/GuardAssert.java
@@ -1,6 +1,7 @@
 package dmx.fun.assertj;
 
 import dmx.fun.Guard;
+import dmx.fun.NonEmptyList;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -17,6 +18,21 @@ public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, G
         super(actual, GuardAssert.class);
     }
 
+    /** Renders the guard's identity for failure messages: "Guard 'name'" or plain "Guard". */
+    private String guardLabel() {
+        return actual.isNamed() ? "Guard '" + actual.name() + "'" : "Guard";
+    }
+
+    /** Shared reject preamble: fails unless the guard rejects {@code value}; returns the errors. */
+    private NonEmptyList<String> checkRejected(T value) {
+        isNotNull();
+        var result = actual.check(value);
+        if (!result.isInvalid()) {
+            throw buildError("Expected %s to reject <%s> but accepted it", guardLabel(), value);
+        }
+        return result.getError();
+    }
+
     /**
      * Verifies that the guard accepts (validates successfully) the given value.
      *
@@ -27,8 +43,8 @@ public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, G
         isNotNull();
         var result = actual.check(value);
         if (!result.isValid()) {
-            throw buildError("Expected Guard to accept <%s> but rejected it with <%s>",
-                value, result.getError());
+            throw buildError("Expected %s to accept <%s> but rejected it with <%s>",
+                guardLabel(), value, result.getError());
         }
         return this;
     }
@@ -40,11 +56,7 @@ public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, G
      * @return this assertion for chaining
      */
     public GuardAssert<T> rejects(T value) {
-        isNotNull();
-        var result = actual.check(value);
-        if (!result.isInvalid()) {
-            throw buildError("Expected Guard to reject <%s> but accepted it", value);
-        }
+        checkRejected(value);
         return this;
     }
 
@@ -57,16 +69,7 @@ public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, G
      * @return this assertion for chaining
      */
     public GuardAssert<T> rejectsWithMessage(T value, String message) {
-        isNotNull();
-        var result = actual.check(value);
-        if (!result.isInvalid()) {
-            throw buildError("Expected Guard to reject <%s> but accepted it", value);
-        }
-        var errors = result.getError();
-        if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
-            throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
-        }
-        return this;
+        return rejectsWithMessages(value, message);
     }
 
     /**
@@ -78,15 +81,11 @@ public final class GuardAssert<T> extends AbstractDmxFunAssert<GuardAssert<T>, G
      * @return this assertion for chaining
      */
     public GuardAssert<T> rejectsWithMessages(T value, String... messages) {
-        isNotNull();
-        var result = actual.check(value);
-        if (!result.isInvalid()) {
-            throw buildError("Expected Guard to reject <%s> but accepted it", value);
-        }
-        var errors = result.getError();
+        var errors = checkRejected(value);
         for (String message : messages) {
             if (errors.toList().stream().noneMatch(e -> e.contains(message))) {
-                throw buildError("Expected rejection messages <%s> to contain <%s>", errors, message);
+                throw buildError("Expected %s rejection messages <%s> to contain <%s>",
+                    guardLabel(), errors, message);
             }
         }
         return this;

--- a/core/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
+++ b/core/assertj/src/test/java/dmx/fun/assertj/GuardAssertTest.java
@@ -109,4 +109,31 @@ class GuardAssertTest {
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("[my guard]");
     }
+
+    // ── named guards in failure messages ──────────────────────────────────────
+
+    @Test
+    void shouldRenderGuardName_inAcceptAndRejectFailures() {
+        var named = ALPHANUMERIC.named("username");
+
+        assertThatThrownBy(() -> assertThat(named).accepts("!!"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Expected Guard 'username' to accept");
+
+        assertThatThrownBy(() -> assertThat(named).rejects("alice"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Expected Guard 'username' to reject");
+
+        assertThatThrownBy(() -> assertThat(named).rejectsWithMessage("!!", "no such message"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Expected Guard 'username' rejection messages");
+    }
+
+    @Test
+    void shouldRenderPlainGuard_forAnonymousGuards() {
+        assertThatThrownBy(() -> assertThat(ALPHANUMERIC).accepts("!!"))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Expected Guard to accept")
+            .hasMessageNotContaining("Guard '");
+    }
 }

--- a/core/lib/src/main/java/dmx/fun/Guard.java
+++ b/core/lib/src/main/java/dmx/fun/Guard.java
@@ -19,7 +19,8 @@ import org.jspecify.annotations.Nullable;
  * All composition operators ({@link #and}, {@link #or}, {@link #negate()}, {@link #andThen},
  * {@link #contramap}, {@link #withMessage}) are {@code default} methods, so guards can be
  * defined as lambdas and composed without inheritance; {@link #allOf} and {@link #anyOf}
- * compose several guards at once. The choice to use {@code @FunctionalInterface} with
+ * compose several guards at once. For logging and metrics, {@link #named(String)} attaches a
+ * descriptive identity retrievable via {@link #name()}. The choice to use {@code @FunctionalInterface} with
  * {@code default} methods rather than an abstract class is documented in
  * <a href="https://domix.github.io/dmx-fun/adr/adr-011-guard-functional-interface/">
  * ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods</a>.
@@ -330,6 +331,14 @@ public interface Guard<T> {
      */
     static <T> Guard<T> narrow(Guard<? super T> guard) {
         Objects.requireNonNull(guard, "guard");
+        return keepName(guard, narrowRaw(guard));
+    }
+
+    /**
+     * The adaptation behind {@link #narrow} without name preservation — used internally by
+     * the composition operators, whose result is anonymous anyway.
+     */
+    private static <T> Guard<T> narrowRaw(Guard<? super T> guard) {
         return value -> guard.check(value).map(_ -> value);
     }
 
@@ -403,7 +412,7 @@ public interface Guard<T> {
      */
     default Guard<T> andThen(Guard<? super T> next) {
         Objects.requireNonNull(next, "next");
-        Guard<T> narrowed = narrow(next);
+        Guard<T> narrowed = narrowRaw(next);
         return value -> {
             var first = this.check(value);
             return first.isInvalid() ? first : narrowed.check(value);
@@ -438,7 +447,7 @@ public interface Guard<T> {
      */
     default Guard<T> or(Guard<? super T> other) {
         Objects.requireNonNull(other, "other");
-        Guard<T> narrowed = narrow(other);
+        Guard<T> narrowed = narrowRaw(other);
         return value -> {
             var left = this.check(value);
             if (left.isValid()) {
@@ -484,9 +493,9 @@ public interface Guard<T> {
      */
     default Guard<T> negate(String errorMessage) {
         Objects.requireNonNull(errorMessage, "errorMessage");
-        return value -> this.check(value).isValid()
+        return keepName(this, value -> this.check(value).isValid()
             ? Validated.invalidNel(errorMessage)
-            : Validated.valid(value);
+            : Validated.valid(value));
     }
 
     /**
@@ -511,9 +520,9 @@ public interface Guard<T> {
      */
     default Guard<T> negate(Function<? super T, String> messageFromValue) {
         Objects.requireNonNull(messageFromValue, "messageFromValue");
-        return value -> this.check(value).isValid()
+        return keepName(this, value -> this.check(value).isValid()
             ? Validated.invalidNel(messageFromValue.apply(value))
-            : Validated.valid(value);
+            : Validated.valid(value));
     }
 
     /**
@@ -538,9 +547,112 @@ public interface Guard<T> {
      */
     default Guard<T> withMessage(String message) {
         Objects.requireNonNull(message, "message");
-        return value -> this.check(value).isValid()
+        return keepName(this, value -> this.check(value).isValid()
             ? Validated.valid(value)
-            : Validated.invalidNel(message);
+            : Validated.invalidNel(message));
+    }
+
+    // -------------------------------------------------------------------------
+    // Naming / observability
+    // -------------------------------------------------------------------------
+
+    /**
+     * The name reported by {@link #name()} for guards that were never {@link #named(String)}.
+     */
+    String ANONYMOUS = "anonymous";
+
+    /**
+     * Returns a descriptive name for this guard, for logging and metrics.
+     *
+     * <p>Guards are anonymous by default; use {@link #named(String)} to attach a name. The
+     * name identifies <em>which guard</em> was applied — a different piece of information
+     * from the error messages, which say <em>which rule</em> was violated. It never alters
+     * {@link #check(Object)} results or error messages.
+     *
+     * <p><strong>Note for implementors:</strong> this is a {@code default} method on a
+     * public interface. A class implementing {@code Guard} that already declares its own
+     * {@code String name()} accessor — a record with a {@code name} component, say —
+     * silently overrides this method, and that value will surface wherever guard names are
+     * logged or tagged. Rename such a component or override {@code name()} deliberately.
+     *
+     * @return the guard's name, or {@link #ANONYMOUS} when none was assigned
+     */
+    default String name() {
+        return ANONYMOUS;
+    }
+
+    /**
+     * Returns {@code true} when this guard carries a name assigned via {@link #named(String)}
+     * (or an overridden {@link #name()}), {@code false} for anonymous guards.
+     *
+     * <p>Lets observability code skip or bucket unnamed guards without comparing against the
+     * {@link #ANONYMOUS} literal.
+     *
+     * @return whether this guard has a non-default name
+     */
+    default boolean isNamed() {
+        return !ANONYMOUS.equals(name());
+    }
+
+    /**
+     * Returns a guard with the same {@link #check(Object)} behavior carrying a descriptive
+     * name, retrievable via {@link #name()}.
+     *
+     * <p><strong>Name propagation.</strong> Operators that decorate this same guard —
+     * {@link #withMessage}, {@link #mapMessages}, {@link #negate()}, {@link #contramap} and
+     * {@link #narrow} — preserve the name. Operators that <em>compose</em> guards —
+     * {@link #and}, {@link #or}, {@link #andThen}, {@link #allOf}, {@link #anyOf} — produce a
+     * new anonymous guard, so name the composite after composing. The rationale is documented
+     * in <a href="https://domix.github.io/dmx-fun/adr/adr-024-guard-naming/">ADR-024 — Guard
+     * naming</a>.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Guard<String> username = notBlank.and(minLength3).and(alphanumeric)
+     *     .named("username");
+     *
+     * var result = username.check(input);
+     * if (result.isInvalid()) {
+     *     log.warn("guard '{}' failed: {}", username.name(), result.getError().toList());
+     * }
+     * }</pre>
+     *
+     * @param name the descriptive name; must not be {@code null}, blank, or the
+     *             {@link #ANONYMOUS} sentinel (a guard named {@code "anonymous"} would be
+     *             indistinguishable from an unnamed one)
+     * @return a guard delegating to this one, with the given name
+     * @throws NullPointerException     if {@code name} is {@code null}
+     * @throws IllegalArgumentException if {@code name} is blank or equals {@link #ANONYMOUS}
+     */
+    default Guard<T> named(String name) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (ANONYMOUS.equals(name)) {
+            throw new IllegalArgumentException(
+                "name must not be the reserved \"" + ANONYMOUS + "\" sentinel");
+        }
+        var self = this;
+        return new Guard<>() {
+            @Override
+            public Validated<NonEmptyList<String>, T> check(T value) {
+                return self.check(value);
+            }
+
+            @Override
+            public String name() {
+                return name;
+            }
+        };
+    }
+
+    /**
+     * Re-attaches {@code source}'s name to {@code decorated} when one was assigned — the
+     * single propagation site behind every unary decorator and {@link #narrow}.
+     */
+    private static <U> Guard<U> keepName(Guard<?> source, Guard<U> decorated) {
+        return source.isNamed() ? decorated.named(source.name()) : decorated;
     }
 
     // -------------------------------------------------------------------------
@@ -597,7 +709,7 @@ public interface Guard<T> {
      */
     default <U> Guard<U> contramap(Function<? super U, ? extends T> mapper) {
         Objects.requireNonNull(mapper, "mapper");
-        return u -> this.check(mapper.apply(u)).map(_ -> u);
+        return keepName(this, u -> this.check(mapper.apply(u)).map(_ -> u));
     }
 
     /**
@@ -630,8 +742,11 @@ public interface Guard<T> {
      * @throws NullPointerException if {@code mapper} or {@code fieldName} is {@code null}
      */
     default <U> Guard<U> contramap(Function<? super U, ? extends T> mapper, String fieldName) {
+        Objects.requireNonNull(mapper, "mapper");
         Objects.requireNonNull(fieldName, "fieldName");
-        return this.<U>contramap(mapper).mapMessages(message -> fieldName + ": " + message);
+        return keepName(this, u -> this.check(mapper.apply(u))
+            .map(_ -> u)
+            .mapError(errors -> errors.map(message -> fieldName + ": " + message)));
     }
 
     /**
@@ -660,7 +775,7 @@ public interface Guard<T> {
      */
     default Guard<T> mapMessages(Function<? super String, String> transform) {
         Objects.requireNonNull(transform, "transform");
-        return value -> this.check(value).mapError(errors -> errors.map(transform));
+        return keepName(this, value -> this.check(value).mapError(errors -> errors.map(transform)));
     }
 
     /**
@@ -776,7 +891,9 @@ public interface Guard<T> {
      *
      * <p>Returns {@code Try.success(value)} when the guard passes. When it fails, the
      * accumulated error messages are joined with {@code "; "} and wrapped in an
-     * {@link IllegalArgumentException}. Use {@link #checkToTry(Object, Function)} to supply
+     * {@link IllegalArgumentException}; for a {@link #named(String) named} guard the message
+     * is prefixed with {@code "guard 'name': "} so the failure stays traceable after the
+     * {@code Try} propagates. Use {@link #checkToTry(Object, Function)} to supply
      * a domain-specific exception instead.
      *
      * <p>Example:
@@ -798,7 +915,8 @@ public interface Guard<T> {
         return checkToTry(
             value,
             errors -> new IllegalArgumentException(
-                String.join("; ", errors.toList())
+                (isNamed() ? "guard '" + name() + "': " : "")
+                    + String.join("; ", errors.toList())
             )
         );
     }

--- a/core/lib/src/test/java/dmx/fun/GuardTest.java
+++ b/core/lib/src/test/java/dmx/fun/GuardTest.java
@@ -907,4 +907,105 @@ class GuardTest {
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("guard");
     }
+
+    // -------------------------------------------------------------------------
+    // name / named
+    // -------------------------------------------------------------------------
+
+    @Test
+    void name_isAnonymousByDefault() {
+        assertThat(notBeBlank.name()).isEqualTo(Guard.ANONYMOUS);
+        assertThat(notBeBlank.isNamed()).isFalse();
+    }
+
+    @Test
+    void named_attachesName_withoutChangingCheckBehavior() {
+        var shorterThan10 = Guard.<String>of(s -> s.length() < 10, "must be shorter than 10");
+        Guard<String> username = notBeBlank.and(shorterThan10).named("username");
+
+        assertThat(username.name()).isEqualTo("username");
+        assertThat(username.isNamed()).isTrue();
+        assertThat(username.check("alice").isValid()).isTrue();
+        assertThat(username.check("  ").getError().toList())
+            .containsExactly("must not be blank");
+    }
+
+    @Test
+    void named_lastApplicationWins() {
+        Guard<String> guard = notBeBlank.named("first").named("second");
+
+        assertThat(guard.name()).isEqualTo("second");
+    }
+
+    @Test
+    void named_isNotPropagatedByCompositionOperators() {
+        Guard<String> named = notBeBlank.named("notBlank");
+
+        assertThat(named.and(email).name()).isEqualTo(Guard.ANONYMOUS);
+        assertThat(named.or(email).name()).isEqualTo(Guard.ANONYMOUS);
+        assertThat(named.andThen(email).name()).isEqualTo(Guard.ANONYMOUS);
+        assertThat(Guard.allOf(named, email).name()).isEqualTo(Guard.ANONYMOUS);
+        assertThat(Guard.anyOf(named, email).name()).isEqualTo(Guard.ANONYMOUS);
+    }
+
+    @Test
+    void named_isPreservedByUnaryDecorators() {
+        Guard<String> named = notBeBlank.named("notBlank");
+
+        assertThat(named.withMessage("bad").name()).isEqualTo("notBlank");
+        assertThat(named.mapMessages(m -> "x: " + m).name()).isEqualTo("notBlank");
+        assertThat(named.negate().name()).isEqualTo("notBlank");
+        assertThat(named.negate("must be blank").name()).isEqualTo("notBlank");
+        assertThat(named.contramap(User::name).name()).isEqualTo("notBlank");
+        assertThat(named.contramap(User::name, "name").name()).isEqualTo("notBlank");
+        assertThat(Guard.<String>narrow(named).name()).isEqualTo("notBlank");
+
+        // decorators on an anonymous guard stay anonymous
+        assertThat(notBeBlank.withMessage("bad").name()).isEqualTo(Guard.ANONYMOUS);
+    }
+
+    @Test
+    void named_preservedDecorator_keepsDecoratedBehavior() {
+        Guard<String> named = notBeBlank.mapMessages(m -> "user.name: " + m).named("username");
+        Guard<String> decorated = named.withMessage("invalid username");
+
+        assertThat(decorated.name()).isEqualTo("username");
+        assertThat(decorated.check("  ").getError().toList())
+            .containsExactly("invalid username");
+    }
+
+    @Test
+    void named_shouldThrowNPE_whenNameIsNull() {
+        assertThatThrownBy(() -> notBeBlank.named(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("name");
+    }
+
+    @Test
+    void named_shouldThrowIAE_whenNameIsBlank() {
+        assertThatThrownBy(() -> notBeBlank.named("   "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("blank");
+    }
+
+    @Test
+    void named_shouldThrowIAE_whenNameIsTheAnonymousSentinel() {
+        assertThatThrownBy(() -> notBeBlank.named(Guard.ANONYMOUS))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("anonymous");
+    }
+
+    @Test
+    void checkToTry_includesGuardNameInDefaultException_whenNamed() {
+        Guard<String> named = notBeBlank.named("username");
+
+        var failure = named.checkToTry("  ");
+        assertThat(failure.isFailure()).isTrue();
+        assertThat(failure.getCause().getMessage())
+            .isEqualTo("guard 'username': must not be blank");
+
+        var anonymousFailure = notBeBlank.checkToTry("  ");
+        assertThat(anonymousFailure.getCause().getMessage())
+            .isEqualTo("must not be blank");
+    }
 }

--- a/docs/adr/ADR-011-guard-functional-interface.md
+++ b/docs/adr/ADR-011-guard-functional-interface.md
@@ -28,3 +28,8 @@ date: 2026-05-05
 
 - **Abstract class `AbstractGuard<T>`:** allows `final` on composition methods but prevents lambda usage and multiple inheritance.
 - **Concrete class `Guard<T>` with a `Function` field:** more rigid, not extensible as an interface.
+
+## Amendments
+
+- Amended by [ADR-024 — Guard naming](https://domix.github.io/dmx-fun/adr/adr-024-guard-naming/): `name()`/`named(String)` refine
+  the "no state" consequence to *no state affecting `check`*.

--- a/docs/adr/ADR-024-guard-naming.md
+++ b/docs/adr/ADR-024-guard-naming.md
@@ -1,0 +1,73 @@
+---
+number: 24
+title: "Guard naming: name()/named() with decorator-preserving propagation"
+status: Accepted
+date: 2026-07-26
+---
+
+## Context
+
+When a guard fails, its accumulated error messages say *which rule* was violated, but nothing
+identifies *which guard* was being applied. Logs and metrics need that identity once guards
+are composed, passed around, or registered in validation pipelines ([issue #507](https://github.com/domix/dmx-fun/issues/507)).
+
+`Guard<T>` is a `@FunctionalInterface` ([ADR-011](https://domix.github.io/dmx-fun/adr/adr-011-guard-functional-interface/)), so it
+cannot carry a field; any identity mechanism must fit through default methods with `check` as
+the single abstract method.
+
+## Decision
+
+- **`default String name()`** returns the guard's identity, defaulting to the public constant
+  **`Guard.ANONYMOUS`** (`"anonymous"`); **`default boolean isNamed()`** distinguishes named
+  guards without comparing against the literal.
+- **`default Guard<T> named(String)`** returns a wrapper that delegates `check` verbatim and
+  overrides `name()`. It rejects `null`, blank names, and the `ANONYMOUS` sentinel itself — a
+  nameless name would defeat the feature, and a guard literally named `"anonymous"` would be
+  indistinguishable from an unnamed one for `isNamed()` and every propagation decision.
+- **Name propagation follows the shape of the operation:**
+  - *Unary decorators preserve the name* — `withMessage`, `mapMessages`, `negate`,
+    `contramap`, and `Guard.narrow` decorate the same logical guard, so a named field guard
+    keeps its identity through a `contramap` lift.
+  - *Composition operators produce anonymous guards* — `and`, `or`, `andThen`, `allOf`,
+    `anyOf` combine several guards into a new one; the composite is named explicitly, after
+    composing. No automatic name-combining (`"a+b"`) is attempted.
+- The name is identity metadata only: it never alters `check` results or error messages, and
+  stays orthogonal to `withMessage` and to `contramap`'s `fieldName` prefix (which rewrite
+  messages; `name()` never does). The one observability surface where the name does reach a
+  message is `checkToTry(value)`'s default `IllegalArgumentException`, prefixed with
+  `guard 'name': ` for named guards — a `Try.failure` often propagates far from the call site
+  that knew which guard ran.
+
+## Consequences
+
+**Positive:**
+- Failures become traceable: `log.warn("guard '{}' failed", guard.name())`, and
+  `fun-assertj`'s `GuardAssert` renders `Expected Guard 'email' to accept ...`.
+- Observability integrations can tag metrics by guard name and use `isNamed()` to skip or
+  bucket unnamed guards without hardcoding the sentinel.
+- Lambdas keep working unchanged; `check` remains the single abstract method.
+
+**Negative / tradeoffs:**
+- This refines ADR-011's "no state" consequence: it now reads as **no state affecting
+  `check`** — a named guard carries identity metadata. Overriding the `name()` default via
+  `named(...)` is the sanctioned pattern; overriding composition logic remains a misuse.
+- `name()` is a common accessor name: an external class implementing `Guard` that already
+  declares `String name()` with different semantics silently overrides the default and leaks
+  that value into logs/metrics (documented on `name()`).
+- Each preserved-name decoration adds one thin delegation wrapper.
+
+## Alternatives considered
+
+- **`Optional<String> name()`:** more honest about absence, but every logging call site pays
+  an unwrap, and the sentinel plus `isNamed()` covers the same need with plainer call sites.
+- **Automatic name combination in composition (`"notBlank+minLength3"`):** complexity nobody
+  asked for; composite names are better chosen by the author.
+- **Propagating names through composition from the left operand:** makes `a.and(b)` report
+  `a`'s name for a guard that is no longer `a` — misleading in exactly the logs the feature
+  exists for.
+- **A `Guard.of(predicate, message, name)` overload:** redundant; `.named()` already covers
+  creation-time naming.
+
+## Related
+
+- Amends [ADR-011 — Guard&lt;T&gt; as a @FunctionalInterface with default methods](https://domix.github.io/dmx-fun/adr/adr-011-guard-functional-interface/).

--- a/samples/samples/src/main/java/dmx/fun/samples/blog/PaymentResult.java
+++ b/samples/samples/src/main/java/dmx/fun/samples/blog/PaymentResult.java
@@ -1,0 +1,11 @@
+package dmx.fun.samples.blog;
+
+import java.time.Instant;
+
+public sealed interface PaymentResult {
+    record Captured(String reference)        implements PaymentResult {}
+    record Declined(String reason)           implements PaymentResult {}
+    record Pending(Instant retryAfter)       implements PaymentResult {}
+
+
+}

--- a/samples/samples/src/main/java/dmx/fun/samples/blog/Util.java
+++ b/samples/samples/src/main/java/dmx/fun/samples/blog/Util.java
@@ -1,0 +1,11 @@
+package dmx.fun.samples.blog;
+
+public class Util {
+    String describe(PaymentResult r) {
+        return switch (r) {                          // compiler enforces every case
+            case PaymentResult.Captured c -> "captured " + c.reference();
+            case PaymentResult.Declined d -> "declined: " + d.reason();
+            case PaymentResult.Pending p  -> "retry after " + p.retryAfter();
+        };
+    }
+}

--- a/site/src/data/guide/guard.mdx
+++ b/site/src/data/guide/guard.mdx
@@ -176,6 +176,35 @@ accountGuard.check(new Account(" ", "oops"));
 // Invalid(["username: must not be blank", "email: must contain @"])
 ```
 
+## `named(name)` / `name()` — identity for logs and metrics
+
+When a guard fails, the error messages say *which rule* was violated; the name says *which
+guard* was being applied — different information, and the one you need when guards are passed
+around or registered in pipelines. Guards report `Guard.ANONYMOUS` (`"anonymous"`) until
+`named` attaches an identity; `isNamed()` distinguishes the two without comparing literals.
+The name never touches check behavior or messages:
+
+```java
+Guard<String> username = notBlank.and(minLength3).named("username");
+
+username.name();                     // "username"
+notBlank.name();                     // "anonymous" (Guard.ANONYMOUS)
+username.named("login").name();      // "login" — last application wins
+```
+
+Name propagation follows the shape of the operation:
+
+- **Unary decorators preserve the name** — `withMessage`, `mapMessages`, `negate`,
+  `contramap`, and `Guard.narrow` decorate the *same* logical guard, so
+  `username.contramap(Form::username).name()` is still `"username"`.
+- **Composition produces a new, anonymous guard** — `and`, `or`, `andThen`, `allOf`, `anyOf`
+  combine several guards, so name the composite after composing.
+
+`named` rejects `null`, blank names, and the literal `"anonymous"` (it would be
+indistinguishable from an unnamed guard). The name surfaces automatically in `fun-assertj`
+failure messages (`Expected Guard 'username' to accept ...`) and in `checkToTry`'s default
+exception (`guard 'username': must not be blank`).
+
 ## Integrating with `Validated.combine`
 
 Guards produce `Validated<NonEmptyList<String>, T>` values, which compose naturally with
@@ -197,6 +226,7 @@ Validated<NonEmptyList<String>, Form> form =
 |------------------------------------|-----------------------------------|-------------------------------------------------------------------------|
 | `withMessage(message)`             | `Guard<T>`                        | Replace all errors with one fixed message (hides internal rule details) |
 | `mapMessages(transform)`           | `Guard<T>`                        | Rewrite each error message (prefixes, i18n keys, structured formats)    |
+| `named(name)` / `name()`           | `Guard<T>` / `String`             | Attach/read a descriptive identity for logging and metrics              |
 | `asPredicate()`                    | `Predicate<T>`                    | `Stream.filter`, `Collection.removeIf`, any standard Java predicate API |
 | `contramap(fn)`                    | `Guard<U>`                        | Adapt a field guard to validate the enclosing object type               |
 | `contramap(fn, fieldName)`         | `Guard<U>`                        | Same, prefixing each error with the field name                          |


### PR DESCRIPTION
A failing guard's messages say which rule was violated but nothing
identifies which guard was applied. Add name() (defaulting to the
public Guard.ANONYMOUS constant), isNamed(), and a named() decorator
that rejects null, blank, and the reserved "anonymous" sentinel,
keeping check as the single abstract method per ADR-011.

Unary decorators (withMessage, mapMessages, negate, contramap, narrow)
preserve the name through a single static keepName propagation site,
while composition operators (and, or, andThen, allOf, anyOf) return
anonymous guards named after composing; the composition internals use
an unnamed narrow variant so no unobservable wrappers are allocated.
The name surfaces in GuardAssert failure messages (including the
message-mismatch branch) and in checkToTry's default exception.

The design is recorded in new ADR-024 (propagation rules, sentinel
reservation, and rejected alternatives), which amends ADR-011 by
scoping its "no state" consequence to check behavior. Follow-up for
fun-micrometer/fun-observation tagging tracked in #521.

Closes #507

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional names for guards to make validation failures, logs, and metrics easier to identify.
  * Guard names are preserved through decorators and can be accessed through the guard API.
  * Added a sample payment result model with captured, declined, and pending outcomes.

* **Improvements**
  * Assertion failure messages now include guard names when available.
  * Updated sample documentation and examples for guard naming and result handling.

* **Documentation**
  * Added guidance describing guard naming behavior and propagation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->