### PR TITLE
feat(core): add NonFatal and Try.rethrowFatal

### DIFF
--- a/core/lib/src/main/java/dmx/fun/NonFatal.java
+++ b/core/lib/src/main/java/dmx/fun/NonFatal.java
@@ -1,12 +1,15 @@
 package dmx.fun;
 
+import java.util.ArrayDeque;
 import java.util.Objects;
+import java.util.concurrent.CompletionException;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Predicate that classifies a {@link Throwable} as <em>non-fatal</em> — safe to capture,
- * map, and recover from as an ordinary failure value — or <em>fatal</em>, signaling a
- * condition that should propagate rather than travel through a pipeline.
+ * The library's fatal-throwable policy: classifies a {@link Throwable} as
+ * <em>non-fatal</em> — safe to capture, map, and recover from as an ordinary failure
+ * value — or <em>fatal</em>, signaling a condition that should propagate rather than
+ * travel through a pipeline.
  *
  * <p>The fatal set is:
  * <ul>
@@ -22,14 +25,29 @@ import org.jspecify.annotations.NullMarked;
  * {@code ThreadDeath} and {@code ControlThrowable} — the former is deprecated for
  * removal and no longer thrown by the JVM, and the latter has no Java analogue.
  *
- * <p>Note that this checks only the given throwable, not its cause chain. Borders that
- * need chain-aware handling (interruption in particular often arrives wrapped as another
- * exception's cause) should use {@link Try#rethrowFatal()}.
+ * <p>{@link java.util.concurrent.CancellationException} is deliberately non-fatal,
+ * even though it also signals cancellation: it is the library's own convention to
+ * surface a cancelled future as an ordinary failure value
+ * ({@link Try#fromFuture(java.util.concurrent.CompletableFuture) Try.fromFuture}
+ * manufactures exactly that), and unlike {@link InterruptedException} it carries no
+ * thread-local interrupt flag that swallowing would lose.
+ *
+ * <p>{@link #check(Throwable)} classifies only the given throwable. Borders that need
+ * chain-aware handling (interruption in particular often arrives wrapped as another
+ * exception's cause) should use {@link #rethrowIfFatal(Throwable)} or
+ * {@link Try#rethrowFatal()}.
  *
  * @see Try#rethrowFatal()
  */
 @NullMarked
 public final class NonFatal {
+
+    /**
+     * Backstop against unbounded throwable graphs: cause cycles in the allocation-free
+     * linear walk, and {@code getCause()} overrides that synthesize a fresh instance
+     * per call.
+     */
+    private static final int VISIT_CAP = 1000;
 
     private NonFatal() {
     }
@@ -46,5 +64,94 @@ public final class NonFatal {
         return !(throwable instanceof VirtualMachineError
             || throwable instanceof LinkageError
             || throwable instanceof InterruptedException);
+    }
+
+    /**
+     * Rethrows {@code throwable} if it — or any throwable reachable through its cause
+     * chain and suppressed exceptions — is fatal per {@link #check(Throwable)};
+     * otherwise returns normally.
+     *
+     * <p>If an {@link InterruptedException} is reachable, the current thread's
+     * interrupt flag is set before anything is thrown — note this <em>propagates</em>
+     * the interruption to the calling thread, which is not necessarily the thread the
+     * exception was raised on. A fatal {@link Error} takes priority and is rethrown
+     * as-is. Otherwise an interruption is rethrown unchecked: as {@code throwable}
+     * itself when it already is a {@link CompletionException} (not wrapped again), and
+     * as {@code new CompletionException(throwable)} otherwise — the full original
+     * graph stays reachable through the cause.
+     *
+     * <p>Traversal is bounded at {@value #VISIT_CAP} throwables — a backstop against
+     * cause cycles and hostile {@code getCause()} overrides — so a fatal parked beyond
+     * that bound goes undetected. The dominant shapes — a plain cause chain, or one
+     * level of suppressed exceptions as parked by {@link Resource} — are traversed
+     * without allocating; a worklist is built only when a suppressed throwable
+     * carries a graph of its own.
+     *
+     * @param throwable the throwable to inspect; must not be {@code null}
+     * @throws NullPointerException if {@code throwable} is {@code null}
+     * @throws Error                if a fatal {@code Error} is reachable within the
+     *                              traversal bound
+     * @throws CompletionException  if an {@link InterruptedException} is reachable and
+     *                              no fatal {@code Error} is present
+     */
+    public static void rethrowIfFatal(Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable");
+        Error fatalError = null;
+        var interrupted = false;
+        // Escalation structures, allocated only when a suppressed throwable has a
+        // graph of its own — the plain cause chain and Resource's one-level
+        // suppressed pattern stay allocation-free.
+        ArrayDeque<Throwable> pending = null;
+        var visited = 0;
+        var t = throwable;
+        while (t != null && visited < VISIT_CAP) {
+            visited++;
+            if (!check(t)) {
+                if (fatalError == null && t instanceof Error error) {
+                    fatalError = error;
+                }
+                if (t instanceof InterruptedException) {
+                    interrupted = true;
+                }
+                if (fatalError != null && interrupted) {
+                    break; // no further node can change the outcome
+                }
+            }
+            for (var suppressed : t.getSuppressed()) {
+                if (suppressed.getCause() != null || suppressed.getSuppressed().length > 0) {
+                    if (pending == null) {
+                        pending = new ArrayDeque<>();
+                    }
+                    pending.push(suppressed);
+                } else {
+                    visited++;
+                    if (!check(suppressed)) {
+                        if (fatalError == null && suppressed instanceof Error error) {
+                            fatalError = error;
+                        }
+                        if (suppressed instanceof InterruptedException) {
+                            interrupted = true;
+                        }
+                    }
+                }
+            }
+            var next = t.getCause();
+            if (next == null && pending != null) {
+                next = pending.poll();
+            }
+            t = next;
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        if (fatalError != null) {
+            throw fatalError;
+        }
+        if (interrupted) {
+            if (throwable instanceof CompletionException completion) {
+                throw completion;
+            }
+            throw new CompletionException(throwable);
+        }
     }
 }

--- a/core/lib/src/main/java/dmx/fun/NonFatal.java
+++ b/core/lib/src/main/java/dmx/fun/NonFatal.java
@@ -1,0 +1,50 @@
+package dmx.fun;
+
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Predicate that classifies a {@link Throwable} as <em>non-fatal</em> — safe to capture,
+ * map, and recover from as an ordinary failure value — or <em>fatal</em>, signaling a
+ * condition that should propagate rather than travel through a pipeline.
+ *
+ * <p>The fatal set is:
+ * <ul>
+ *   <li>{@link VirtualMachineError} — e.g. {@link OutOfMemoryError},
+ *       {@link StackOverflowError}: the JVM itself is compromised.</li>
+ *   <li>{@link LinkageError} — the class environment is broken.</li>
+ *   <li>{@link InterruptedException} — cancellation, not failure: swallowing it
+ *       defeats cooperative shutdown.</li>
+ * </ul>
+ * Everything else — including other {@link Error} subclasses such as
+ * {@link AssertionError} — is considered non-fatal. This follows the spirit of Scala's
+ * {@code scala.util.control.NonFatal}, whose fatal set additionally includes
+ * {@code ThreadDeath} and {@code ControlThrowable} — the former is deprecated for
+ * removal and no longer thrown by the JVM, and the latter has no Java analogue.
+ *
+ * <p>Note that this checks only the given throwable, not its cause chain. Borders that
+ * need chain-aware handling (interruption in particular often arrives wrapped as another
+ * exception's cause) should use {@link Try#rethrowFatal()}.
+ *
+ * @see Try#rethrowFatal()
+ */
+@NullMarked
+public final class NonFatal {
+
+    private NonFatal() {
+    }
+
+    /**
+     * Returns {@code true} if {@code throwable} is non-fatal.
+     *
+     * @param throwable the throwable to classify; must not be {@code null}
+     * @return {@code true} if non-fatal, {@code false} if fatal
+     * @throws NullPointerException if {@code throwable} is {@code null}
+     */
+    public static boolean check(Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable");
+        return !(throwable instanceof VirtualMachineError
+            || throwable instanceof LinkageError
+            || throwable instanceof InterruptedException);
+    }
+}

--- a/core/lib/src/main/java/dmx/fun/NonFatal.java
+++ b/core/lib/src/main/java/dmx/fun/NonFatal.java
@@ -80,12 +80,24 @@ public final class NonFatal {
      * as {@code new CompletionException(throwable)} otherwise — the full original
      * graph stays reachable through the cause.
      *
+     * <p>{@code CompletionException} is also the transport wrapper the library's
+     * future borders deliberately strip ({@link Try#fromFuture(java.util.concurrent.CompletableFuture)
+     * Try.fromFuture} and friends), so a rethrown interruption that crosses a future
+     * boundary comes back as an ordinary {@code Failure} — with the
+     * {@code InterruptedException} intact as its cause. The rethrow therefore guards a
+     * <em>synchronous</em> border only: after a future round-trip, apply
+     * {@link Try#rethrowFatal()} again on the receiving side and the interruption is
+     * re-detected.
+     *
      * <p>Traversal is bounded at {@value #VISIT_CAP} throwables — a backstop against
-     * cause cycles and hostile {@code getCause()} overrides — so a fatal parked beyond
-     * that bound goes undetected. The dominant shapes — a plain cause chain, or one
-     * level of suppressed exceptions as parked by {@link Resource} — are traversed
-     * without allocating; a worklist is built only when a suppressed throwable
-     * carries a graph of its own.
+     * hostile {@code getCause()} overrides — so a fatal parked beyond that bound goes
+     * undetected. Cause cycles are detected without allocation (Floyd's algorithm) and
+     * abandoned, so a cycle neither loops nor starves the rest of the graph. The
+     * dominant shapes — a plain cause chain, or one level of suppressed exceptions as
+     * parked by {@link Resource} — are traversed without building auxiliary
+     * structures (though {@code getSuppressed()} itself clones its array when
+     * non-empty); a worklist is built only when a suppressed throwable carries a
+     * graph of its own.
      *
      * @param throwable the throwable to inspect; must not be {@code null}
      * @throws NullPointerException if {@code throwable} is {@code null}
@@ -104,6 +116,10 @@ public final class NonFatal {
         ArrayDeque<Throwable> pending = null;
         var visited = 0;
         var t = throwable;
+        // Tortoise for Floyd cycle detection on the current cause chain: a cause
+        // cycle would otherwise never yield the null that lets `pending` drain.
+        var slow = throwable;
+        var advanceSlow = false;
         while (t != null && visited < VISIT_CAP) {
             visited++;
             if (!check(t)) {
@@ -118,6 +134,9 @@ public final class NonFatal {
                 }
             }
             for (var suppressed : t.getSuppressed()) {
+                if (visited >= VISIT_CAP) {
+                    break;
+                }
                 if (suppressed.getCause() != null || suppressed.getSuppressed().length > 0) {
                     if (pending == null) {
                         pending = new ArrayDeque<>();
@@ -136,8 +155,21 @@ public final class NonFatal {
                 }
             }
             var next = t.getCause();
+            if (next != null) {
+                if (advanceSlow) {
+                    slow = slow.getCause();
+                }
+                advanceSlow = !advanceSlow;
+                if (next == slow) {
+                    next = null; // cause cycle closed — abandon this chain
+                }
+            }
             if (next == null && pending != null) {
                 next = pending.poll();
+                if (next != null) {
+                    slow = next; // fresh chain, fresh tortoise
+                    advanceSlow = false;
+                }
             }
             t = next;
         }

--- a/core/lib/src/main/java/dmx/fun/NonFatal.java
+++ b/core/lib/src/main/java/dmx/fun/NonFatal.java
@@ -1,7 +1,10 @@
 package dmx.fun;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import org.jspecify.annotations.NullMarked;
 
@@ -114,6 +117,7 @@ public final class NonFatal {
         // graph of its own — the plain cause chain and Resource's one-level
         // suppressed pattern stay allocation-free.
         ArrayDeque<Throwable> pending = null;
+        Set<Throwable> queued = null;
         var visited = 0;
         var t = throwable;
         // Tortoise for Floyd cycle detection on the current cause chain: a cause
@@ -140,8 +144,13 @@ public final class NonFatal {
                 if (suppressed.getCause() != null || suppressed.getSuppressed().length > 0) {
                     if (pending == null) {
                         pending = new ArrayDeque<>();
+                        queued = Collections.newSetFromMap(new IdentityHashMap<>());
                     }
-                    pending.push(suppressed);
+                    // identity dedup: mutual suppression (a.addSuppressed(b),
+                    // b.addSuppressed(a) is legal) must not re-queue forever
+                    if (queued.add(suppressed)) {
+                        pending.push(suppressed);
+                    }
                 } else {
                     visited++;
                     if (!check(suppressed)) {

--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -554,6 +554,67 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
     }
 
     /**
+     * Rethrows the failure if it is fatal, otherwise returns this instance unchanged.
+     *
+     * <p>{@link #of(CheckedSupplier) Try.of} captures every {@code Throwable}, so fatal
+     * conditions ({@link OutOfMemoryError}, {@link InterruptedException}, …) become
+     * ordinary {@code Failure} values that {@code recover}/{@code recoverWith} will
+     * happily swallow. Placing {@code rethrowFatal()} right after the capture makes a
+     * border strict: fatal failures propagate, domain failures stay on the track.
+     *
+     * <pre>{@code
+     * Try.of(() -> repository.fetch(id))
+     *    .rethrowFatal()
+     *    .toResult(StoreUnavailable::new);
+     * }</pre>
+     *
+     * <p>The cause chain is inspected with {@link NonFatal} (up to 64 links, guarding
+     * against cause cycles), because interruption often arrives wrapped as another
+     * exception's cause. If any link is an {@link InterruptedException}, the current
+     * thread's interrupt flag is restored before rethrowing. A fatal {@link Error}
+     * anywhere in the chain takes priority and is rethrown as-is; otherwise an
+     * interruption is rethrown wrapped in a
+     * {@link java.util.concurrent.CompletionException} whose cause is this failure's
+     * original cause (a cause that already is a {@code CompletionException} is rethrown
+     * unwrapped).
+     *
+     * @return this instance, if it is a {@code Success} or a non-fatal {@code Failure}
+     * @throws Error               if the failure or any of its causes is a fatal {@code Error}
+     * @throws CompletionException if the failure or any of its causes is an
+     *                             {@link InterruptedException} and no fatal {@code Error}
+     *                             is present
+     * @see NonFatal
+     */
+    default Try<Value> rethrowFatal() {
+        if (this instanceof Failure<Value> f) {
+            Error fatalError = null;
+            var interrupted = false;
+            var t = f.cause();
+            for (var i = 0; t != null && i < 64; i++) {  // hop cap guards against cause cycles
+                if (t instanceof InterruptedException) {
+                    interrupted = true;
+                }
+                if (fatalError == null && t instanceof Error error && !NonFatal.check(error)) {
+                    fatalError = error;
+                }
+                t = t.getCause();
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+            if (fatalError != null) {
+                throw fatalError;
+            }
+            if (interrupted) {
+                throw f.cause() instanceof CompletionException ce
+                    ? ce
+                    : new CompletionException(f.cause());
+            }
+        }
+        return this;
+    }
+
+    /**
      * Returns the value if this instance is a {@code Success}, or the specified fallback value if it is a {@code Failure}.
      *
      * @param fallback the value to return if this instance is a {@code Failure}.

--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -576,8 +576,9 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      *
      * <p><strong>Only effective at an outermost call site.</strong> The combinators
      * that re-capture what their lambdas throw — {@code map}, {@code flatMap},
-     * {@code recover}, {@code recoverWith} — also re-capture what {@code rethrowFatal()}
-     * rethrows. Calling it <em>inside</em> one, e.g.
+     * {@code flatMapError}, {@code mapFailure}, {@code recover}, {@code recoverWith},
+     * and the fallible {@code filter} overloads — also re-capture what
+     * {@code rethrowFatal()} rethrows. Calling it <em>inside</em> one, e.g.
      * {@code loadA().flatMap(a -> Try.of(() -> fetchB(a)).rethrowFatal())}, silently
      * converts the rethrown fatal back into a {@code Failure}. Call it on the
      * pipeline's result instead, outside any lambda.

--- a/core/lib/src/main/java/dmx/fun/Try.java
+++ b/core/lib/src/main/java/dmx/fun/Try.java
@@ -568,48 +568,29 @@ public sealed interface Try<Value> permits Try.Success, Try.Failure {
      *    .toResult(StoreUnavailable::new);
      * }</pre>
      *
-     * <p>The cause chain is inspected with {@link NonFatal} (up to 64 links, guarding
-     * against cause cycles), because interruption often arrives wrapped as another
-     * exception's cause. If any link is an {@link InterruptedException}, the current
-     * thread's interrupt flag is restored before rethrowing. A fatal {@link Error}
-     * anywhere in the chain takes priority and is rethrown as-is; otherwise an
-     * interruption is rethrown wrapped in a
-     * {@link java.util.concurrent.CompletionException} whose cause is this failure's
-     * original cause (a cause that already is a {@code CompletionException} is rethrown
-     * unwrapped).
+     * <p>Delegates to {@link NonFatal#rethrowIfFatal(Throwable)}, which inspects the
+     * failure's cause chain and suppressed exceptions (where {@link Resource} parks a
+     * release failure alongside the body's) — see that method for the exact rethrow
+     * contract: Error priority, interrupt-flag propagation, wrapping rules, and the
+     * traversal bound.
+     *
+     * <p><strong>Only effective at an outermost call site.</strong> The combinators
+     * that re-capture what their lambdas throw — {@code map}, {@code flatMap},
+     * {@code recover}, {@code recoverWith} — also re-capture what {@code rethrowFatal()}
+     * rethrows. Calling it <em>inside</em> one, e.g.
+     * {@code loadA().flatMap(a -> Try.of(() -> fetchB(a)).rethrowFatal())}, silently
+     * converts the rethrown fatal back into a {@code Failure}. Call it on the
+     * pipeline's result instead, outside any lambda.
      *
      * @return this instance, if it is a {@code Success} or a non-fatal {@code Failure}
-     * @throws Error               if the failure or any of its causes is a fatal {@code Error}
-     * @throws CompletionException if the failure or any of its causes is an
-     *                             {@link InterruptedException} and no fatal {@code Error}
-     *                             is present
-     * @see NonFatal
+     * @throws Error               if a fatal {@code Error} is reachable from the failure
+     * @throws CompletionException if an {@link InterruptedException} is reachable from
+     *                             the failure and no fatal {@code Error} is present
+     * @see NonFatal#rethrowIfFatal(Throwable)
      */
     default Try<Value> rethrowFatal() {
         if (this instanceof Failure<Value> f) {
-            Error fatalError = null;
-            var interrupted = false;
-            var t = f.cause();
-            for (var i = 0; t != null && i < 64; i++) {  // hop cap guards against cause cycles
-                if (t instanceof InterruptedException) {
-                    interrupted = true;
-                }
-                if (fatalError == null && t instanceof Error error && !NonFatal.check(error)) {
-                    fatalError = error;
-                }
-                t = t.getCause();
-            }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-            if (fatalError != null) {
-                throw fatalError;
-            }
-            if (interrupted) {
-                throw f.cause() instanceof CompletionException ce
-                    ? ce
-                    : new CompletionException(f.cause());
-            }
+            NonFatal.rethrowIfFatal(f.cause());
         }
         return this;
     }

--- a/core/lib/src/main/java/module-info.java
+++ b/core/lib/src/main/java/module-info.java
@@ -27,6 +27,7 @@
  *   <li>{@link dmx.fun.Results}      — collector facade for {@code Stream<Result<V,E>>}</li>
  *   <li>{@link dmx.fun.Options}      — collector facade for {@code Stream<Option<T>>}</li>
  *   <li>{@link dmx.fun.Tries}        — collector facade for {@code Stream<Try<V>>}</li>
+ *   <li>{@link dmx.fun.NonFatal}     — fatal-throwable policy for strict capture borders</li>
  * </ul>
  *
  * <p>The entire module is {@code @NullMarked}: all API types are non-null by default.

--- a/core/lib/src/test/java/dmx/fun/NonFatalTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonFatalTest.java
@@ -185,8 +185,11 @@ class NonFatalTest {
         a.addSuppressed(b);
         b.addSuppressed(a); // mutual suppression must not re-queue forever
         var root = new RuntimeException("root");
-        root.addSuppressed(a);
+        // fatal first, cycle second: the LIFO worklist then drains the cycle
+        // before the fatal — without identity dedup the cycle re-queues until
+        // the visit cap and the fatal is never reached
         root.addSuppressed(new IOException("release failed", new OutOfMemoryError("boom")));
+        root.addSuppressed(a);
 
         assertThatThrownBy(() -> NonFatal.rethrowIfFatal(root))
             .isInstanceOf(OutOfMemoryError.class);

--- a/core/lib/src/test/java/dmx/fun/NonFatalTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonFatalTest.java
@@ -179,6 +179,21 @@ class NonFatalTest {
 
     @Test
     @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void rethrowIfFatal_shouldFindFatalSiblingDespiteSuppressedCycle() {
+        var a = new RuntimeException("a");
+        var b = new RuntimeException("b");
+        a.addSuppressed(b);
+        b.addSuppressed(a); // mutual suppression must not re-queue forever
+        var root = new RuntimeException("root");
+        root.addSuppressed(a);
+        root.addSuppressed(new IOException("release failed", new OutOfMemoryError("boom")));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(root))
+            .isInstanceOf(OutOfMemoryError.class);
+    }
+
+    @Test
+    @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void rethrowIfFatal_shouldFindFatalSuppressedOnCauseCycle() {
         var oom = new OutOfMemoryError("boom");
         var a = new RuntimeException("a");

--- a/core/lib/src/test/java/dmx/fun/NonFatalTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonFatalTest.java
@@ -1,12 +1,22 @@
 package dmx.fun;
 
 import java.io.IOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NonFatalTest {
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted(); // never leak the flag into other tests
+    }
 
     @Test
     void check_shouldClassifyOrdinaryExceptionsAsNonFatal() {
@@ -33,5 +43,126 @@ class NonFatalTest {
         assertThatThrownBy(() -> NonFatal.check(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("throwable");
+    }
+
+    @Test
+    void rethrowIfFatal_shouldReturnNormallyOnNonFatal() {
+        assertThatCode(() -> NonFatal.rethrowIfFatal(new IOException("boom")))
+            .doesNotThrowAnyException();
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldRethrowFatalErrorDirectly() {
+        var oom = new OutOfMemoryError("boom");
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(oom)).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowIfFatal_shouldInspectSuppressedExceptions() {
+        var oom = new OutOfMemoryError("boom");
+        var body = new IOException("body failed");
+        body.addSuppressed(oom);
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(body)).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowIfFatal_shouldWrapInterruptionAndSetInterruptFlag() {
+        var ie = new InterruptedException("cancelled");
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(ie))
+            .isInstanceOf(CompletionException.class)
+            .cause().isSameAs(ie);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldThrowNPEOnNull() {
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("throwable");
+    }
+
+    @Test
+    void rethrowIfFatal_shouldSetInterruptFlagWhenInterruptionIsSuppressedOnFatalError() {
+        var oom = new OutOfMemoryError("boom");
+        oom.addSuppressed(new InterruptedException("release interrupted"));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(oom)).isSameAs(oom);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldDetectInterruptionOnlyReachableViaSuppressed() {
+        var body = new IOException("body failed");
+        body.addSuppressed(new InterruptedException("release interrupted"));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(body))
+            .isInstanceOf(CompletionException.class)
+            .cause().isSameAs(body);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldInspectGraphOfSuppressedException() {
+        var oom = new OutOfMemoryError("boom");
+        var suppressed = new IOException("release failed", oom);
+        var body = new IOException("body failed");
+        body.addSuppressed(suppressed);
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(body)).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowIfFatal_shouldNotDoubleWrapCompletionException() {
+        var ce = new CompletionException(new InterruptedException("cancelled"));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(ce)).isSameAs(ce);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldPreserveExecutionExceptionInWrappedGraph() {
+        var ee = new ExecutionException(new InterruptedException("cancelled"));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(ee))
+            .isInstanceOf(CompletionException.class)
+            .cause().isSameAs(ee);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @Test
+    void rethrowIfFatal_shouldFindFatalWithinTraversalBound() {
+        var oom = new OutOfMemoryError("boom");
+        Throwable chain = oom;
+        for (var i = 0; i < 999; i++) { // oom is the 1000th node — last one inside the cap
+            chain = new RuntimeException("wrapper " + i, chain);
+        }
+        var visible = chain;
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(visible)).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowIfFatal_shouldNotSeeFatalBeyondTraversalBound() {
+        Throwable chain = new OutOfMemoryError("boom");
+        for (var i = 0; i < 1000; i++) { // pushes the fatal to node 1001 — past the cap
+            chain = new RuntimeException("wrapper " + i, chain);
+        }
+        var hidden = chain;
+
+        assertThatCode(() -> NonFatal.rethrowIfFatal(hidden)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void rethrowIfFatal_shouldNotLoopOnCauseCycle() {
+        var a = new RuntimeException("a");
+        var b = new RuntimeException("b", a);
+        a.initCause(b);
+
+        assertThatCode(() -> NonFatal.rethrowIfFatal(a)).doesNotThrowAnyException();
     }
 }

--- a/core/lib/src/test/java/dmx/fun/NonFatalTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonFatalTest.java
@@ -1,0 +1,37 @@
+package dmx.fun;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NonFatalTest {
+
+    @Test
+    void check_shouldClassifyOrdinaryExceptionsAsNonFatal() {
+        assertThat(NonFatal.check(new RuntimeException())).isTrue();
+        assertThat(NonFatal.check(new IOException())).isTrue();
+        assertThat(NonFatal.check(new AssertionError())).isTrue();
+    }
+
+    @Test
+    void check_shouldClassifyFatalThrowables() {
+        assertThat(NonFatal.check(new OutOfMemoryError())).isFalse();
+        assertThat(NonFatal.check(new StackOverflowError())).isFalse();
+        assertThat(NonFatal.check(new NoClassDefFoundError())).isFalse();
+        assertThat(NonFatal.check(new InterruptedException())).isFalse();
+    }
+
+    @Test
+    void check_shouldNotInspectCauseChain() {
+        assertThat(NonFatal.check(new RuntimeException(new OutOfMemoryError()))).isTrue();
+    }
+
+    @Test
+    void check_shouldThrowNPEOnNull() {
+        assertThatThrownBy(() -> NonFatal.check(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("throwable");
+    }
+}

--- a/core/lib/src/test/java/dmx/fun/NonFatalTest.java
+++ b/core/lib/src/test/java/dmx/fun/NonFatalTest.java
@@ -157,6 +157,17 @@ class NonFatalTest {
     }
 
     @Test
+    void rethrowIfFatal_shouldNotSeeFatalSuppressedBeyondTraversalBound() {
+        var root = new RuntimeException("root");
+        for (var i = 0; i < 999; i++) { // root + 999 suppressed exhaust the cap
+            root.addSuppressed(new IOException("suppressed " + i));
+        }
+        root.addSuppressed(new OutOfMemoryError("boom")); // node 1001 — past the cap
+
+        assertThatCode(() -> NonFatal.rethrowIfFatal(root)).doesNotThrowAnyException();
+    }
+
+    @Test
     @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void rethrowIfFatal_shouldNotLoopOnCauseCycle() {
         var a = new RuntimeException("a");
@@ -164,5 +175,17 @@ class NonFatalTest {
         a.initCause(b);
 
         assertThatCode(() -> NonFatal.rethrowIfFatal(a)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void rethrowIfFatal_shouldFindFatalSuppressedOnCauseCycle() {
+        var oom = new OutOfMemoryError("boom");
+        var a = new RuntimeException("a");
+        var b = new RuntimeException("b", a);
+        a.initCause(b); // cause cycle must not starve the suppressed graph
+        a.addSuppressed(new IOException("release failed", oom));
+
+        assertThatThrownBy(() -> NonFatal.rethrowIfFatal(a)).isSameAs(oom);
     }
 }

--- a/core/lib/src/test/java/dmx/fun/TryTest.java
+++ b/core/lib/src/test/java/dmx/fun/TryTest.java
@@ -4,11 +4,13 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1497,11 +1499,13 @@ class TryTest {
             return "never";
         });
 
-        // Clear the interrupt status set by withTimeout so the test harness is clean
-        Thread.interrupted();
-
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(InterruptedException.class);
+    }
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted(); // never leak the flag into other tests
     }
 
     @Test
@@ -1535,17 +1539,38 @@ class TryTest {
     }
 
     @Test
-    void rethrowFatal_shouldWrapInterruptionAndRestoreInterruptFlag() {
+    void rethrowFatal_shouldPassNonFatalErrorThroughUntouched() {
+        var t = Try.failure(new AssertionError("expectation failed"));
+
+        assertThat(t.rethrowFatal()).isSameAs(t);
+    }
+
+    @Test
+    void rethrowFatal_shouldRethrowLinkageError() {
+        var linkage = new NoClassDefFoundError("gone");
+        var t = Try.failure(linkage);
+
+        assertThatThrownBy(t::rethrowFatal).isSameAs(linkage);
+    }
+
+    @Test
+    void rethrowFatal_shouldFindFatalErrorInSuppressedExceptions() {
+        var oom = new OutOfMemoryError("boom");
+        var body = new IOException("body failed");
+        body.addSuppressed(oom); // Resource.runBody parks the release failure this way
+        var t = Try.failure(body);
+
+        assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowFatal_shouldWrapInterruptionAndSetInterruptFlag() {
         var t = Try.failure(new InterruptedException("cancelled"));
 
-        try {
-            assertThatThrownBy(t::rethrowFatal)
-                .isInstanceOf(java.util.concurrent.CompletionException.class)
-                .cause().isInstanceOf(InterruptedException.class);
-            assertThat(Thread.interrupted()).isTrue();
-        } finally {
-            Thread.interrupted(); // never leak the flag into other tests
-        }
+        assertThatThrownBy(t::rethrowFatal)
+            .isInstanceOf(CompletionException.class)
+            .cause().isInstanceOf(InterruptedException.class);
+        assertThat(Thread.interrupted()).isTrue();
     }
 
     @Test
@@ -1553,14 +1578,10 @@ class TryTest {
         var wrapped = new IOException("query aborted", new InterruptedException("cancelled"));
         var t = Try.failure(wrapped);
 
-        try {
-            assertThatThrownBy(t::rethrowFatal)
-                .isInstanceOf(java.util.concurrent.CompletionException.class)
-                .cause().isSameAs(wrapped);
-            assertThat(Thread.interrupted()).isTrue();
-        } finally {
-            Thread.interrupted(); // never leak the flag into other tests
-        }
+        assertThatThrownBy(t::rethrowFatal)
+            .isInstanceOf(CompletionException.class)
+            .cause().isSameAs(wrapped);
+        assertThat(Thread.interrupted()).isTrue();
     }
 
     @Test
@@ -1570,34 +1591,8 @@ class TryTest {
         ie.initCause(oom);
         var t = Try.failure(ie);
 
-        try {
-            assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
-            assertThat(Thread.interrupted()).isTrue();
-        } finally {
-            Thread.interrupted(); // never leak the flag into other tests
-        }
+        assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
+        assertThat(Thread.interrupted()).isTrue();
     }
 
-    @Test
-    void rethrowFatal_shouldNotDoubleWrapCompletionException() {
-        var ce = new java.util.concurrent.CompletionException(new InterruptedException("cancelled"));
-        var t = Try.failure(ce);
-
-        try {
-            assertThatThrownBy(t::rethrowFatal).isSameAs(ce);
-            assertThat(Thread.interrupted()).isTrue();
-        } finally {
-            Thread.interrupted(); // never leak the flag into other tests
-        }
-    }
-
-    @Test
-    void rethrowFatal_shouldNotLoopOnCauseCycle() {
-        var a = new RuntimeException("a");
-        var b = new RuntimeException("b", a);
-        a.initCause(b);
-        var t = Try.failure(a);
-
-        assertThat(t.rethrowFatal()).isSameAs(t);
-    }
 }

--- a/core/lib/src/test/java/dmx/fun/TryTest.java
+++ b/core/lib/src/test/java/dmx/fun/TryTest.java
@@ -1503,4 +1503,101 @@ class TryTest {
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(InterruptedException.class);
     }
+
+    @Test
+    void rethrowFatal_shouldReturnSameInstanceOnSuccess() {
+        var t = Try.success(42);
+
+        assertThat(t.rethrowFatal()).isSameAs(t);
+    }
+
+    @Test
+    void rethrowFatal_shouldReturnSameInstanceOnNonFatalFailure() {
+        var t = Try.failure(new IOException("boom"));
+
+        assertThat(t.rethrowFatal()).isSameAs(t);
+    }
+
+    @Test
+    void rethrowFatal_shouldRethrowFatalErrorDirectly() {
+        var oom = new OutOfMemoryError("boom");
+        var t = Try.failure(oom);
+
+        assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowFatal_shouldRethrowFatalErrorFoundInCauseChain() {
+        var oom = new OutOfMemoryError("boom");
+        var t = Try.failure(new RuntimeException("wrapper", oom));
+
+        assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
+    }
+
+    @Test
+    void rethrowFatal_shouldWrapInterruptionAndRestoreInterruptFlag() {
+        var t = Try.failure(new InterruptedException("cancelled"));
+
+        try {
+            assertThatThrownBy(t::rethrowFatal)
+                .isInstanceOf(java.util.concurrent.CompletionException.class)
+                .cause().isInstanceOf(InterruptedException.class);
+            assertThat(Thread.interrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // never leak the flag into other tests
+        }
+    }
+
+    @Test
+    void rethrowFatal_shouldDetectInterruptionWrappedAsCause() {
+        var wrapped = new IOException("query aborted", new InterruptedException("cancelled"));
+        var t = Try.failure(wrapped);
+
+        try {
+            assertThatThrownBy(t::rethrowFatal)
+                .isInstanceOf(java.util.concurrent.CompletionException.class)
+                .cause().isSameAs(wrapped);
+            assertThat(Thread.interrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // never leak the flag into other tests
+        }
+    }
+
+    @Test
+    void rethrowFatal_shouldPrioritizeFatalErrorOverInterruption() {
+        var oom = new OutOfMemoryError("boom");
+        var ie = new InterruptedException("cancelled");
+        ie.initCause(oom);
+        var t = Try.failure(ie);
+
+        try {
+            assertThatThrownBy(t::rethrowFatal).isSameAs(oom);
+            assertThat(Thread.interrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // never leak the flag into other tests
+        }
+    }
+
+    @Test
+    void rethrowFatal_shouldNotDoubleWrapCompletionException() {
+        var ce = new java.util.concurrent.CompletionException(new InterruptedException("cancelled"));
+        var t = Try.failure(ce);
+
+        try {
+            assertThatThrownBy(t::rethrowFatal).isSameAs(ce);
+            assertThat(Thread.interrupted()).isTrue();
+        } finally {
+            Thread.interrupted(); // never leak the flag into other tests
+        }
+    }
+
+    @Test
+    void rethrowFatal_shouldNotLoopOnCauseCycle() {
+        var a = new RuntimeException("a");
+        var b = new RuntimeException("b", a);
+        a.initCause(b);
+        var t = Try.failure(a);
+
+        assertThat(t.rethrowFatal()).isSameAs(t);
+    }
 }

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -122,7 +122,9 @@ Because `Try.of` captures every `Throwable`, an `OutOfMemoryError` or an
 swallow it, running your fallback on a sick JVM or with a cancelled thread.
 `rethrowFatal()` makes a border strict: it rethrows the failure if it — or anything
 reachable through its cause chain and suppressed exceptions — is fatal, and returns
-the instance unchanged otherwise.
+the instance unchanged otherwise. Traversal is bounded at 1,000 visited throwables;
+a fatal parked beyond that bound is not detected and the instance is returned
+unchanged.
 
 ```java
 Result<Customer, StoreUnavailable> fetched =

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -137,9 +137,10 @@ chain-aware `rethrowIfFatal(Throwable)` helper are usable in your own catch bloc
 too. A fatal `Error` is rethrown as-is; an interruption sets the current thread's
 interrupt flag and is rethrown as a `CompletionException`.
 
-One rule: call `rethrowFatal()` **outside any combinator lambda**. `map`, `flatMap`,
-and `recover` re-capture whatever their lambdas throw, so a `rethrowFatal()` inside
-one is silently converted back into a `Failure`.
+One rule: call `rethrowFatal()` **outside any combinator lambda**. The combinators
+that re-capture whatever their lambdas throw — `map`, `flatMap`, `flatMapError`,
+`mapFailure`, `recover`, `recoverWith`, and the fallible `filter` overloads — will
+silently convert a `rethrowFatal()` inside one back into a `Failure`.
 
 ## sequence and traverse
 

--- a/site/src/data/guide/try.mdx
+++ b/site/src/data/guide/try.mdx
@@ -48,8 +48,10 @@ when you own the error domain and need callers to branch on specific error subty
 
 <CreatingInstances/>
 
-`Try.of` catches **any** `Throwable` — not just `Exception`.
-`Try.run` is the void-safe variant: it yields `Success(null)` on success.
+`Try.of` catches **any** `Throwable` — not just `Exception`. That includes fatal
+conditions like `OutOfMemoryError` and `InterruptedException`; see
+[Fatal failures](#fatal-failures--rethrowfatal) for how to keep those from being
+swallowed. `Try.run` is the void-safe variant: it yields `Success(null)` on success.
 See the [Null handling](#null-handling) section for the implications.
 
 ## Checking state
@@ -112,6 +114,32 @@ Recovery operations convert a `Failure` back to a `Success` by inspecting the
 exception. Typed overloads match only a specific exception subtype.
 
 <Recovery/>
+
+## Fatal failures — `rethrowFatal`
+
+Because `Try.of` captures every `Throwable`, an `OutOfMemoryError` or an
+`InterruptedException` becomes an ordinary `Failure` — and `recover` will happily
+swallow it, running your fallback on a sick JVM or with a cancelled thread.
+`rethrowFatal()` makes a border strict: it rethrows the failure if it — or anything
+reachable through its cause chain and suppressed exceptions — is fatal, and returns
+the instance unchanged otherwise.
+
+```java
+Result<Customer, StoreUnavailable> fetched =
+    Try.of(() -> repository.fetchCustomer(id))
+       .rethrowFatal()
+       .toResult(StoreUnavailable::new);
+```
+
+The fatal set — `VirtualMachineError`, `LinkageError`, `InterruptedException` — is
+defined by the public `NonFatal` class, whose `check(Throwable)` predicate and
+chain-aware `rethrowIfFatal(Throwable)` helper are usable in your own catch blocks
+too. A fatal `Error` is rethrown as-is; an interruption sets the current thread's
+interrupt flag and is rethrown as a `CompletionException`.
+
+One rule: call `rethrowFatal()` **outside any combinator lambda**. `map`, `flatMap`,
+and `recover` re-capture whatever their lambdas throw, so a `rethrowFatal()` inside
+one is silently converted back into a `Failure`.
 
 ## sequence and traverse
 
@@ -238,6 +266,13 @@ If you own the error type and callers need to branch on specific subtypes,
 use `Result`. Reserve `Try` for the boundary where third-party code throws.
 
 <PitfallsUseResult/>
+
+### Recovering a fatal failure
+
+`recover(e -> fallback)` does not distinguish an expected `IOException` from an
+`OutOfMemoryError` — both are `Failure` values. Put `rethrowFatal()` before any
+recovery at a strict border, or match specific exception types with the
+`recover(Class, fn)` overload instead of catch-all lambdas.
 
 ### Using `toOption()` after `Try.run()`
 


### PR DESCRIPTION
Strict Try borders needed hand-rolled fatal handling that
map/recover re-capture silently defeats. NonFatal defines
the fatal set; rethrowFatal walks the cause chain, restores
the interrupt flag, and rethrows.

Closes #537

# Pull Request

## 📌 Summary

Briefly describe the purpose of this pull request and what problem it solves.

> Example: This PR adds a functional implementation of a lazy list, demonstrating deferred computation using Java 17 features.

---

## ✅ Checklist

Please check all that apply:

- [ ] I have tested my changes locally
- [ ] I have added unit tests where applicable
- [ ] I have updated documentation where necessary
- [ ] My code follows the project's coding conventions
- [ ] I have linked any related issue(s) below

---

## 🔗 Related Issues

Closes #[issue-number]  
Fixes #[issue-number]  
(Related but not closing: #[issue-number])

---

## 💬 Additional Notes

Any other context, screenshots, design decisions, or points to be reviewed carefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities for identifying and rethrowing fatal failures and interruptions from nested exceptions.
  * Fatal errors are preserved, thread interruption status is restored, and completion exceptions are not double-wrapped.
  * Exception inspection safely handles suppressed exceptions, cyclic cause chains, and bounded traversal.

* **Documentation**
  * Added guidance for handling fatal failures and using `rethrowFatal()` correctly.

* **Tests**
  * Expanded coverage for fatal errors, interruptions, wrapping, suppressed exceptions, cycles, and traversal limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->