### PR TITLE
docs(blog): add selling fp to stakeholders post

### DIFF
--- a/site/src/content/plan.md
+++ b/site/src/content/plan.md
@@ -147,7 +147,7 @@
 
 103. ~~A practical learning path for functional programming in Java~~
 104. Onboarding a developer to a functional codebase
-105. Selling functional programming to skeptical stakeholders
+105. ~~Selling functional programming to skeptical stakeholders~~
 106. Functional thinking as a career skill, not a language feature
 
 ### More reflective and opinionated topics

--- a/site/src/data/blog/selling-fp-to-skeptical-stakeholders.md
+++ b/site/src/data/blog/selling-fp-to-skeptical-stakeholders.md
@@ -1,0 +1,162 @@
+---
+title: "Selling Functional Programming to Skeptical Stakeholders"
+description: "Nobody at a street market buys a philosophy of produce. They buy what is on the table, at the price on the card, after picking it up and looking at it. Yet engineers routinely pitch functional programming the opposite way — paradigm first, evidence later, price undisclosed. Here is the honest sales technique: translate the technique into the listener's ledger, price the ask small enough to inspect, and concede the failure modes before the skeptic finds them."
+pubDate: 2026-08-14
+author: "domix"
+authorImage: "https://gravatar.com/avatar/797a8fc41feef42d4bc41aff8cecb986d6f3fbbc157e49a65b2d5a5b6cd42640?s=200"
+category: "Article"
+tags: ["Functional Programming", "Teams", "Adoption", "Stakeholders", "Communication", "Engineering Culture", "Java"]
+image: "https://images.pexels.com/photos/10697692/pexels-photo-10697692.jpeg?auto=compress&cs=tinysrgb&w=1200"
+imageCredit:
+    author: "Helena Jankovičová Kováčová"
+    authorUrl: "https://www.pexels.com/@helen1/"
+    source: "Pexels"
+    sourceUrl: "https://www.pexels.com/photo/outdoors-market-on-city-square-10697692/"
+---
+
+Look at the market stall in the photo: goods laid out where anyone can inspect them, prices
+on handwritten cards, a vendor who expects you to pick things up before you pay. No stall
+sells "a philosophy of produce." The transaction works because the buyer can see what they
+are getting, what it costs, and can walk away.
+
+Now compare the way functional programming usually gets pitched inside a company: paradigm
+first, vocabulary the listener does not share, benefits asserted rather than shown, cost
+undisclosed, and — fatally — no way to walk away, because the proposal arrives as a
+conviction rather than an offer. Stakeholders decline, and here is the uncomfortable part:
+**declining is the rational response to that pitch.** The people you are trying to convince
+have survived several waves of "this changes everything." Their skepticism is not ignorance;
+it is accumulated experience of paradigm pitches whose costs were real and whose benefits
+were vibes.
+
+So this post is not about overcoming skeptics. It is about making an offer a rational
+skeptic can accept — which turns out to be the same discipline as the market stall: show
+the goods, price them plainly, let the buyer inspect.
+
+---
+
+## Stop selling the paradigm
+
+"We should adopt functional programming" is a losing sentence in any room where someone
+owns a budget or a roadmap. The listener hears: retraining cost, hiring constraint,
+schedule risk, and one engineer's enthusiasm — and they are right to hear that, because
+the sentence names a *means* and asks them to fund it on faith.
+
+Stakeholders do not buy means. They buy changes in outcomes they already care about:
+incidents, delivery speed, support load, the cost of changing the system next quarter.
+The entire sales job is translation — from the technique you want to use to the ledger
+they already keep. The good news: for functional programming in Java, the translation is
+unusually direct, because the strongest arguments are
+[operational, not aesthetic](/dmx-fun/blog/real-world-cases-where-fp-adds-value).
+
+Three translations that survive contact with a skeptical room:
+
+- **"Sealed error types with exhaustive handling"** translates to: *a category of
+  production incident becomes a build failure.* When a payment gateway grows a new failure
+  mode, the code that has not decided what to do about it stops compiling — instead of
+  retrying declined cards nightly until someone reads the right log. The
+  [error-type post](/dmx-fun/blog/designing-a-good-error-type) has the mechanics; the
+  ledger entry is "incident class moved to compile time."
+- **"Validation that accumulates errors"** translates to: *users stop abandoning the form
+  on the third resubmission, and "your form won't accept my data" tickets drop.* One
+  response [listing everything wrong](/dmx-fun/blog/validated-accumulating-errors) instead
+  of one error per round-trip — measurable in a funnel you already track.
+- **"Immutability and pure functions"** translates to: *the intermittently-wrong-totals
+  bug cannot fire, and changes get cheaper to review* — when no computation writes what
+  another reads, a whole family of race conditions is gone
+  [by construction](/dmx-fun/blog/functional-concurrency-parallel-work-without-shared-state),
+  not by vigilance.
+
+Notice what the translations have in common: each names an outcome the listener can
+verify without trusting you. That is the standard the pitch has to meet — every claim
+checkable, no claim resting on "trust me, it's cleaner."
+
+---
+
+## Price the ask small
+
+The second half of the market-stall discipline: a price card the buyer considers cheap
+enough to risk. The paradigm pitch fails partly because its implicit price is enormous —
+"rewrite our practices" — and enormous prices demand proof you do not yet have, locally.
+So structure the ask as a pilot with these properties:
+
+- **One boundary, not the codebase.** Pick a single seam where the pain already lives —
+  the flaky integration, the validation endpoint with the abandonment problem. The
+  [legacy-adoption post](/dmx-fun/blog/introducing-fp-into-legacy-codebase) covers picking
+  seams; the point here is that "one adapter" is a price a skeptic can pay.
+- **No new language, no exotic dependency.** This is modern Java: records, sealed types,
+  pattern matching, streams — plus, at most,
+  [a small library of value types](/dmx-fun/blog/library-vs-habits). You are hiring the
+  same Java developers afterward. Much of it is
+  [JDK-only](/dmx-fun/blog/jdk-first-functional-programming), which reduces the pitch's
+  dependency surface to nearly zero.
+- **Metric agreed before, not after.** Whatever the pain was — incident count, ticket
+  volume, time-to-change on that module — write it down *with the stakeholder* before the
+  pilot starts. A benefit measured against a pre-registered baseline is evidence; a benefit
+  discovered afterward is advocacy.
+- **Timeboxed and reversible.** A seam refactor that took three weeks and can be reverted
+  is an experiment. Anything that cannot be walked away from is not an offer, it is a
+  hostage situation — and stakeholders can smell the difference.
+
+And one artifact outsells every slide deck: **a diff in their own repository.** A small
+pull request showing the before and after of a real bug class — the swallowed exception
+that became an exhaustive `switch` — is concrete in a way no conference talk can be. The
+goods, on the table, available for inspection.
+
+---
+
+## Concede the failure modes first
+
+The strongest move available to you in a skeptical room is the one evangelists never make:
+name the conditions under which the technique loses, before anyone asks.
+
+Functional style *can* make code worse — a passthrough CRUD service gains ceremony, not
+safety, from wrapping everything in `Result`;
+[this blog has a whole post on the failure modes](/dmx-fun/blog/when-making-it-functional-makes-it-worse).
+Combinator-dense code *can* slow reviews in a team that has not built the reading skill
+yet. Purity crusades *do* burn political capital that the incremental version would have
+banked — [pragmatism beats purism](/dmx-fun/blog/pragmatic-fp-vs-academic-purism) in
+exactly this arena. Saying so out loud does two things: it makes your positive claims
+credible by contrast, and it converts the skeptic's objections from ammunition against you
+into scope agreements with you — "right, so we won't apply it there."
+
+The remaining objections have short honest answers. *"The team doesn't know FP"* — the
+pilot uses Java features the team is already expected to learn; the training cost is
+bounded and visible in the diff. *"We tried a big idea before and it hurt"* — which is why
+this one is scoped, measured, and killable. *"What about performance"* — measured on the
+pilot, like everything else; the
+[data-processing post](/dmx-fun/blog/streams-immutable-collections-efficient-data-processing)
+covers where the costs actually live.
+
+And if the pilot misses its metric: say so, plainly, and stop. It feels like losing; it is
+the opposite. The engineer who reports a failed experiment accurately is the engineer
+whose *next* proposal gets funded — credibility compounds across asks, and it is worth
+more than any single technique. A team that adopted functional programming because the
+evidence held is durable; a team that adopted it because an enthusiast wore them down
+reverts the moment the enthusiast changes jobs.
+
+The market stall, one last time: the vendor who lets you inspect the fruit, quotes the
+real price, and points out which crates are yesterday's — that vendor gets your business
+for years. Sell the way they sell.
+
+---
+
+## Further reading
+
+- [Real-World Cases Where Functional Programming Actually Adds Value](/dmx-fun/blog/real-world-cases-where-fp-adds-value)
+  — the evidence pack this pitch draws on: five incident-shaped cases.
+- [Fearless Change: Patterns for Introducing New Ideas](https://www.informit.com/store/fearless-change-patterns-for-introducing-new-ideas-9780201741575)
+  by Mary Lynn Manns and Linda Rising — the classic catalog of organizational-change
+  patterns, most of which this post is quietly applying.
+- [Driving Technical Change](https://pragprog.com/titles/trevan/driving-technical-change/)
+  by Terrence Ryan — a field guide to skeptic archetypes and what each one actually needs
+  to hear.
+- [How to Introduce Functional Programming into a Legacy Codebase](/dmx-fun/blog/introducing-fp-into-legacy-codebase)
+  — the technical playbook for the pilot itself.
+- [Functional Programming in Java Without Losing Pragmatism](/dmx-fun/blog/functional-programming-in-java-without-losing-pragmatism)
+  — the tone that keeps the political capital intact.
+- [When "Making It Functional" Actually Makes the Code Worse](/dmx-fun/blog/when-making-it-functional-makes-it-worse)
+  — the concessions that make the rest of the pitch believable.
+
+---
+
+*Found a bug or have a suggestion? Open an issue on [GitHub](https://github.com/domix/dmx-fun).*


### PR DESCRIPTION
Pitch as translation to the stakeholder ledger: outcomes
over paradigm, small pre-measured pilot, concede failure
modes first.

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an article explaining how to present functional programming in terms of measurable business outcomes.
  * Included practical pilot recommendations, stakeholder objection responses, examples, and further reading.

* **Documentation**
  * Marked the related functional programming topic as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->