### PR TITLE
feat(site): show post counters next to blog categories

### DIFF
--- a/site/src/pages/blog/category/[category]/index.astro
+++ b/site/src/pages/blog/category/[category]/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../../../../layouts/DocsLayout.astro';
 import { calculateReadingTime, formatReadingTime } from '../../../../utils/readingTime';
 import Pagination from '../../../../components/Pagination.astro';
-import { PAGE_SIZE, normalizeCategorySlug } from '../../../../utils/blog';
+import { PAGE_SIZE, normalizeCategorySlug, countByCategory } from '../../../../utils/blog';
 
 export async function getStaticPaths() {
   const { PAGE_SIZE, normalizeCategorySlug } = await import('../../../../utils/blog');
@@ -29,6 +29,8 @@ export async function getStaticPaths() {
 const base = import.meta.env.BASE_URL;
 const { pagePosts, category, totalPages, allCategories } = Astro.props;
 const categorySlug = normalizeCategorySlug(category);
+const allPostsForCounts = await getCollection('blog');
+const categoryCounts = countByCategory(allPostsForCounts);
 ---
 
 <DocsLayout title={`${category} - Blog`} description={`Articles about ${category}`}>
@@ -41,18 +43,19 @@ const categorySlug = normalizeCategorySlug(category);
     </a>
     <h1>{category}</h1>
     <p class="blog-subtitle">
-      Page 1 of {totalPages}
+      {categoryCounts.get(category)} posts · Page 1 of {totalPages}
     </p>
   </div>
 
   <div class="blog-filters">
-    <a href={`${base}blog`} class="filter-btn">All Posts</a>
+    <a href={`${base}blog`} class="filter-btn" aria-label={`All posts, ${allPostsForCounts.length} posts`}>All Posts<span class="filter-count" aria-hidden="true">{allPostsForCounts.length}</span></a>
     {allCategories.map(cat => (
       <a
         href={`${base}blog/category/${normalizeCategorySlug(cat)}`}
         class={`filter-btn ${cat === category ? 'active' : ''}`}
+        aria-label={`${cat}, ${categoryCounts.get(cat)} posts`}
       >
-        {cat}
+        {cat}<span class="filter-count" aria-hidden="true">{categoryCounts.get(cat)}</span>
       </a>
     ))}
   </div>
@@ -158,6 +161,23 @@ const categorySlug = normalizeCategorySlug(category);
     transition: all 0.2s ease;
     font-weight: 500;
     font-size: 0.875rem;
+  }
+
+
+  .filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.45rem;
+    padding: 0 0.45em;
+    min-width: 1.6em;
+    height: 1.6em;
+    border-radius: 999px;
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    font-variant-numeric: tabular-nums;
   }
 
   .filter-btn:hover {

--- a/site/src/pages/blog/category/[category]/page/[page].astro
+++ b/site/src/pages/blog/category/[category]/page/[page].astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../../../../../layouts/DocsLayout.astro';
 import { calculateReadingTime, formatReadingTime } from '../../../../../utils/readingTime';
 import Pagination from '../../../../../components/Pagination.astro';
-import { PAGE_SIZE, normalizeCategorySlug } from '../../../../../utils/blog';
+import { PAGE_SIZE, normalizeCategorySlug, countByCategory } from '../../../../../utils/blog';
 
 export async function getStaticPaths() {
   const { PAGE_SIZE, normalizeCategorySlug } = await import('../../../../../utils/blog');
@@ -38,6 +38,8 @@ export async function getStaticPaths() {
 const base = import.meta.env.BASE_URL;
 const { pagePosts, category, currentPage, totalPages, allCategories } = Astro.props;
 const categorySlug = normalizeCategorySlug(category);
+const allPostsForCounts = await getCollection('blog');
+const categoryCounts = countByCategory(allPostsForCounts);
 ---
 
 <DocsLayout title={`${category} — Page ${currentPage} - Blog`} description={`Articles about ${category}`}>
@@ -50,18 +52,19 @@ const categorySlug = normalizeCategorySlug(category);
     </a>
     <h1>{category}</h1>
     <p class="blog-subtitle">
-      Page {currentPage} of {totalPages}
+      {categoryCounts.get(category)} posts · Page {currentPage} of {totalPages}
     </p>
   </div>
 
   <div class="blog-filters">
-    <a href={`${base}blog`} class="filter-btn">All Posts</a>
+    <a href={`${base}blog`} class="filter-btn" aria-label={`All posts, ${allPostsForCounts.length} posts`}>All Posts<span class="filter-count" aria-hidden="true">{allPostsForCounts.length}</span></a>
     {allCategories.map(cat => (
       <a
         href={`${base}blog/category/${normalizeCategorySlug(cat)}`}
         class={`filter-btn ${cat === category ? 'active' : ''}`}
+        aria-label={`${cat}, ${categoryCounts.get(cat)} posts`}
       >
-        {cat}
+        {cat}<span class="filter-count" aria-hidden="true">{categoryCounts.get(cat)}</span>
       </a>
     ))}
   </div>
@@ -167,6 +170,23 @@ const categorySlug = normalizeCategorySlug(category);
     transition: all 0.2s ease;
     font-weight: 500;
     font-size: 0.875rem;
+  }
+
+
+  .filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.45rem;
+    padding: 0 0.45em;
+    min-width: 1.6em;
+    height: 1.6em;
+    border-radius: 999px;
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    font-variant-numeric: tabular-nums;
   }
 
   .filter-btn:hover {

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import { calculateReadingTime, formatReadingTime } from '../../utils/readingTime';
 import Pagination from '../../components/Pagination.astro';
-import { PAGE_SIZE, FIRST_PAGE_SIZE, normalizeCategorySlug } from '../../utils/blog';
+import { PAGE_SIZE, FIRST_PAGE_SIZE, normalizeCategorySlug, countByCategory } from '../../utils/blog';
 
 const base = import.meta.env.BASE_URL;
 
@@ -18,6 +18,7 @@ const gridPosts = pagePosts.slice(1);
 const heroReadingTime = heroPost ? formatReadingTime(calculateReadingTime(heroPost.body)) : '';
 
 const categories = [...new Set(allPosts.map(post => post.data.category))];
+const categoryCounts = countByCategory(allPosts);
 ---
 
 <DocsLayout title="Blog" description="Articles, tutorials, and insights about functional programming in Java">
@@ -38,10 +39,11 @@ const categories = [...new Set(allPosts.map(post => post.data.category))];
   </div>
 
   <div class="blog-filters">
-    <a href={`${base}blog`} class="filter-btn active">All Posts</a>
+    <a href={`${base}blog`} class="filter-btn active" aria-label={`All posts, ${allPosts.length} posts`}>All Posts<span class="filter-count" aria-hidden="true">{allPosts.length}</span></a>
     {categories.map(category => (
-      <a href={`${base}blog/category/${normalizeCategorySlug(category)}`} class="filter-btn">
-        {category}
+      <a href={`${base}blog/category/${normalizeCategorySlug(category)}`} class="filter-btn"
+         aria-label={`${category}, ${categoryCounts.get(category)} posts`}>
+        {category}<span class="filter-count" aria-hidden="true">{categoryCounts.get(category)}</span>
       </a>
     ))}
   </div>
@@ -185,6 +187,23 @@ const categories = [...new Set(allPosts.map(post => post.data.category))];
     transition: border-color 0.15s, color 0.15s, background-color 0.15s;
     font-weight: 500;
     font-size: 0.8rem;
+  }
+
+
+  .filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.45rem;
+    padding: 0 0.45em;
+    min-width: 1.6em;
+    height: 1.6em;
+    border-radius: 999px;
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    font-variant-numeric: tabular-nums;
   }
 
   .filter-btn:hover {

--- a/site/src/pages/blog/page/[page].astro
+++ b/site/src/pages/blog/page/[page].astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
 import { calculateReadingTime, formatReadingTime } from '../../../utils/readingTime';
 import Pagination from '../../../components/Pagination.astro';
-import { PAGE_SIZE, FIRST_PAGE_SIZE, normalizeCategorySlug } from '../../../utils/blog';
+import { PAGE_SIZE, FIRST_PAGE_SIZE, normalizeCategorySlug, countByCategory } from '../../../utils/blog';
 
 export async function getStaticPaths() {
   const { PAGE_SIZE, FIRST_PAGE_SIZE } = await import('../../../utils/blog');
@@ -29,6 +29,8 @@ export async function getStaticPaths() {
 
 const base = import.meta.env.BASE_URL;
 const { pagePosts, currentPage, totalPages, categories } = Astro.props;
+const allPostsForCounts = await getCollection('blog');
+const categoryCounts = countByCategory(allPostsForCounts);
 ---
 
 <DocsLayout title={`Blog — Page ${currentPage}`} description="Articles, tutorials, and insights about functional programming in Java">
@@ -48,10 +50,11 @@ const { pagePosts, currentPage, totalPages, categories } = Astro.props;
   </div>
 
   <div class="blog-filters">
-    <a href={`${base}blog`} class="filter-btn active">All Posts</a>
+    <a href={`${base}blog`} class="filter-btn active" aria-label={`All posts, ${allPostsForCounts.length} posts`}>All Posts<span class="filter-count" aria-hidden="true">{allPostsForCounts.length}</span></a>
     {categories.map(category => (
-      <a href={`${base}blog/category/${normalizeCategorySlug(category)}`} class="filter-btn">
-        {category}
+      <a href={`${base}blog/category/${normalizeCategorySlug(category)}`} class="filter-btn"
+         aria-label={`${category}, ${categoryCounts.get(category)} posts`}>
+        {category}<span class="filter-count" aria-hidden="true">{categoryCounts.get(category)}</span>
       </a>
     ))}
   </div>
@@ -167,6 +170,23 @@ const { pagePosts, currentPage, totalPages, categories } = Astro.props;
     transition: all 0.2s ease;
     font-weight: 500;
     font-size: 0.875rem;
+  }
+
+
+  .filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.45rem;
+    padding: 0 0.45em;
+    min-width: 1.6em;
+    height: 1.6em;
+    border-radius: 999px;
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    font-variant-numeric: tabular-nums;
   }
 
   .filter-btn:hover {

--- a/site/src/utils/blog.ts
+++ b/site/src/utils/blog.ts
@@ -6,3 +6,12 @@ export const FIRST_PAGE_SIZE = PAGE_SIZE + 1;
 export function normalizeCategorySlug(category: string): string {
   return category.toLowerCase().replaceAll(' ', '-');
 }
+
+/** Post count per category, for the counters shown next to category names. */
+export function countByCategory(posts: { data: { category: string } }[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const post of posts) {
+    counts.set(post.data.category, (counts.get(post.data.category) ?? 0) + 1);
+  }
+  return counts;
+}


### PR DESCRIPTION
Filter buttons carry per-category counts as pill badges
that inherit button state via currentColor, category
headers show totals, and each button gets a full-phrase
aria-label with the visual badge hidden from screen
readers. Counts derive at build time from a shared
countByCategory helper.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.
