### PR TITLE
docs(blog): add substitution model post

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -90,7 +90,7 @@
 66. ~~Closures and variable capture explained for Java developers~~
 67. Expressions over statements: why functional code avoids `void`
 68. Recursion vs iteration: tail calls, stack safety, and the JVM
-69. The substitution model: evaluating code in your head
+69. ~~The substitution model: evaluating code in your head~~
 70. Total vs partial functions: making every input return a value
 
 ### Working with the core types

--- a/site/src/data/blog/substitution-model-evaluating-code-in-your-head.md
+++ b/site/src/data/blog/substitution-model-evaluating-code-in-your-head.md
@@ -32,7 +32,9 @@ cosmetic. It is a property you either protect or lose.
 
 ## The model in action: reduction as reading
 
-Take a small pure pricing calculation:
+Take a small pure pricing calculation — with `prices` an immutable snapshot
+(`List.of`-style), stable for the duration of the evaluation, since a list someone else can
+mutate mid-reduction would smuggle time back in:
 
 ```java
 static BigDecimal subtotal(List<BigDecimal> prices) {
@@ -115,10 +117,13 @@ refactorings are substitution-model moves:
 - **Inline variable** replaces a name with its defining expression.
 - **Extract variable** replaces repeated expressions with a name bound once.
 
-Both claim to preserve behavior. Both actually *do* preserve behavior only when the
-expression is pure. Inline a variable bound to `subtotalCounted(prices)` used twice, and the
-counter now increments twice — the IDE performed a textually correct, semantically wrong
-transformation, because the code stepped outside the region where substitution is valid.
+Both claim to preserve behavior, and both actually do so exactly when the transformation
+leaves evaluation *count, order, and timing* unchanged — which purity makes unconditionally
+true, and impurity makes a case-by-case gamble. Inlining a variable used once can be safe
+even for an impure expression (one evaluation before, one after); inline a variable bound to
+`subtotalCounted(prices)` used *twice*, and the counter now increments twice — the IDE
+performed a textually correct, semantically wrong transformation, because the evaluation
+count changed and the code had stepped outside the region where substitution is valid.
 Some IDEs flag the obvious cases, but the machine cannot warn you *reliably* — purity is
 undecidable in general — so the model is ultimately in your head.
 
@@ -129,10 +134,13 @@ and it is safe on exactly the functions where the model applies. Equational reas
 a proof technique you deploy on special occasions; it is the invisible license behind every
 refactoring you do on autopilot.
 
-Testing makes the same claim: asserting `total([10,10], 0.16)` equals `23.20` *is* a
-substitution claim — that the call and the value are interchangeable. It holds for the pure
-version and silently fails to mean that for the counted one, whose call is not equivalent to
-any value.
+Testing is adjacent, with a precision worth keeping: asserting `total([10,10], 0.16)`
+equals `23.20` verifies one observed result — it does not by itself prove the call and the
+value are interchangeable. For the pure version, that one observation *extends* to
+interchangeability, because nothing about the call varies between evaluations. For the
+counted version the same assertion passes just as green — while saying nothing about the
+mutation of `calls`; establishing substitutability there would require checking repeated
+evaluation and effects, which is exactly the extra work purity spares your test suite.
 
 ---
 

--- a/site/src/data/blog/substitution-model-evaluating-code-in-your-head.md
+++ b/site/src/data/blog/substitution-model-evaluating-code-in-your-head.md
@@ -1,0 +1,181 @@
+---
+title: "The Substitution Model: Evaluating Code in Your Head"
+description: "There is a reason you can verify algebra on a chalkboard but need a debugger for a service method: algebra lets you replace equals with equals, step by step, without losing the meaning. The substitution model is that same move applied to code — the mental evaluator that pure functional programs permit and side-effecting programs break. Here is how the technique works, where it stops working, and why your IDE's safest refactorings depend on it."
+pubDate: 2026-08-07
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Article"
+tags: ["Substitution Model", "Equational Reasoning", "Pure Functions", "Functional Programming", "Java", "Core Concepts", "SICP"]
+image: "https://images.pexels.com/photos/6238297/pexels-photo-6238297.jpeg?auto=compress&cs=tinysrgb&w=1200"
+imageCredit:
+    author: "Monstera Production"
+    authorUrl: "https://www.pexels.com/@gabby-k/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/photo/equations-written-on-blackboard-6238297/"
+---
+
+When you simplify `2x + 3x` to `5x` on a chalkboard, you are running an evaluator in your
+head. Its single rule is the one algebra is built on: **you may replace any expression with
+another expression equal to it, anywhere, without changing the meaning of the whole.** You
+never ask *when* `2x` will be computed, or *how many times*, or what happened *before* it —
+equality is all there is.
+
+The **substitution model** — the name comes from
+[*Structure and Interpretation of Computer Programs*](https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/full-text/book/book-Z-H-10.html),
+which uses it as the first model of evaluation a programmer should own — is that same rule
+applied to programs: to evaluate a function call, substitute the arguments into the body, and
+keep substituting until only a value remains. It is the mental evaluator this post wants to
+put in your toolbox, because whether it works on *your* code is neither automatic nor
+cosmetic. It is a property you either protect or lose.
+
+---
+
+## The model in action: reduction as reading
+
+Take a small pure pricing calculation:
+
+```java
+static BigDecimal subtotal(List<BigDecimal> prices) {
+    return prices.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+}
+
+static BigDecimal withTax(BigDecimal amount, BigDecimal rate) {
+    return amount.add(amount.multiply(rate));
+}
+
+static BigDecimal total(List<BigDecimal> prices, BigDecimal rate) {
+    return withTax(subtotal(prices), rate);
+}
+```
+
+To understand a call — say, two ten-peso items at a 16% rate — you do not need a debugger, a
+heap, or a timeline. You reduce it like the chalkboard expression, replacing equals with
+equals:
+
+```text
+total([10, 10], 0.16)
+= withTax(subtotal([10, 10]), 0.16)      // substitute total's body
+= withTax(20, 0.16)                      // subtotal of the list is 20
+= 20 + (20 × 0.16)                       // withTax's body, BigDecimal calls as arithmetic
+= 23.20
+```
+
+Each line *means the same thing* as the previous one. You can stop at any step and hold a
+true statement. You can go inside-out or outside-in and arrive at the same place — provided
+every subexpression terminates; totality is a topic of its own. And the
+reduction is complete — nothing about the program's past or future was needed, because pure
+expressions have no past or future, only a value.
+
+This is the reading mode functional style buys. A
+[`Result` pipeline](/dmx-fun/blog/railway-oriented-programming-in-java) reduces the same way
+— replace the chain up to any point with "either this `Ok` or that `Err`" and keep going —
+which is why long compositions stay
+[predictable](/dmx-fun/blog/predictable-code-with-fp) where equivalent imperative flows
+require simulating a machine.
+
+---
+
+## Where the model breaks — and what you lose
+
+Now one small change:
+
+```java
+static int calls = 0;
+
+static BigDecimal subtotalCounted(List<BigDecimal> prices) {
+    calls++;                              // one side effect
+    return prices.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+}
+```
+
+Substitution just died. `subtotalCounted([10, 10])` and its value `20` are no longer
+interchangeable: replacing the call with `20` changes `calls`; duplicating the call — which
+substitution freely permits — increments it twice. Suddenly *when* and *how many times* an
+expression evaluates is part of its meaning, and the chalkboard rule "replace equals with
+equals" produces wrong answers. To reason about the effectful version you must abandon the
+substitution model for the machine model: heap state, evaluation order, time. That is not a
+harder version of the same reading — it is a different and strictly heavier activity, the one
+that [pure functions](/dmx-fun/blog/pure-functions-and-side-effects) exist to spare you.
+
+The boundary is precise, and it has a name: an expression that can be replaced by its value
+without changing the program's meaning is *referentially transparent*. The
+[pure-functions post](/dmx-fun/blog/pure-functions-and-side-effects) approaches that property
+from the definition side; this post is about what it licenses as a reading technique, and the
+term itself deserves — and will get — a treatment of its own. Purity is the precondition, not
+a style preference — every effect you push to the edges enlarges the region of your program
+that can be read like algebra instead of simulated like a machine.
+
+---
+
+## You already trust this model — your IDE does too
+
+Here is the everyday proof that this is not academic. Two of your IDE's most-used
+refactorings are substitution-model moves:
+
+- **Inline variable** replaces a name with its defining expression.
+- **Extract variable** replaces repeated expressions with a name bound once.
+
+Both claim to preserve behavior. Both actually *do* preserve behavior only when the
+expression is pure. Inline a variable bound to `subtotalCounted(prices)` used twice, and the
+counter now increments twice — the IDE performed a textually correct, semantically wrong
+transformation, because the code stepped outside the region where substitution is valid.
+Some IDEs flag the obvious cases, but the machine cannot warn you *reliably* — purity is
+undecidable in general — so the model is ultimately in your head.
+
+The same is true of the transformations you perform without a tool: reordering two
+computations, hoisting one out of a loop, deduplicating a repeated call, replacing a call
+with a cached value — [memoization is just substitution rehearsed at runtime](/dmx-fun/blog/lazy-evaluation-when-it-helps),
+and it is safe on exactly the functions where the model applies. Equational reasoning is not
+a proof technique you deploy on special occasions; it is the invisible license behind every
+refactoring you do on autopilot.
+
+Testing makes the same claim: asserting `total([10,10], 0.16)` equals `23.20` *is* a
+substitution claim — that the call and the value are interchangeable. It holds for the pure
+version and silently fails to mean that for the counted one, whose call is not equivalent to
+any value.
+
+---
+
+## Using it deliberately
+
+Three habits turn the model from theory into a daily instrument:
+
+- **Read pipelines by reduction, not simulation.** When a composed expression confuses you,
+  reduce a subexpression to its value on paper — replace `parse(raw)` with "an
+  `Ok(config)` or an `Err(malformed)`" and continue outward. If you find yourself unable to
+  do that — because some step's meaning depends on when it runs — you have located the
+  effect, and probably [the bug's habitat](/dmx-fun/blog/why-avoid-mutable-state).
+- **Treat "can I inline this?" as a purity detector.** If mentally inlining or duplicating a
+  call makes you nervous, the call has effects; the nervousness is the model telling you
+  where its territory ends. That line is exactly where
+  [functional core meets imperative shell](/dmx-fun/blog/should-all-business-logic-be-pure).
+- **Write code you can reduce.** Prefer expressions that return values over statements that
+  change things, and keep effects at the edges — which is the honest content of the claim
+  that functional code is "easier to reason about": not a mood, a *mechanical procedure* you
+  can actually run in your head.
+
+The chalkboard is the point. A production codebase will never be all algebra — the shell has
+to touch the world — but every function you keep pure is a function whose behavior you can
+verify the way you verified `2x + 3x = 5x`: by substitution, at a glance, with no machine in
+sight.
+
+---
+
+## Further reading
+
+- [SICP §1.1 — The Elements of Programming](https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/full-text/book/book-Z-H-10.html)
+  — the original presentation of the substitution model.
+- [Pure Functions and Side Effects](/dmx-fun/blog/pure-functions-and-side-effects) — the
+  precondition: what qualifies code for substitution in the first place.
+- [How to Write More Predictable Code with Functional Programming](/dmx-fun/blog/predictable-code-with-fp)
+  — the working-programmer payoff of code that reduces.
+- [Railway-Oriented Programming in Java](/dmx-fun/blog/railway-oriented-programming-in-java)
+  — reading `Result` pipelines as reducible expressions.
+- [Why Avoid Mutable State?](/dmx-fun/blog/why-avoid-mutable-state) — what the machine model
+  costs once substitution stops applying.
+- [Declarative vs Imperative: How the Mindset Changes](/dmx-fun/blog/declarative-vs-imperative-mindset)
+  — the same divide seen from the style side.
+
+---
+
+*Found a bug or have a suggestion? Open an issue on [GitHub](https://github.com/domix/dmx-fun).*


### PR DESCRIPTION
Plan item 69. The chalkboard rule as a mental evaluator:
step-by-step reduction, the one-line side effect that
kills it, and IDE inline/extract as substitution moves.
Names referential transparency once (deep dive reserved
for item 5), scopes confluence to terminating expressions.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blog article explaining the substitution model for evaluating pure functional code, including examples, practical guidance, testing considerations, and further reading.

* **Documentation**
  * Marked “The substitution model” as completed in the learning plan.
  * Expanded learning resources covering referential transparency, side effects, memoization, refactoring, and practical techniques for understanding functional programs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->